### PR TITLE
Retry web requests after token refresh

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -92,11 +92,41 @@ export interface PasswordResetValidation {
 
 const BASE = (import.meta as any).env?.VITE_API_URL ?? "http://localhost:8787";
 
+type ReauthHandler = () => Promise<string | null>;
+
+interface RequestOptions {
+  allowReauth?: boolean;
+  retrying?: boolean;
+}
+
+let reauthHandler: ReauthHandler | null = null;
+let reauthInFlight: Promise<string | null> | null = null;
+
+export function setReauthHandler(handler: ReauthHandler | null) {
+  reauthHandler = handler;
+}
+
+async function tryReauth() {
+  if (!reauthHandler) {
+    return null;
+  }
+
+  if (!reauthInFlight) {
+    reauthInFlight = reauthHandler().finally(() => {
+      reauthInFlight = null;
+    });
+  }
+
+  return reauthInFlight;
+}
+
 async function req<T>(
   path: string,
   init: RequestInit = {},
   token?: string,
+  options: RequestOptions = {},
 ): Promise<T> {
+  const { allowReauth = Boolean(token), retrying = false } = options;
   const headers = new Headers(init.headers);
 
   if (!headers.has("Content-Type") && !(init.body instanceof FormData)) {
@@ -114,6 +144,17 @@ async function req<T>(
   });
 
   if (!res.ok) {
+    if (res.status === 401 && token && allowReauth && !retrying) {
+      const refreshedToken = await tryReauth();
+
+      if (refreshedToken) {
+        return req<T>(path, init, refreshedToken, {
+          allowReauth,
+          retrying: true,
+        });
+      }
+    }
+
     const body = (await res.json().catch(() => ({}))) as {
       error?: unknown;
       details?: unknown;
@@ -135,7 +176,9 @@ async function req<T>(
 
 export const api = {
   refreshToken: () =>
-    req<{ access_token: string }>("/token", { method: "POST" }),
+    req<{ access_token: string }>("/token", { method: "POST" }, undefined, {
+      allowReauth: false,
+    }),
 
   login: (email: string, password: string) =>
     req<{ access_token: string }>("/login", {

--- a/web/src/context/auth.tsx
+++ b/web/src/context/auth.tsx
@@ -1,6 +1,6 @@
 import { createContext } from "preact";
 import { useContext, useState, useEffect, useCallback } from "preact/hooks";
-import { api } from "../api";
+import { api, setReauthHandler } from "../api";
 import { deriveWrappingKey, hashPasswordForAuth } from "../crypto";
 
 const WRAPPING_KEY_STORAGE = "virtue_wrapping_key";
@@ -126,6 +126,19 @@ export function AuthProvider({
     [],
   );
 
+  const refresh = useCallback(async () => {
+    const res = await api.refreshToken();
+    const uid = jwtSub(res.access_token);
+
+    if (!uid) {
+      throw new Error("Refreshed access token is missing a subject");
+    }
+
+    setToken(res.access_token);
+    setUserId(uid);
+    return res.access_token;
+  }, []);
+
   const logout = useCallback(async () => {
     await api.logout().catch(() => {});
     clearWrappingKey();
@@ -141,6 +154,22 @@ export function AuthProvider({
     },
     [],
   );
+
+  useEffect(() => {
+    setReauthHandler(async () => {
+      try {
+        return await refresh();
+      } catch {
+        clearWrappingKey();
+        setToken(null);
+        setUserId(null);
+        setWrappingKey(null);
+        return null;
+      }
+    });
+
+    return () => setReauthHandler(null);
+  }, [refresh]);
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
Summary:
- add a shared reauth hook for authenticated web API requests
- refresh the access token once on 401 responses and retry the original request
- clear in-memory auth state if refresh fails so the app can recover cleanly

Testing:
- cd web && npm run typecheck
- cd web && npm run build
- cd web && npm run prettier:check

Closes #125