### PR TITLE
Asymmetric JWT

### DIFF
--- a/api/.dev.vars.example
+++ b/api/.dev.vars.example
@@ -1,8 +1,10 @@
 # .dev.vars template
 # Copy this file to .dev.vars and fill in the values
 
-# JWT Secret - Use a strong random string
-JWT_SECRET=your-super-secret-key-change-this-in-production
+# JWT signing keypair. Use an Ed25519 PKCS#8 private key and matching SPKI public key.
+# Values can be literal PEM blocks or "\n"-escaped PEM strings.
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIICDMV++otdvtyN120jSEqOU7u5a119/aSvUSuh26V61\n-----END PRIVATE KEY-----"
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAbYBZuUYl4eRF+lRwOKOk6fgjK2OA7CSA7EZSWtHeN9I=\n-----END PUBLIC KEY-----"
 
 # Web app URL. Its origin is also used for CORS.
 APP_URL=http://localhost:5173

--- a/api/API.md
+++ b/api/API.md
@@ -11,10 +11,10 @@ Base URL examples:
 - `DateTime`: millisecond Unix timestamp
 - `Base64`: base64-encoded binary
 - `SHA256`: lowercase hex-encoded SHA-256 digest
-- `AccessToken`: JWT with `type: "access"` and `sub = user id`
-- `DeviceAccessToken`: JWT with `type: "device-access"` and `sub = device id`
+- `AccessToken`: EdDSA JWT (`Ed25519`) with `type: "access"` and `sub = user id`
+- `DeviceAccessToken`: EdDSA JWT (`Ed25519`) with `type: "device-access"` and `sub = device id`
 - `DeviceRefreshToken`: opaque string returned by `POST /d/device`
-- `ServerToken`: JWT with `type: "server"` and `sub = device id`
+- `ServerToken`: EdDSA JWT (`Ed25519`) with `type: "server"` and `sub = device id`
 
 ## Shared Shapes
 
@@ -100,6 +100,27 @@ Response `200`:
 
 ```js
 HashParams;
+```
+
+### `GET /.well-known/jwks.json`
+
+Returns the public signing key in JWKS form for remote JWT verification.
+
+Response `200`:
+
+```js
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "x": "base64url-public-key",
+      "alg": "EdDSA",
+      "use": "sig",
+      "kid": "thumbprint"
+    }
+  ]
+}
 ```
 
 ### `GET /user/login-material?email=user@example.com`

--- a/api/README.md
+++ b/api/README.md
@@ -55,7 +55,19 @@ HASH_SERVER_URL=http://127.0.0.1:8787
 
 ## Deployment
 
