### PR TITLE
Increased blurring and reduced file size

### DIFF
--- a/client/core/src/image_pipeline.rs
+++ b/client/core/src/image_pipeline.rs
@@ -54,7 +54,7 @@ mod tests {
 
     use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
 
-    use super::ImagePipeline;
+    use super::{ImagePipeline, TARGET_SMALL_DIM};
 
     #[test]
     fn resizes_so_small_dimension_matches_target() {
@@ -69,9 +69,10 @@ mod tests {
             .expect("encode input");
 
         let output = ImagePipeline.process(&input.into_inner()).expect("process");
+        let expected_width = (800.0_f32 / 600.0_f32 * TARGET_SMALL_DIM as f32).round() as u32;
 
-        assert_eq!(output.height, 256);
-        assert_eq!(output.width, 341); // 800/600 * 256, rounded
+        assert_eq!(output.height, TARGET_SMALL_DIM);
+        assert_eq!(output.width, expected_width);
         assert_eq!(output.content_type, "image/webp");
         assert!(!output.bytes.is_empty());
     }
@@ -89,9 +90,10 @@ mod tests {
             .expect("encode input");
 
         let output = ImagePipeline.process(&input.into_inner()).expect("process");
+        let expected_height = (800.0_f32 / 600.0_f32 * TARGET_SMALL_DIM as f32).round() as u32;
 
-        assert_eq!(output.width, 256);
-        assert_eq!(output.height, 341); // 800/600 * 256, rounded
+        assert_eq!(output.width, TARGET_SMALL_DIM);
+        assert_eq!(output.height, expected_height);
         assert_eq!(output.content_type, "image/webp");
         assert!(!output.bytes.is_empty());
     }


### PR DESCRIPTION
Fixes #121 

Before:
<img width="1563" height="887" alt="image" src="https://github.com/user-attachments/assets/fbcd99fe-d276-41da-a1a7-99ab1d4d5ee2" />

After:
<img width="1506" height="885" alt="image" src="https://github.com/user-attachments/assets/6c96a000-3900-4329-b4f8-a9f347c4ee37" />

And here's an example of a duckduckgo image search for oranges.
<img width="1496" height="895" alt="image" src="https://github.com/user-attachments/assets/ee9438ea-a5fe-412e-b27b-5a55d83dca97" />
