### PR TITLE
Clarify partner and encryption UI copy

### DIFF
--- a/web/src/pages/Auth/index.tsx
+++ b/web/src/pages/Auth/index.tsx
@@ -252,11 +252,11 @@ export function Auth() {
             </p>
             {resetRequiresKeyRotation && (
               <p class="alert-error">
-                Resetting your password will generate fresh encryption keys.
-                Previously uploaded logs will remain inaccessible, and you
-                should sign back in on your Virtue clients so future uploads use
-                the new keys. Partners who already monitor this account will
-                keep access to new logs automatically.
+                Resetting your password will generate a new end-to-end
+                encryption key for this account. Previously uploaded logs will
+                remain inaccessible, and you should sign back in on your Virtue
+                clients so future uploads use the new keys. Partners who already
+                monitor this account will keep access to new logs automatically.
               </p>
             )}
           </>
@@ -270,17 +270,24 @@ export function Auth() {
 
         <form class="auth-form" onSubmit={handleSubmit}>
           {mode === "signup" && (
-            <div class="field">
-              <label for="name">Name (optional)</label>
-              <input
-                id="name"
-                type="text"
-                value={name}
-                onInput={(e) => setName((e.target as HTMLInputElement).value)}
-                placeholder="Your name"
-                autoComplete="name"
-              />
-            </div>
+            <>
+              <div class="field">
+                <label for="name">Name (optional)</label>
+                <input
+                  id="name"
+                  type="text"
+                  value={name}
+                  onInput={(e) => setName((e.target as HTMLInputElement).value)}
+                  placeholder="Your name"
+                  autoComplete="name"
+                />
+              </div>
+              <p class="settings-hint">
+                During sign-up, Virtue creates an end-to-end encryption key for
+                your account. It protects your uploaded logs, screenshots, and
+                blocks so only you and partners you approve can decrypt them.
+              </p>
+            </>
           )}
 
           <div class="field">

--- a/web/src/pages/Home/index.tsx
+++ b/web/src/pages/Home/index.tsx
@@ -26,6 +26,18 @@ function UserPlusIcon() {
   );
 }
 
+function relationshipSummary(partner: Partner) {
+  return partner.role === "invitee"
+    ? "You are monitoring this person."
+    : "This person is monitoring you.";
+}
+
+function dataAccessLabel(partner: Partner) {
+  return partner.role === "invitee"
+    ? "You can view their data"
+    : "They can view your data";
+}
+
 export function Home() {
   const { token, userId } = useAuth();
   const [devices, setDevices] = useState<Device[]>([]);
@@ -217,7 +229,7 @@ function InviteButton({
                 setViewData((e.target as HTMLInputElement).checked)
               }
             />
-            Can view data
+            This partner can view your encrypted activity data
           </label>
           {error && <p class="alert-error">{error}</p>}
           <div class="invite-actions">
@@ -273,15 +285,17 @@ function PendingPartnerCard({
       <p class="invite-desc">
         {partner.role === "invitee"
           ? partner.permissions.view_data
-            ? "This relationship includes access to encrypted activity data."
-            : "This relationship does not include data access."
+            ? "You have been invited to monitor this person. Once you accept, you will be able to view their encrypted activity data."
+            : "You have been invited to support this person, but this relationship does not include access to their activity data."
           : partner.permissions.view_data
-            ? "The partner invite is waiting for acceptance. After they accept the email link, you can confirm them to attach the encrypted access key."
-            : "This relationship does not include data access."}
+            ? "You invited this person to monitor your account. After they accept the email link, click Confirm partner to share the encrypted key they need to view your logs."
+            : "You invited this person, but this relationship does not include access to your activity data."}
       </p>
       <dl class="card-meta">
         <dt>Email</dt>
         <dd>{partner.partner.email}</dd>
+        <dt>Relationship</dt>
+        <dd>{relationshipSummary(partner)}</dd>
         <dt>Created</dt>
         <dd>{formatDate(partner.created_at)}</dd>
       </dl>
@@ -375,7 +389,9 @@ function PartnerCard({
       <dl class="card-meta">
         <dt>Email</dt>
         <dd>{partner.partner.email}</dd>
-        <dt>Can view data</dt>
+        <dt>Relationship</dt>
+        <dd>{relationshipSummary(partner)}</dd>
+        <dt>{dataAccessLabel(partner)}</dt>
         <dd>{partner.permissions.view_data ? "Yes" : "No"}</dd>
       </dl>
       {error && <p class="alert-error">{error}</p>}
@@ -438,10 +454,10 @@ function PartnerDevicesSection({
       {partner.permissions.view_data && partnerId && !hasKey && (
         <div class="card settings-form partner-key-notice">
           <p class="settings-hint">
-            You can browse this partner's devices now, but encrypted screenshots
-            and uploaded blocks cannot be decrypted yet. Ask the owner of these
-            logs to click <strong>Confirm partner</strong> if they invited you
-            before your account existed.
+            You are monitoring this partner now, but encrypted screenshots and
+            uploaded blocks cannot be decrypted yet. Ask the person you monitor
+            to click <strong>Confirm partner</strong> if they invited you before
+            your account existed.
           </p>
         </div>
       )}

--- a/web/src/pages/Logs/index.tsx
+++ b/web/src/pages/Logs/index.tsx
@@ -373,10 +373,11 @@ export function Logs() {
           {missingPartnerKey && (
             <div class="card settings-form">
               <p class="settings-hint">
-                You do not have this partner's decryption key yet, so encrypted
-                screenshots and uploaded blocks cannot be shown. Ask the owner
-                of these logs to click <strong>Confirm partner</strong> so the
-                encrypted sharing key is attached to your partnership.
+                You are monitoring this person, but you do not have their
+                decryption key yet, so encrypted screenshots and uploaded blocks
+                cannot be shown. Ask the owner of these logs to click{" "}
+                <strong>Confirm partner</strong> so the encrypted sharing key is
+                attached to your partnership.
               </p>
             </div>
           )}

--- a/web/src/pages/Settings/index.tsx
+++ b/web/src/pages/Settings/index.tsx
@@ -166,7 +166,8 @@ export function Settings() {
 
         {preferences.length === 0 ? (
           <p class="settings-hint">
-            Accept a partner invite to configure email notifications.
+            Accept a partner invite to configure email notifications for the
+            people you monitor.
           </p>
         ) : (
           <div class="settings-list">
@@ -174,6 +175,7 @@ export function Settings() {
               <div class="settings-item" key={preference.partnership_id}>
                 <div class="settings-item-header">
                   <strong>
+                    Monitoring{" "}
                     {preference.monitored_user.name ??
                       preference.monitored_user.email}
                   </strong>


### PR DESCRIPTION
## Summary
- clarify partner relationship text so it is explicit who is monitoring whom
- make data-access wording role-specific across partner cards and notices
- explain the end-to-end encryption key during signup and password reset

## Testing
- cd web && npm run typecheck
- cd web && npm run build
- cd web && npm run prettier:check

Closes #50