-Ensure all the enviroment variables are set correctly (in `wrangler.json` and
+Generate a signing keypair once:
+
+```bash
+openssl genpkey -algorithm ed25519 -out jwt-private.pem
+openssl pkey -in jwt-private.pem -pubout -out jwt-public.pem
+```
+
+Set `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` in local `.dev.vars`, and in deployed
+environments upload at least the private key with `wrangler secret put`. The
+public key can be shared with any other server that needs to verify tokens.
+The worker also exposes the verifier key at `GET /.well-known/jwks.json`.
+
+Ensure all the environment variables are set correctly (in `wrangler.json` and
 using `wrangler secret put`) and run
 
 ```bash

--- a/api/TESTING.md
+++ b/api/TESTING.md
@@ -35,7 +35,8 @@ These test the crypto utilities directly, with no HTTP layer or database:
   - Verifies two hashes of the same password are different (salted)
 - **JWT tokens** — `generateAccessToken` + `verifyJWT` using `jose`
   - Verifies token round-trips with correct payload (`sub`, `type`)
-  - Verifies token is rejected if the secret is wrong
+  - Verifies token is rejected if the public key does not match the signer
+  - Verifies the worker publishes an Ed25519 JWKS endpoint for remote verification
   - Verifies token is rejected after expiry (generates a 1-second token, waits 1.5s)
 
 > **Note:** Argon2id hashing uses production parameters (`t:3, m:65536`), which takes ~7–11 seconds per hash. The test timeout is set to **30 seconds** in `vitest.config.ts` to accommodate this.

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,7 @@ import hashes from './routes/hashes';
 import notifications from './routes/notifications';
 import partners from './routes/partners';
 import { stripApiBasePath } from './lib/base-path';
+import { getJWKS } from './lib/jwt';
 import { runNotificationSchedule } from './lib/scheduler';
 import { Env, Variables } from './types/bindings';
 
@@ -37,6 +38,8 @@ app.get('/', (c) =>
     status: 'ok',
   }),
 );
+
+app.get('/.well-known/jwks.json', async (c) => c.json(await getJWKS(c.env.JWT_PUBLIC_KEY)));
 
 app.route('/', auth);
 app.route('/', notifications);

--- a/api/src/lib/jwt.ts
+++ b/api/src/lib/jwt.ts
@@ -1,4 +1,12 @@
-import { SignJWT, jwtVerify } from 'jose';
+import {
+  calculateJwkThumbprint,
+  exportJWK,
+  importPKCS8,
+  importSPKI,
+  jwtVerify,
+  SignJWT,
+  type JWK,
+} from 'jose';
 
 export type JWTType = 'access' | 'refresh' | 'server' | 'device-access' | 'device-refresh';
 
@@ -9,24 +17,104 @@ export interface JWTPayload {
   exp?: number;
 }
 
-function getSecretKey(secret: string) {
-  return new TextEncoder().encode(secret);
+const JWT_ALGORITHM = 'EdDSA';
+const JWT_CURVE = 'Ed25519';
+
+type JWTPrivateKey = Awaited<ReturnType<typeof importPKCS8>>;
+type JWTPublicKey = Awaited<ReturnType<typeof importSPKI>>;
+type PublicJwk = JWK & {
+  alg: typeof JWT_ALGORITHM;
+  crv: typeof JWT_CURVE;
+  kid: string;
+  kty: 'OKP';
+  use: 'sig';
+  x: string;
+};
+
+const privateKeyCache = new Map<string, Promise<JWTPrivateKey>>();
+const publicKeyCache = new Map<string, Promise<JWTPublicKey>>();
+const publicJwkCache = new Map<string, Promise<PublicJwk>>();
+
+function normalizePem(pem: string) {
+  const normalized = pem.replace(/\r\n/g, '\n').replace(/\\n/g, '\n').trim();
+
+  if (!normalized) {
+    throw new Error('JWT key must not be empty');
+  }
+
+  return normalized;
+}
+
+function getPrivateKey(privateKeyPem: string) {
+  const normalized = normalizePem(privateKeyPem);
+  let keyPromise = privateKeyCache.get(normalized);
+
+  if (!keyPromise) {
+    keyPromise = importPKCS8(normalized, JWT_ALGORITHM);
+    privateKeyCache.set(normalized, keyPromise);
+  }
+
+  return keyPromise;
+}
+
+function getPublicKey(publicKeyPem: string) {
+  const normalized = normalizePem(publicKeyPem);
+  let keyPromise = publicKeyCache.get(normalized);
+
+  if (!keyPromise) {
+    keyPromise = importSPKI(normalized, JWT_ALGORITHM);
+    publicKeyCache.set(normalized, keyPromise);
+  }
+
+  return keyPromise;
+}
+
+export async function getPublicJwk(publicKeyPem: string) {
+  const normalized = normalizePem(publicKeyPem);
+  let jwkPromise = publicJwkCache.get(normalized);
+
+  if (!jwkPromise) {
+    jwkPromise = (async () => {
+      const exported = await exportJWK(await getPublicKey(normalized));
+      const kid = await calculateJwkThumbprint(exported);
+
+      return {
+        ...exported,
+        alg: JWT_ALGORITHM,
+        crv: JWT_CURVE,
+        kid,
+        kty: 'OKP',
+        use: 'sig',
+      } as PublicJwk;
+    })();
+    publicJwkCache.set(normalized, jwkPromise);
+  }
+
+  return jwkPromise;
+}
+
+export async function getJWKS(publicKeyPem: string) {
+  return {
+    keys: [await getPublicJwk(publicKeyPem)],
+  };
 }
 
 export async function signJWT(
   payload: Omit<JWTPayload, 'iat' | 'exp'>,
-  secret: string,
+  privateKeyPem: string,
   expiresInSeconds: number,
 ): Promise<string> {
   return new SignJWT(payload)
-    .setProtectedHeader({ alg: 'HS256' })
+    .setProtectedHeader({ alg: JWT_ALGORITHM })
     .setIssuedAt()
     .setExpirationTime(Math.floor(Date.now() / 1000) + expiresInSeconds)
-    .sign(getSecretKey(secret));
+    .sign(await getPrivateKey(privateKeyPem));
 }
 
-export async function verifyJWT(token: string, secret: string): Promise<JWTPayload> {
-  const { payload } = await jwtVerify(token, getSecretKey(secret));
+export async function verifyJWT(token: string, publicKeyPem: string): Promise<JWTPayload> {
+  const { payload } = await jwtVerify(token, await getPublicKey(publicKeyPem), {
+    algorithms: [JWT_ALGORITHM],
+  });
 
   if (typeof payload.sub !== 'string' || typeof payload.type !== 'string') {
     throw new Error('Invalid token payload');
@@ -43,16 +131,16 @@ export async function verifyJWT(token: string, secret: string): Promise<JWTPaylo
 export function generateToken(
   type: JWTType,
   sub: string,
-  secret: string,
+  privateKeyPem: string,
   expiresInSeconds: number,
 ): Promise<string> {
-  return signJWT({ sub, type }, secret, expiresInSeconds);
+  return signJWT({ sub, type }, privateKeyPem, expiresInSeconds);
 }
 
-export function generateAccessToken(sub: string, secret: string, expiresInSeconds: number) {
-  return generateToken('access', sub, secret, expiresInSeconds);
+export function generateAccessToken(sub: string, privateKeyPem: string, expiresInSeconds: number) {
+  return generateToken('access', sub, privateKeyPem, expiresInSeconds);
 }
 
-export function generateRefreshToken(sub: string, secret: string, expiresInSeconds: number) {
-  return generateToken('refresh', sub, secret, expiresInSeconds);
+export function generateRefreshToken(sub: string, privateKeyPem: string, expiresInSeconds: number) {
+  return generateToken('refresh', sub, privateKeyPem, expiresInSeconds);
 }

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -14,7 +14,7 @@ export function authenticate(type: JWTType) {
     }
 
     try {
-      const payload = await verifyJWT(authHeader.slice(7), c.env.JWT_SECRET);
+      const payload = await verifyJWT(authHeader.slice(7), c.env.JWT_PUBLIC_KEY);
 
       if (payload.type !== type) {
         return c.json({ error: 'Unauthorized', details: { reason: 'Invalid token type' } }, 401);

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -136,7 +136,11 @@ function badRequest(c: Context<{ Bindings: Env; Variables: Variables }>, message
 }
 
 async function createSession(c: Context<{ Bindings: Env; Variables: Variables }>, userId: string) {
-  const accessToken = await generateAccessToken(userId, c.env.JWT_SECRET, ACCESS_TOKEN_TTL_SECONDS);
+  const accessToken = await generateAccessToken(
+    userId,
+    c.env.JWT_PRIVATE_KEY,
+    ACCESS_TOKEN_TTL_SECONDS,
+  );
   const refreshToken = generateOpaqueToken();
   const now = Date.now();
 
@@ -376,7 +380,7 @@ auth.post('/token', async (c) => {
 
   const accessToken = await generateAccessToken(
     session.user_id,
-    c.env.JWT_SECRET,
+    c.env.JWT_PRIVATE_KEY,
     ACCESS_TOKEN_TTL_SECONDS,
   );
 

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -173,7 +173,7 @@ deviceOnly.post(
     await createDevice(c.env.DB, { id, owner, name, platform });
 
     const [accessToken, refreshToken] = await Promise.all([
-      generateToken('device-access', id, c.env.JWT_SECRET, DEVICE_ACCESS_TOKEN_TTL_SECONDS),
+      generateToken('device-access', id, c.env.JWT_PRIVATE_KEY, DEVICE_ACCESS_TOKEN_TTL_SECONDS),
       createDeviceSession(c, id),
     ]);
 
@@ -246,7 +246,7 @@ deviceOnly.post('/token', validateZ('json', deviceTokenSchema), async (c) => {
   const accessToken = await generateToken(
     'device-access',
     session.device_id,
-    c.env.JWT_SECRET,
+    c.env.JWT_PRIVATE_KEY,
     DEVICE_ACCESS_TOKEN_TTL_SECONDS,
   );
 
@@ -311,7 +311,7 @@ deviceOnly.post(
       c,
       device,
       configuredHashBaseUrl,
-      await generateToken('server', device.id, c.env.JWT_SECRET, 60),
+      await generateToken('server', device.id, c.env.JWT_PRIVATE_KEY, 60),
     );
 
     return c.json({ id: batchId, start_time, end_time, end_hash: endHash, url }, 201);

--- a/api/src/types/bindings.ts
+++ b/api/src/types/bindings.ts
@@ -1,7 +1,8 @@
 export interface Env {
   DB: D1Database;
   BUCKET: R2Bucket;
-  JWT_SECRET: string;
+  JWT_PRIVATE_KEY: string;
+  JWT_PUBLIC_KEY: string;
   API_BASE_PATH?: string;
   HASH_SERVER_URL?: string;
   R2_URL: string;

--- a/api/test/auth.test.ts
+++ b/api/test/auth.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { generateAccessToken, verifyJWT } from '../src/lib/jwt';
 import { generatePasswordSalt, hashPasswordAuth, verifyPasswordAuth } from '../src/lib/password';
-import { TEST_JWT_PRIVATE_KEY, TEST_JWT_PUBLIC_KEY, TEST_OTHER_JWT_PUBLIC_KEY } from './jwt-test-keys';
+import {
+  TEST_JWT_PRIVATE_KEY,
+  TEST_JWT_PUBLIC_KEY,
+  TEST_OTHER_JWT_PUBLIC_KEY,
+} from './jwt-test-keys';
 
 describe('Password auth hashing', () => {
   it('hashes and verifies correct password auth material', async () => {

--- a/api/test/auth.test.ts
+++ b/api/test/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateAccessToken, verifyJWT } from '../src/lib/jwt';
 import { generatePasswordSalt, hashPasswordAuth, verifyPasswordAuth } from '../src/lib/password';
+import { TEST_JWT_PRIVATE_KEY, TEST_JWT_PUBLIC_KEY, TEST_OTHER_JWT_PUBLIC_KEY } from './jwt-test-keys';
 
 describe('Password auth hashing', () => {
   it('hashes and verifies correct password auth material', async () => {
@@ -25,17 +26,15 @@ describe('Password auth hashing', () => {
 });
 
 describe('JWT tokens', () => {
-  const secret = 'test-secret-key-12345';
-
   it('generates and verifies an access token', async () => {
-    const token = await generateAccessToken('user-123', secret, 900);
-    const payload = await verifyJWT(token, secret);
+    const token = await generateAccessToken('user-123', TEST_JWT_PRIVATE_KEY, 900);
+    const payload = await verifyJWT(token, TEST_JWT_PUBLIC_KEY);
     expect(payload.sub).toBe('user-123');
     expect(payload.type).toBe('access');
   });
 
-  it('rejects a token signed with the wrong secret', async () => {
-    const token = await generateAccessToken('user-123', secret, 900);
-    await expect(verifyJWT(token, 'wrong-secret')).rejects.toThrow();
+  it('rejects a token signed with a different public key', async () => {
+    const token = await generateAccessToken('user-123', TEST_JWT_PRIVATE_KEY, 900);
+    await expect(verifyJWT(token, TEST_OTHER_JWT_PUBLIC_KEY)).rejects.toThrow();
   });
 });

--- a/api/test/env.d.ts
+++ b/api/test/env.d.ts
@@ -1,3 +1,6 @@
 declare module 'cloudflare:test' {
-  interface ProvidedEnv extends Cloudflare.Env {}
+  interface ProvidedEnv extends Cloudflare.Env {
+    JWT_PRIVATE_KEY: string;
+    JWT_PUBLIC_KEY: string;
+  }
 }

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -121,7 +121,7 @@ export async function createDeviceForUser(token: string, name = 'Laptop', platfo
 }
 
 export async function createServerToken(deviceId: string) {
-  return generateToken('server', deviceId, env.JWT_SECRET, 60);
+  return generateToken('server', deviceId, env.JWT_PRIVATE_KEY, 60);
 }
 
 export async function listEmailDeliveries() {

--- a/api/test/jwt-test-keys.ts
+++ b/api/test/jwt-test-keys.ts
@@ -1,0 +1,11 @@
+export const TEST_JWT_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIAJm+07rCmNlHyGjt5bwX0pFVeoddBs1yeY1jJyd7Gkm
+-----END PRIVATE KEY-----`;
+
+export const TEST_JWT_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAmjBnclbQ5hpvPrTnHBuk3CseEB0k2yurLQIU8r25jN0=
+-----END PUBLIC KEY-----`;
+
+export const TEST_OTHER_JWT_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAMJvLAK+FdbRAaUhIDXqWshEHgumXiWgZBl7hbVdOZ7s=
+-----END PUBLIC KEY-----`;

--- a/api/test/routing.test.ts
+++ b/api/test/routing.test.ts
@@ -16,6 +16,35 @@ describe('API base path routing', () => {
     expect(await prefixedRes.json()).toEqual(await rootRes.json());
   });
 
+  it('serves the same JWKS with and without the configured base path', async () => {
+    const [rootRes, prefixedRes] = await Promise.all([
+      SELF.fetch(`${BASE}/.well-known/jwks.json`),
+      SELF.fetch(`${BASE}/api/.well-known/jwks.json`),
+    ]);
+
+    expect(rootRes.status).toBe(200);
+    expect(prefixedRes.status).toBe(200);
+
+    const rootJson = (await rootRes.json()) as {
+      keys: Array<Record<string, string>>;
+    };
+
+    expect(await prefixedRes.json()).toEqual(rootJson);
+    expect(rootJson).toMatchObject({
+      keys: [
+        {
+          alg: 'EdDSA',
+          crv: 'Ed25519',
+          kty: 'OKP',
+          use: 'sig',
+        },
+      ],
+    });
+    expect(rootJson.keys).toHaveLength(1);
+    expect(rootJson.keys[0]?.kid).toBeTruthy();
+    expect(rootJson.keys[0]?.x).toBeTruthy();
+  });
+
   it('preserves the /api base path in device hash_base_url responses', async () => {
     const { token } = await signupAndGetToken('prefixed-device@example.com', 'pw');
 

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+import { TEST_JWT_PRIVATE_KEY, TEST_JWT_PUBLIC_KEY } from './test/jwt-test-keys';
 
 export default defineWorkersConfig({
   test: {
@@ -8,7 +9,8 @@ export default defineWorkersConfig({
         wrangler: { configPath: './wrangler.json', environment: 'staging' },
         miniflare: {
           bindings: {
-            JWT_SECRET: 'test-secret-key-for-testing-only',
+            JWT_PRIVATE_KEY: TEST_JWT_PRIVATE_KEY,
+            JWT_PUBLIC_KEY: TEST_JWT_PUBLIC_KEY,
             AWS_ACCESS_KEY_ID: 'test-aws-key',
             AWS_SECRET_ACCESS_KEY: 'test-aws-secret',
             EMAIL_DELIVERY_MODE: 'log',


### PR DESCRIPTION
Use public/private key crypto for our JWTs. Allows us to verify tokens from a different server if we need to without sharing keys. Fixes #99 

When merged we will need to update the environment variables/secrets in staging