### PR TITLE
Use a shared relative-time library in web UI

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@msgpack/msgpack": "^3.1.3",
         "@virtueinitiative/styles": "file:../styles",
+        "dayjs": "^1.11.19",
         "hash-wasm": "^4.12.0",
         "preact": "^10.26.9",
         "preact-iso": "^2.11.1",
@@ -2143,6 +2144,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@msgpack/msgpack": "^3.1.3",
     "@virtueinitiative/styles": "file:../styles",
+    "dayjs": "^1.11.19",
     "hash-wasm": "^4.12.0",
     "preact": "^10.26.9",
     "preact-iso": "^2.11.1",

--- a/web/src/pages/Home/index.tsx
+++ b/web/src/pages/Home/index.tsx
@@ -4,26 +4,8 @@ import { api, Device, Partner } from "../../api";
 import { Button } from "../../components/Button";
 import { useAuth } from "../../context/auth";
 import { useE2EE } from "../../context/e2ee";
+import { formatDate, formatRelativeTimestamp } from "../../utils/time";
 import "./style.css";
-
-function relativeTime(timestamp: number | null) {
-  if (!timestamp) return "Never";
-
-  const diffMs = Date.now() - timestamp;
-  const diffMinutes = Math.floor(diffMs / 60_000);
-
-  if (diffMinutes < 1) return "Just now";
-  if (diffMinutes < 60) {
-    return `${diffMinutes} minute${diffMinutes === 1 ? "" : "s"} ago`;
-  }
-
-  const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) {
-    return `${diffHours} hour${diffHours === 1 ? "" : "s"} ago`;
-  }
-
-  return new Date(timestamp).toLocaleString();
-}
 
 function UserPlusIcon() {
   return (
@@ -312,7 +294,7 @@ function PendingPartnerCard({
         <dt>Email</dt>
         <dd>{partner.partner.email}</dd>
         <dt>Created</dt>
-        <dd>{new Date(partner.created_at).toLocaleDateString()}</dd>
+        <dd>{formatDate(partner.created_at)}</dd>
       </dl>
       {error && <p class="alert-error">{error}</p>}
       <div class="card-actions">
@@ -490,7 +472,7 @@ function PartnerDevicesSection({
                 <dt>Platform</dt>
                 <dd>{device.platform}</dd>
                 <dt>Last upload</dt>
-                <dd>{relativeTime(device.last_upload_at)}</dd>
+                <dd>{formatRelativeTimestamp(device.last_upload_at)}</dd>
               </dl>
               {partnerId && partner.permissions.view_data && (
                 <div class="card-actions">
@@ -565,7 +547,7 @@ function DeviceCard({
         <dt>Platform</dt>
         <dd>{device.platform}</dd>
         <dt>Last upload</dt>
-        <dd>{relativeTime(device.last_upload_at)}</dd>
+        <dd>{formatRelativeTimestamp(device.last_upload_at)}</dd>
         {!device.enabled && (
           <>
             <dt>Status</dt>

--- a/web/src/pages/Logs/LogsGallery.tsx
+++ b/web/src/pages/Logs/LogsGallery.tsx
@@ -1,4 +1,5 @@
 import { groupLogsByDay, ImageLogItem, LogImage } from "./shared";
+import { formatTime } from "../../utils/time";
 
 export function LogsGallery({
   items,
@@ -29,7 +30,7 @@ export function LogsGallery({
                 <div
                   class={`gallery-item${item.batch_status === "failed" ? " gallery-item--unverified" : ""}`}
                   key={item.id}
-                  title={`${deviceName(item.device_id)} — ${new Date(item.taken_at).toLocaleTimeString()}${item.batch_status === "failed" ? " ⚠ Unverified" : ""}`}
+                  title={`${deviceName(item.device_id)} — ${formatTime(item.taken_at)}${item.batch_status === "failed" ? " ⚠ Unverified" : ""}`}
                 >
                   <LogImage imageBytes={item.image} />
                 </div>

--- a/web/src/pages/Logs/LogsList.tsx
+++ b/web/src/pages/Logs/LogsList.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "preact";
 import { groupLogsByDay, LogItem, LogImage } from "./shared";
+import { formatRelativeTimestamp, formatTime } from "../../utils/time";
 
 function humanizeKind(kind: string): string {
   return kind.replace(/_/g, " ");
@@ -61,12 +62,8 @@ export function LogsList({
                           ⚠ Unverified
                         </span>
                       )}
-                      <span class="log-time">
-                        {new Date(item.taken_at).toLocaleTimeString([], {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          second: "2-digit",
-                        })}
+                      <span class="log-time" title={formatTime(item.taken_at)}>
+                        {formatRelativeTimestamp(item.taken_at)}
                       </span>
                     </div>
                     {item.metadata.length > 0 && (

--- a/web/src/pages/Logs/shared.tsx
+++ b/web/src/pages/Logs/shared.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "preact/hooks";
 import { BatchVerification } from "../../crypto";
+import { formatDayHeading, localDateKey } from "../../utils/time";
 
 export interface LogItem {
   id: string;
@@ -20,21 +21,6 @@ export interface LogDayGroup<T extends { taken_at: number }> {
   items: T[];
 }
 
-const dayHeadingFormatter = new Intl.DateTimeFormat(undefined, {
-  weekday: "long",
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-});
-
-function localDateKey(ts: number): string {
-  const date = new Date(ts);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
 export function groupLogsByDay<T extends { taken_at: number }>(
   items: T[],
 ): LogDayGroup<T>[] {
@@ -47,7 +33,7 @@ export function groupLogsByDay<T extends { taken_at: number }>(
     if (!group) {
       group = {
         key,
-        label: dayHeadingFormatter.format(new Date(item.taken_at)),
+        label: formatDayHeading(item.taken_at),
         items: [],
       };
       byKey.set(key, group);

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,0 +1,54 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+dayjs.extend(relativeTime);
+
+const dayHeadingFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+export function formatRelativeTimestamp(timestamp: number | null): string {
+  if (!timestamp) return "Never";
+  return dayjs(timestamp).fromNow();
+}
+
+export function formatDate(timestamp: number): string {
+  return dateFormatter.format(new Date(timestamp));
+}
+
+export function formatTime(timestamp: number): string {
+  return timeFormatter.format(new Date(timestamp));
+}
+
+export function formatDayHeading(timestamp: number): string {
+  const day = dayjs(timestamp).startOf("day");
+  const today = dayjs().startOf("day");
+
+  if (day.isSame(today)) return "Today";
+  if (day.isSame(today.subtract(1, "day"))) return "Yesterday";
+
+  return dayHeadingFormatter.format(new Date(timestamp));
+}
+
+export function localDateKey(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary
- add `dayjs` + `relativeTime` and centralize time formatting in `web/src/utils/time.ts`
- replace Home dashboard manual relative-time logic with shared helpers
- switch Logs list row times to relative format (with exact time as tooltip)
- unify Logs day heading/time formatting through shared utilities
- day headings now show `Today`/`Yesterday` before falling back to full date

## Validation
- `cd web && npm run typecheck`
- `cd web && npm run build`

Closes #52