### PR TITLE
Add GitHub link to landing footer

### DIFF
--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -4,8 +4,9 @@
       The Virtue Initiative is a non-profit project. Free to use, forever.
       &nbsp;·&nbsp; <a href="/privacy">Privacy Policy</a> &nbsp;·&nbsp;
       <a href="/terms">Terms of Use</a> &nbsp;·&nbsp;
-      <a href="https://github.com/virtue-initiative/virtue-initiative">GitHub</a
-      >
+      <a href="https://github.com/virtue-initiative/virtue-initiative">
+        GitHub
+      </a>
     </p>
   </div>
 </footer>

--- a/shared-web/state.ts
+++ b/shared-web/state.ts
@@ -92,10 +92,7 @@ function loadState(storageKey: string) {
 }
 
 const clients = new Set<{ source: MessageEventSource; origin: string }>();
-let state =
-  typeof window === "undefined"
-    ? {}
-    : loadState("shared-state");
+let state = typeof window === "undefined" ? {} : loadState("shared-state");
 let initialized = false;
 let server = (
   typeof window === "undefined" ? undefined : document.createElement("iframe")
@@ -156,9 +153,7 @@ export function startStateServer() {
 
 // Client code
 let clientState =
-  typeof window === "undefined"
-    ? {}
-    : loadState("shared-state-local");
+  typeof window === "undefined" ? {} : loadState("shared-state-local");
 
 function getServerLocation() {
   if (window.location.hostname === "localhost") {


### PR DESCRIPTION
## Summary
- add the repository GitHub link to the shared landing/help footer
- keep the change scoped to the footer so all landing/help pages inherit it

## Testing
- cd landing && npm run typecheck
- cd landing && npm run build
- cd landing && npm run prettier:check

Closes #129