### PR TITLE
Add dev commands and better version

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -5984,6 +5984,7 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "base64",
+ "chrono",
  "flate2",
  "hex",
  "hkdf",

--- a/client/android/rust/Cargo.lock
+++ b/client/android/rust/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -718,9 +718,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -731,7 +731,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -803,12 +802,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -843,15 +843,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -863,15 +863,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -964,9 +964,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1034,10 +1034,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1050,9 +1052,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libwebp-sys"
@@ -1066,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1122,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1143,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1212,12 +1214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1546,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1630,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1718,9 +1714,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1860,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1885,9 +1881,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2037,9 +2033,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2076,6 +2072,7 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "base64",
+ "chrono",
  "flate2",
  "hex",
  "hkdf",
@@ -2138,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2151,23 +2148,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2175,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2188,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2231,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2648,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -2664,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2675,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2687,18 +2680,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2707,18 +2700,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2748,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2759,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2770,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2793,9 +2786,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -3,6 +3,9 @@ name = "virtue-core"
 version = "0.0.2"
 edition = "2024"
 
+[build-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
 [dependencies]
 aes-gcm = "0.10"
 argon2 = "0.5"

--- a/client/core/build.rs
+++ b/client/core/build.rs
@@ -1,0 +1,137 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use chrono::Utc;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=VIRTUE_BUILD_LABEL");
+    println!("cargo:rerun-if-env-changed=VIRTUE_BUILD_DATE");
+    println!("cargo:rerun-if-env-changed=VIRTUE_GIT_SHORT_HASH");
+    println!("cargo:rerun-if-env-changed=VIRTUE_GIT_REF_NAME");
+    println!("cargo:rerun-if-env-changed=VIRTUE_RELEASE_CHANNEL");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+    println!("cargo:rerun-if-changed=../version.properties");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let build_label = build_label();
+    println!("cargo:rustc-env=VIRTUE_BUILD_LABEL={build_label}");
+}
+
+fn build_label() -> String {
+    env::var("VIRTUE_BUILD_LABEL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("{}-{}-{}", release_tag(), build_date(), git_short_hash()))
+}
+
+fn release_tag() -> String {
+    let base_version = base_version();
+    if release_channel() == "stable" {
+        base_version
+    } else {
+        format!("{base_version}-dev")
+    }
+}
+
+fn release_channel() -> String {
+    match env::var("VIRTUE_RELEASE_CHANNEL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        Some(value) if value == "stable" || value == "dev" => value,
+        Some(value) => panic!("Unsupported VIRTUE_RELEASE_CHANNEL: {value}"),
+        None => {
+            if git_ref_name() == "main" {
+                "stable".to_string()
+            } else {
+                "dev".to_string()
+            }
+        }
+    }
+}
+
+fn git_ref_name() -> String {
+    env::var("VIRTUE_GIT_REF_NAME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("GITHUB_REF_NAME")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| git_output(&["rev-parse", "--abbrev-ref", "HEAD"]))
+        .filter(|value| !value.trim().is_empty() && value != "HEAD")
+        .unwrap_or_else(|| "detached".to_string())
+}
+
+fn git_short_hash() -> String {
+    env::var("VIRTUE_GIT_SHORT_HASH")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("GITHUB_SHA").ok().and_then(|value| {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.chars().take(7).collect::<String>())
+                }
+            })
+        })
+        .or_else(|| git_output(&["rev-parse", "--short", "HEAD"]))
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn build_date() -> String {
+    env::var("VIRTUE_BUILD_DATE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string())
+}
+
+fn base_version() -> String {
+    version_property("VERSION").unwrap_or_else(|| {
+        env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION should always be set")
+    })
+}
+
+fn version_property(key: &str) -> Option<String> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").ok()?);
+    let version_file = manifest_dir.join("../version.properties");
+    let contents = fs::read_to_string(version_file).ok()?;
+
+    contents.lines().find_map(|line| {
+        let (raw_key, raw_value) = line.split_once('=')?;
+        if raw_key.trim() == key {
+            Some(raw_value.trim().to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").ok()?);
+    let repo_root = manifest_dir.join("../..");
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}

--- a/client/core/src/api.rs
+++ b/client/core/src/api.rs
@@ -223,6 +223,8 @@ impl ApiClient {
         device_access_token: &str,
         log: &LogEntry,
     ) -> CoreResult<UploadedLogResponse> {
+        let data = serde_json::to_value(&log.data)?;
+
         #[derive(Serialize)]
         struct UploadLogRequest<'a> {
             ts: i64,
@@ -239,10 +241,10 @@ impl ApiClient {
             "/d/log",
             Some(device_access_token),
             Some(&UploadLogRequest {
-                ts: log.ts_ms,
+                ts: log.ts,
                 kind: &log.kind,
                 risk: log.risk,
-                data: &log.data,
+                data: &data,
             }),
         )
     }

--- a/client/core/src/api.rs
+++ b/client/core/src/api.rs
@@ -223,7 +223,7 @@ impl ApiClient {
         device_access_token: &str,
         log: &LogEntry,
     ) -> CoreResult<UploadedLogResponse> {
-        let data = serde_json::to_value(&log.data)?;
+        let data = serde_json::Value::Object(log.data.object());
 
         #[derive(Serialize)]
         struct UploadLogRequest<'a> {

--- a/client/core/src/batch.rs
+++ b/client/core/src/batch.rs
@@ -6,19 +6,19 @@ use serde::Serialize;
 
 use crate::crypto::CryptoEngine;
 use crate::error::{CoreError, CoreResult};
-use crate::model::{BatchEvent, BatchRecipient, BatchUpload, BufferedScreenshot};
+use crate::model::{BatchEvent, BatchRecipient, BatchUpload, BufferedBatchEvent};
 
 #[derive(Debug, Default, Clone)]
 pub struct BatchBuilder;
 
 impl BatchBuilder {
     pub fn build_upload(
-        screenshots: &[BufferedScreenshot],
+        items: &[BufferedBatchEvent],
         crypto: &CryptoEngine,
         recipients: &[BatchRecipient],
         end_time_ms: i64,
     ) -> CoreResult<BatchUpload> {
-        let first = screenshots.first().ok_or(CoreError::InvalidState(
+        let first = items.first().ok_or(CoreError::InvalidState(
             "cannot build a batch from an empty buffer",
         ))?;
         if recipients.is_empty() {
@@ -27,7 +27,7 @@ impl BatchBuilder {
             ));
         }
 
-        let events: Vec<&BatchEvent> = screenshots.iter().map(|item| &item.event).collect();
+        let events: Vec<&BatchEvent> = items.iter().map(|item| &item.event).collect();
         let msgpack = rmp_serde::to_vec_named(&BatchEnvelope { events })?;
 
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());

--- a/client/core/src/batch.rs
+++ b/client/core/src/batch.rs
@@ -2,11 +2,10 @@ use std::io::Write;
 
 use flate2::Compression;
 use flate2::write::GzEncoder;
-use serde::Serialize;
 
-use crate::crypto::CryptoEngine;
+use crate::crypto::{CryptoEngine, encode_batch_event};
 use crate::error::{CoreError, CoreResult};
-use crate::model::{BatchEvent, BatchRecipient, BatchUpload, BufferedBatchEvent};
+use crate::model::{BatchRecipient, BatchUpload, BufferedBatchEvent};
 
 #[derive(Debug, Default, Clone)]
 pub struct BatchBuilder;
@@ -27,8 +26,11 @@ impl BatchBuilder {
             ));
         }
 
-        let events: Vec<&BatchEvent> = items.iter().map(|item| &item.event).collect();
-        let msgpack = rmp_serde::to_vec_named(&BatchEnvelope { events })?;
+        let encoded_events = items
+            .iter()
+            .map(|item| encode_batch_event(&item.event))
+            .collect::<CoreResult<Vec<_>>>()?;
+        let msgpack = rmp_serde::to_vec_named(&encoded_events)?;
 
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(&msgpack)?;
@@ -54,7 +56,26 @@ impl BatchBuilder {
     }
 }
 
-#[derive(Serialize)]
-struct BatchEnvelope<'a> {
-    events: Vec<&'a BatchEvent>,
+#[cfg(test)]
+mod tests {
+    use crate::crypto::encode_batch_event;
+    use crate::model::{BatchEvent, EventData};
+
+    #[test]
+    fn batch_payload_is_array_of_encoded_event_bytes() {
+        let event = BatchEvent {
+            ts: 123,
+            kind: "developer_log".to_string(),
+            risk: Some(0.5),
+            data: EventData::from_pairs([("source".to_string(), "test".to_string())]),
+        };
+
+        let encoded_event = encode_batch_event(&event).expect("encode event");
+        let encoded_batch =
+            rmp_serde::to_vec_named(&vec![encoded_event.clone()]).expect("encode batch");
+        let decoded_batch: Vec<Vec<u8>> =
+            rmp_serde::from_slice(&encoded_batch).expect("decode batch");
+
+        assert_eq!(decoded_batch, vec![encoded_event]);
+    }
 }

--- a/client/core/src/build_info.rs
+++ b/client/core/src/build_info.rs
@@ -1,0 +1,5 @@
+pub const BUILD_LABEL: &str = env!("VIRTUE_BUILD_LABEL");
+
+pub fn build_label() -> &'static str {
+    BUILD_LABEL
+}

--- a/client/core/src/crypto.rs
+++ b/client/core/src/crypto.rs
@@ -11,6 +11,7 @@ use hpke::{
     setup_sender,
 };
 use rand_core::{OsRng as HpkeOsRng, TryRngCore};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::error::{CoreError, CoreResult};
@@ -112,39 +113,34 @@ pub fn buffer_batch_event(event: BatchEvent) -> BufferedBatchEvent {
 }
 
 pub fn prepare_screenshot_event(screenshot: Screenshot) -> BufferedBatchEvent {
-    prepare_screenshot_batch_event(screenshot, "screenshot", None, Vec::new())
+    prepare_screenshot_batch_event(screenshot, "screenshot", None, BatchEventData::default())
 }
 
 pub fn prepare_screenshot_batch_event(
     screenshot: Screenshot,
     kind: impl Into<String>,
     risk: Option<f32>,
-    metadata: Vec<(String, String)>,
+    data: BatchEventData,
 ) -> BufferedBatchEvent {
     buffer_batch_event(BatchEvent {
         ts: screenshot.captured_at_ms,
         kind: kind.into(),
         risk,
-        metadata,
-        data: BatchEventData {
-            image: screenshot.bytes,
-            content_type: screenshot.content_type,
-        },
+        data: data.with_image(screenshot.bytes, screenshot.content_type),
     })
 }
 
-pub fn prepare_metadata_batch_event(
-    ts_ms: i64,
+pub fn prepare_log_batch_event(
+    ts: i64,
     kind: impl Into<String>,
     risk: Option<f32>,
-    metadata: Vec<(String, String)>,
+    data: BatchEventData,
 ) -> BufferedBatchEvent {
     buffer_batch_event(BatchEvent {
-        ts: ts_ms,
+        ts,
         kind: kind.into(),
         risk,
-        metadata,
-        data: BatchEventData::default(),
+        data,
     })
 }
 
@@ -157,36 +153,53 @@ pub fn compute_event_hash(event: &BatchEvent) -> [u8; 32] {
         bytes.extend_from_slice(&risk.to_bits().to_le_bytes());
     }
 
-    let mut fields = vec![
-        ("content_type", BatchValue::String(&event.data.content_type)),
-        ("image", BatchValue::Bytes(&event.data.image)),
-    ];
-    fields.sort_by(|(left, _), (right, _)| left.cmp(right));
-
-    for (key, value) in fields {
-        bytes.extend_from_slice(key.as_bytes());
-        match value {
-            BatchValue::String(value) => bytes.extend_from_slice(value.as_bytes()),
-            BatchValue::Bytes(value) => bytes.extend_from_slice(value),
-        }
+    if !event.data.content_type.is_empty() {
+        bytes.extend_from_slice(b"content_type");
+        bytes.extend_from_slice(event.data.content_type.as_bytes());
     }
-
-    let mut metadata = event.metadata.iter().collect::<Vec<_>>();
-    metadata.sort_by(|(left_key, left_value), (right_key, right_value)| {
-        left_key
-            .cmp(right_key)
-            .then_with(|| left_value.cmp(right_value))
-    });
-    for (key, value) in metadata {
-        bytes.extend_from_slice(b"metadata");
+    if !event.data.image.is_empty() {
+        bytes.extend_from_slice(b"image");
+        bytes.extend_from_slice(&event.data.image);
+    }
+    for (key, value) in &event.data.fields {
         bytes.extend_from_slice(key.as_bytes());
-        bytes.extend_from_slice(value.as_bytes());
+        append_json_value(&mut bytes, value);
     }
 
     Sha256::digest(bytes).into()
 }
 
-enum BatchValue<'a> {
-    String(&'a str),
-    Bytes(&'a [u8]),
+fn append_json_value(bytes: &mut Vec<u8>, value: &Value) {
+    match value {
+        Value::Null => bytes.extend_from_slice(b"n"),
+        Value::Bool(value) => {
+            bytes.extend_from_slice(b"b");
+            bytes.push(u8::from(*value));
+        }
+        Value::Number(value) => {
+            bytes.extend_from_slice(b"#");
+            bytes.extend_from_slice(value.to_string().as_bytes());
+        }
+        Value::String(value) => {
+            bytes.extend_from_slice(b"s");
+            bytes.extend_from_slice(value.as_bytes());
+        }
+        Value::Array(values) => {
+            bytes.extend_from_slice(b"[");
+            for value in values {
+                append_json_value(bytes, value);
+            }
+            bytes.extend_from_slice(b"]");
+        }
+        Value::Object(values) => {
+            bytes.extend_from_slice(b"{");
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort();
+            for key in keys {
+                bytes.extend_from_slice(key.as_bytes());
+                append_json_value(bytes, &values[key]);
+            }
+            bytes.extend_from_slice(b"}");
+        }
+    }
 }

--- a/client/core/src/crypto.rs
+++ b/client/core/src/crypto.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::{CoreError, CoreResult};
 use crate::model::{
-    BatchEvent, BatchEventData, BatchRecipient, BufferedScreenshot, HashParams, Screenshot,
+    BatchEvent, BatchEventData, BatchRecipient, BufferedBatchEvent, HashParams, Screenshot,
 };
 
 type HpkeKem = X25519HkdfSha256;
@@ -104,26 +104,58 @@ pub fn derive_password_auth(
     Ok(password_auth)
 }
 
-pub fn prepare_screenshot_event(screenshot: Screenshot) -> BufferedScreenshot {
-    let event = BatchEvent {
+pub fn buffer_batch_event(event: BatchEvent) -> BufferedBatchEvent {
+    BufferedBatchEvent {
+        content_hash: compute_event_hash(&event),
+        event,
+    }
+}
+
+pub fn prepare_screenshot_event(screenshot: Screenshot) -> BufferedBatchEvent {
+    prepare_screenshot_batch_event(screenshot, "screenshot", None, Vec::new())
+}
+
+pub fn prepare_screenshot_batch_event(
+    screenshot: Screenshot,
+    kind: impl Into<String>,
+    risk: Option<f32>,
+    metadata: Vec<(String, String)>,
+) -> BufferedBatchEvent {
+    buffer_batch_event(BatchEvent {
         ts: screenshot.captured_at_ms,
-        kind: "screenshot".to_string(),
+        kind: kind.into(),
+        risk,
+        metadata,
         data: BatchEventData {
             image: screenshot.bytes,
             content_type: screenshot.content_type,
         },
-    };
+    })
+}
 
-    BufferedScreenshot {
-        content_hash: compute_event_hash(&event),
-        event,
-    }
+pub fn prepare_metadata_batch_event(
+    ts_ms: i64,
+    kind: impl Into<String>,
+    risk: Option<f32>,
+    metadata: Vec<(String, String)>,
+) -> BufferedBatchEvent {
+    buffer_batch_event(BatchEvent {
+        ts: ts_ms,
+        kind: kind.into(),
+        risk,
+        metadata,
+        data: BatchEventData::default(),
+    })
 }
 
 pub fn compute_event_hash(event: &BatchEvent) -> [u8; 32] {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&(event.ts as u64).to_le_bytes());
     bytes.extend_from_slice(event.kind.as_bytes());
+    if let Some(risk) = event.risk {
+        bytes.extend_from_slice(b"risk");
+        bytes.extend_from_slice(&risk.to_bits().to_le_bytes());
+    }
 
     let mut fields = vec![
         ("content_type", BatchValue::String(&event.data.content_type)),
@@ -137,6 +169,18 @@ pub fn compute_event_hash(event: &BatchEvent) -> [u8; 32] {
             BatchValue::String(value) => bytes.extend_from_slice(value.as_bytes()),
             BatchValue::Bytes(value) => bytes.extend_from_slice(value),
         }
+    }
+
+    let mut metadata = event.metadata.iter().collect::<Vec<_>>();
+    metadata.sort_by(|(left_key, left_value), (right_key, right_value)| {
+        left_key
+            .cmp(right_key)
+            .then_with(|| left_value.cmp(right_value))
+    });
+    for (key, value) in metadata {
+        bytes.extend_from_slice(b"metadata");
+        bytes.extend_from_slice(key.as_bytes());
+        bytes.extend_from_slice(value.as_bytes());
     }
 
     Sha256::digest(bytes).into()

--- a/client/core/src/crypto.rs
+++ b/client/core/src/crypto.rs
@@ -11,7 +11,6 @@ use hpke::{
     setup_sender,
 };
 use rand_core::{OsRng as HpkeOsRng, TryRngCore};
-use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::error::{CoreError, CoreResult};
@@ -105,14 +104,15 @@ pub fn derive_password_auth(
     Ok(password_auth)
 }
 
-pub fn buffer_batch_event(event: BatchEvent) -> BufferedBatchEvent {
-    BufferedBatchEvent {
-        content_hash: compute_event_hash(&event),
+pub fn buffer_batch_event(event: BatchEvent) -> CoreResult<BufferedBatchEvent> {
+    let encoded = encode_batch_event(&event)?;
+    Ok(BufferedBatchEvent {
+        content_hash: compute_event_hash(&encoded),
         event,
-    }
+    })
 }
 
-pub fn prepare_screenshot_event(screenshot: Screenshot) -> BufferedBatchEvent {
+pub fn prepare_screenshot_event(screenshot: Screenshot) -> CoreResult<BufferedBatchEvent> {
     prepare_screenshot_batch_event(screenshot, "screenshot", None, BatchEventData::default())
 }
 
@@ -121,12 +121,12 @@ pub fn prepare_screenshot_batch_event(
     kind: impl Into<String>,
     risk: Option<f32>,
     data: BatchEventData,
-) -> BufferedBatchEvent {
+) -> CoreResult<BufferedBatchEvent> {
     buffer_batch_event(BatchEvent {
         ts: screenshot.captured_at_ms,
         kind: kind.into(),
         risk,
-        data: data.with_image(screenshot.bytes, screenshot.content_type),
+        data: data.with_screenshot(screenshot.bytes, screenshot.content_type),
     })
 }
 
@@ -135,7 +135,7 @@ pub fn prepare_log_batch_event(
     kind: impl Into<String>,
     risk: Option<f32>,
     data: BatchEventData,
-) -> BufferedBatchEvent {
+) -> CoreResult<BufferedBatchEvent> {
     buffer_batch_event(BatchEvent {
         ts,
         kind: kind.into(),
@@ -144,62 +144,10 @@ pub fn prepare_log_batch_event(
     })
 }
 
-pub fn compute_event_hash(event: &BatchEvent) -> [u8; 32] {
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(&(event.ts as u64).to_le_bytes());
-    bytes.extend_from_slice(event.kind.as_bytes());
-    if let Some(risk) = event.risk {
-        bytes.extend_from_slice(b"risk");
-        bytes.extend_from_slice(&risk.to_bits().to_le_bytes());
-    }
-
-    if !event.data.content_type.is_empty() {
-        bytes.extend_from_slice(b"content_type");
-        bytes.extend_from_slice(event.data.content_type.as_bytes());
-    }
-    if !event.data.image.is_empty() {
-        bytes.extend_from_slice(b"image");
-        bytes.extend_from_slice(&event.data.image);
-    }
-    for (key, value) in &event.data.fields {
-        bytes.extend_from_slice(key.as_bytes());
-        append_json_value(&mut bytes, value);
-    }
-
-    Sha256::digest(bytes).into()
+pub fn encode_batch_event(event: &BatchEvent) -> CoreResult<Vec<u8>> {
+    Ok(rmp_serde::to_vec_named(event)?)
 }
 
-fn append_json_value(bytes: &mut Vec<u8>, value: &Value) {
-    match value {
-        Value::Null => bytes.extend_from_slice(b"n"),
-        Value::Bool(value) => {
-            bytes.extend_from_slice(b"b");
-            bytes.push(u8::from(*value));
-        }
-        Value::Number(value) => {
-            bytes.extend_from_slice(b"#");
-            bytes.extend_from_slice(value.to_string().as_bytes());
-        }
-        Value::String(value) => {
-            bytes.extend_from_slice(b"s");
-            bytes.extend_from_slice(value.as_bytes());
-        }
-        Value::Array(values) => {
-            bytes.extend_from_slice(b"[");
-            for value in values {
-                append_json_value(bytes, value);
-            }
-            bytes.extend_from_slice(b"]");
-        }
-        Value::Object(values) => {
-            bytes.extend_from_slice(b"{");
-            let mut keys = values.keys().collect::<Vec<_>>();
-            keys.sort();
-            for key in keys {
-                bytes.extend_from_slice(key.as_bytes());
-                append_json_value(bytes, &values[key]);
-            }
-            bytes.extend_from_slice(b"}");
-        }
-    }
+pub fn compute_event_hash(encoded_event: &[u8]) -> [u8; 32] {
+    Sha256::digest(encoded_event).into()
 }

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -16,8 +16,8 @@ pub use config::Config;
 pub use error::{CoreError, CoreResult};
 pub use model::{
     AuditLogPayload, AuditRecord, AuditState, AuthState, BatchEvent, BatchEventData, BatchUpload,
-    BufferedBatchEvent, DeviceCredentials, DeviceSettings, LogEntry, LoginStatus, LoopOutcome,
-    Screenshot, ServiceStatus,
+    BufferedBatchEvent, DeviceCredentials, DeviceSettings, EventData, LogEntry, LoginStatus,
+    LoopOutcome, Screenshot, ServiceStatus,
 };
 pub use platform::PlatformHooks;
 pub use service::MonitorService;

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod audit;
 pub mod batch;
+pub mod build_info;
 pub mod config;
 pub mod crypto;
 pub mod error;
@@ -10,11 +11,12 @@ pub mod platform;
 pub mod service;
 pub mod storage;
 
+pub use build_info::{BUILD_LABEL, build_label};
 pub use config::Config;
 pub use error::{CoreError, CoreResult};
 pub use model::{
     AuditLogPayload, AuditRecord, AuditState, AuthState, BatchEvent, BatchEventData, BatchUpload,
-    BufferedScreenshot, DeviceCredentials, DeviceSettings, LogEntry, LoginStatus, LoopOutcome,
+    BufferedBatchEvent, DeviceCredentials, DeviceSettings, LogEntry, LoginStatus, LoopOutcome,
     Screenshot, ServiceStatus,
 };
 pub use platform::PlatformHooks;

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -8,21 +8,12 @@ pub struct Screenshot {
     pub content_type: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BatchEventData {
     #[serde(default, with = "serde_bytes", skip_serializing_if = "Vec::is_empty")]
     pub image: Vec<u8>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub content_type: String,
-}
-
-impl Default for BatchEventData {
-    fn default() -> Self {
-        Self {
-            image: Vec::new(),
-            content_type: String::new(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -10,9 +10,19 @@ pub struct Screenshot {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchEventData {
-    #[serde(with = "serde_bytes")]
+    #[serde(default, with = "serde_bytes", skip_serializing_if = "Vec::is_empty")]
     pub image: Vec<u8>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub content_type: String,
+}
+
+impl Default for BatchEventData {
+    fn default() -> Self {
+        Self {
+            image: Vec::new(),
+            content_type: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,11 +30,16 @@ pub struct BatchEvent {
     pub ts: i64,
     #[serde(rename = "type")]
     pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk: Option<f32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub metadata: Vec<(String, String)>,
+    #[serde(default)]
     pub data: BatchEventData,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BufferedScreenshot {
+pub struct BufferedBatchEvent {
     pub event: BatchEvent,
     pub content_hash: [u8; 32],
 }
@@ -41,22 +56,22 @@ pub struct LogEntry {
 pub struct AuditLogPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direct_log: Option<LogEntry>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub batch_screenshot: Option<BufferedScreenshot>,
+    #[serde(skip_serializing_if = "Option::is_none", alias = "batch_screenshot")]
+    pub batch_event: Option<BufferedBatchEvent>,
 }
 
 impl AuditLogPayload {
     pub fn for_direct_log(log: LogEntry) -> Self {
         Self {
             direct_log: Some(log),
-            batch_screenshot: None,
+            batch_event: None,
         }
     }
 
-    pub fn for_batch_screenshot(screenshot: BufferedScreenshot) -> Self {
+    pub fn for_batch_event(event: BufferedBatchEvent) -> Self {
         Self {
             direct_log: None,
-            batch_screenshot: Some(screenshot),
+            batch_event: Some(event),
         }
     }
 }

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Screenshot {
@@ -11,26 +12,35 @@ pub struct Screenshot {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-pub struct EventData {
-    #[serde(default, with = "serde_bytes", skip_serializing_if = "Vec::is_empty")]
-    pub image: Vec<u8>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub content_type: String,
-    #[serde(flatten)]
-    pub fields: BTreeMap<String, serde_json::Value>,
-}
+#[serde(transparent)]
+pub struct EventData(pub BTreeMap<String, Value>);
 
 impl EventData {
-    pub fn with_image(mut self, image: Vec<u8>, content_type: impl Into<String>) -> Self {
-        self.image = image;
-        self.content_type = content_type.into();
+    pub fn insert(&mut self, key: impl Into<String>, value: Value) {
+        self.0.insert(key.into(), value);
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.0.get(key)
+    }
+
+    pub fn object(&self) -> Map<String, Value> {
+        self.0.clone().into_iter().collect()
+    }
+
+    pub fn with_screenshot(mut self, image: Vec<u8>, content_type: impl Into<String>) -> Self {
+        self.insert(
+            "image",
+            Value::Array(image.into_iter().map(Value::from).collect()),
+        );
+        self.insert("content_type", Value::String(content_type.into()));
         self
     }
 
     pub fn from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -> Self {
         let mut data = Self::default();
         for (key, value) in pairs {
-            data.fields.insert(key, serde_json::Value::String(value));
+            data.insert(key, Value::String(value));
         }
         data
     }

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -8,25 +10,41 @@ pub struct Screenshot {
     pub content_type: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct BatchEventData {
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct EventData {
     #[serde(default, with = "serde_bytes", skip_serializing_if = "Vec::is_empty")]
     pub image: Vec<u8>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub content_type: String,
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl EventData {
+    pub fn with_image(mut self, image: Vec<u8>, content_type: impl Into<String>) -> Self {
+        self.image = image;
+        self.content_type = content_type.into();
+        self
+    }
+
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -> Self {
+        let mut data = Self::default();
+        for (key, value) in pairs {
+            data.fields.insert(key, serde_json::Value::String(value));
+        }
+        data
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BatchEvent {
+pub struct LogEntry {
     pub ts: i64,
     #[serde(rename = "type")]
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk: Option<f32>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub metadata: Vec<(String, String)>,
     #[serde(default)]
-    pub data: BatchEventData,
+    pub data: EventData,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,34 +53,36 @@ pub struct BufferedBatchEvent {
     pub content_hash: [u8; 32],
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LogEntry {
-    pub ts_ms: i64,
-    pub kind: String,
-    pub risk: Option<f32>,
-    pub data: serde_json::Value,
-}
+pub type BatchEvent = LogEntry;
+pub type BatchEventData = EventData;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct AuditLogPayload {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub direct_log: Option<LogEntry>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "batch_screenshot")]
-    pub batch_event: Option<BufferedBatchEvent>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum AuditLogPayload {
+    Direct(LogEntry),
+    Batch(BufferedBatchEvent),
 }
 
 impl AuditLogPayload {
     pub fn for_direct_log(log: LogEntry) -> Self {
-        Self {
-            direct_log: Some(log),
-            batch_event: None,
-        }
+        Self::Direct(log)
     }
 
     pub fn for_batch_event(event: BufferedBatchEvent) -> Self {
-        Self {
-            direct_log: None,
-            batch_event: Some(event),
+        Self::Batch(event)
+    }
+
+    pub fn as_direct_log(&self) -> Option<&LogEntry> {
+        match self {
+            Self::Direct(log) => Some(log),
+            Self::Batch(_) => None,
+        }
+    }
+
+    pub fn as_batch_event(&self) -> Option<&BufferedBatchEvent> {
+        match self {
+            Self::Direct(_) => None,
+            Self::Batch(event) => Some(event),
         }
     }
 }

--- a/client/core/src/service.rs
+++ b/client/core/src/service.rs
@@ -160,7 +160,7 @@ impl<P: PlatformHooks> MonitorService<P> {
         data: EventData,
     ) -> CoreResult<()> {
         self.ensure_running()?;
-        let event = prepare_log_batch_event(self.platform.get_time_utc_ms()?, kind, risk, data);
+        let event = prepare_log_batch_event(self.platform.get_time_utc_ms()?, kind, risk, data)?;
         self.enqueue_batch_event(event, false)?;
         self.persist_state()
     }
@@ -281,7 +281,7 @@ impl<P: PlatformHooks> MonitorService<P> {
 
     fn process_screenshot(&self, screenshot: Screenshot) -> CoreResult<BufferedBatchEvent> {
         let processed = ImagePipeline.process(screenshot)?;
-        Ok(prepare_screenshot_event(processed))
+        prepare_screenshot_event(processed)
     }
 
     fn process_screenshot_with_data(
@@ -292,7 +292,7 @@ impl<P: PlatformHooks> MonitorService<P> {
         data: EventData,
     ) -> CoreResult<BufferedBatchEvent> {
         let processed = ImagePipeline.process(screenshot)?;
-        Ok(prepare_screenshot_batch_event(processed, kind, risk, data))
+        prepare_screenshot_batch_event(processed, kind, risk, data)
     }
 
     fn enqueue_batch_event(
@@ -947,11 +947,8 @@ mod tests {
                             ts: index as i64,
                             kind: "screenshot".to_string(),
                             risk: None,
-                            data: crate::model::BatchEventData {
-                                image: Vec::new(),
-                                content_type: "image/png".to_string(),
-                                fields: Default::default(),
-                            },
+                            data: crate::model::BatchEventData::from_pairs([])
+                                .with_screenshot(Vec::new(), "image/png"),
                         },
                         content_hash: [0; 32],
                     }),

--- a/client/core/src/service.rs
+++ b/client/core/src/service.rs
@@ -2,12 +2,15 @@ use crate::api::ApiClient;
 use crate::audit::{derive_state, generate_local_id};
 use crate::batch::BatchBuilder;
 use crate::config::Config;
-use crate::crypto::{CryptoEngine, prepare_screenshot_event};
+use crate::crypto::{
+    CryptoEngine, prepare_metadata_batch_event, prepare_screenshot_batch_event,
+    prepare_screenshot_event,
+};
 use crate::error::{CoreError, CoreResult};
 use crate::image_pipeline::ImagePipeline;
 use crate::model::{
     AuditLogItem, AuditLogPayload, AuditRecord, AuditState, AuthState, BatchRecipient, BatchUpload,
-    BufferedScreenshot, DeviceCredentials, DeviceSettings, LogEntry, LoginStatus, LoopOutcome,
+    BufferedBatchEvent, DeviceCredentials, DeviceSettings, LogEntry, LoginStatus, LoopOutcome,
     Screenshot, ServiceStatus,
 };
 use crate::platform::PlatformHooks;
@@ -102,7 +105,7 @@ impl<P: PlatformHooks> MonitorService<P> {
             if self.can_capture() && self.should_take_screenshot(now_ms) {
                 let screenshot = self.platform.take_screenshot()?;
                 let processed = self.process_screenshot(screenshot)?;
-                let item = self.enqueue_batch_screenshot(processed)?;
+                let item = self.enqueue_batch_event(processed, true)?;
                 let _ = self.try_upload_hash_for_item(&item);
                 self.status.last_screenshot_at_ms = Some(now_ms);
             }
@@ -151,6 +154,58 @@ impl<P: PlatformHooks> MonitorService<P> {
         let item = self.append_audit_log(false, false, AuditLogPayload::for_direct_log(log))?;
         let _ = self.try_upload_direct_log(&item);
         self.persist_state()
+    }
+
+    pub fn queue_batch_log(
+        &mut self,
+        kind: &str,
+        risk: Option<f32>,
+        metadata: Vec<(String, String)>,
+    ) -> CoreResult<()> {
+        self.ensure_running()?;
+        let event =
+            prepare_metadata_batch_event(self.platform.get_time_utc_ms()?, kind, risk, metadata);
+        self.enqueue_batch_event(event, false)?;
+        self.persist_state()
+    }
+
+    pub fn capture_batch_screenshot(
+        &mut self,
+        kind: &str,
+        risk: Option<f32>,
+        metadata: Vec<(String, String)>,
+    ) -> CoreResult<()> {
+        self.ensure_running()?;
+        let screenshot = self.platform.take_screenshot()?;
+        let item = self.process_screenshot_with_metadata(screenshot, kind, risk, metadata)?;
+        let item = self.enqueue_batch_event(item, true)?;
+        let _ = self.try_upload_hash_for_item(&item);
+        self.status.last_screenshot_at_ms = Some(self.platform.get_time_utc_ms()?);
+        self.persist_state()
+    }
+
+    pub fn upload_pending_batch_now(&mut self) -> CoreResult<(usize, usize)> {
+        self.ensure_running()?;
+        self.refresh_runtime_config()?;
+        self.reload_persisted_state()?;
+
+        let audit_state = self.load_audit_state()?;
+        let count = audit_state
+            .pending_batch_uploads
+            .len()
+            .min(MAX_BATCH_ITEMS_PER_UPLOAD);
+        if count == 0 {
+            self.persist_state()?;
+            return Ok((0, 0));
+        }
+
+        self.refresh_device_settings()?;
+        let now_ms = self.platform.get_time_utc_ms()?;
+        let batch_items = self.batch_upload_candidates(&audit_state);
+        self.try_upload_pending_batch(batch_items, now_ms)?;
+        let remaining = self.load_audit_state()?.pending_batch_uploads.len();
+        self.persist_state()?;
+        Ok((count, remaining))
     }
 
     pub fn login(&mut self, username: &str, password: &str) -> CoreResult<LoginStatus> {
@@ -230,19 +285,33 @@ impl<P: PlatformHooks> MonitorService<P> {
         Ok(status)
     }
 
-    fn process_screenshot(&self, screenshot: Screenshot) -> CoreResult<BufferedScreenshot> {
+    fn process_screenshot(&self, screenshot: Screenshot) -> CoreResult<BufferedBatchEvent> {
         let processed = ImagePipeline.process(screenshot)?;
         Ok(prepare_screenshot_event(processed))
     }
 
-    fn enqueue_batch_screenshot(
+    fn process_screenshot_with_metadata(
+        &self,
+        screenshot: Screenshot,
+        kind: &str,
+        risk: Option<f32>,
+        metadata: Vec<(String, String)>,
+    ) -> CoreResult<BufferedBatchEvent> {
+        let processed = ImagePipeline.process(screenshot)?;
+        Ok(prepare_screenshot_batch_event(
+            processed, kind, risk, metadata,
+        ))
+    }
+
+    fn enqueue_batch_event(
         &mut self,
-        screenshot: BufferedScreenshot,
+        event: BufferedBatchEvent,
+        requires_hash_upload: bool,
     ) -> CoreResult<AuditLogItem> {
         self.append_audit_log(
             true,
-            true,
-            AuditLogPayload::for_batch_screenshot(screenshot),
+            requires_hash_upload,
+            AuditLogPayload::for_batch_event(event),
         )
     }
 
@@ -272,7 +341,7 @@ impl<P: PlatformHooks> MonitorService<P> {
     }
 
     fn try_upload_hash_for_item(&mut self, item: &AuditLogItem) -> CoreResult<RetryAttemptOutcome> {
-        let Some(screenshot) = item.payload.batch_screenshot.as_ref() else {
+        let Some(batch_event) = item.payload.batch_event.as_ref() else {
             self.log_error(
                 "hash upload skipped; batch payload missing",
                 Some(&item.local_id),
@@ -289,7 +358,7 @@ impl<P: PlatformHooks> MonitorService<P> {
             api.upload_hash(
                 hash_base_url.as_deref(),
                 access_token,
-                &screenshot.content_hash,
+                &batch_event.content_hash,
             )
         }) {
             Ok(()) => {
@@ -363,26 +432,26 @@ impl<P: PlatformHooks> MonitorService<P> {
     }
 
     fn try_upload_pending_batch(&mut self, items: &[AuditLogItem], now_ms: i64) -> CoreResult<()> {
-        let screenshots = items
+        let batch_events = items
             .iter()
             .filter_map(|item| {
-                if item.payload.batch_screenshot.is_none() {
+                if item.payload.batch_event.is_none() {
                     self.log_error(
                         "batch upload skipped item; batch payload missing",
                         Some(&item.local_id),
                         None,
                     );
                 }
-                item.payload.batch_screenshot.clone()
+                item.payload.batch_event.clone()
             })
             .collect::<Vec<_>>();
-        if screenshots.is_empty() {
+        if batch_events.is_empty() {
             return Ok(());
         }
 
-        let mut screenshots = screenshots;
-        screenshots.sort_by_key(|item| item.event.ts);
-        let batch = self.build_batch(&screenshots, now_ms)?;
+        let mut batch_events = batch_events;
+        batch_events.sort_by_key(|item| item.event.ts);
+        let batch = self.build_batch(&batch_events, now_ms)?;
 
         match self
             .with_device_token_retry(|api, access_token, _| api.upload_batch(access_token, &batch))
@@ -393,7 +462,7 @@ impl<P: PlatformHooks> MonitorService<P> {
                         server_id: response.id.clone(),
                     })?;
                 for item in items {
-                    if item.payload.batch_screenshot.is_none() {
+                    if item.payload.batch_event.is_none() {
                         continue;
                     }
                     self.storage
@@ -423,11 +492,11 @@ impl<P: PlatformHooks> MonitorService<P> {
 
     fn build_batch(
         &self,
-        screenshots: &[BufferedScreenshot],
+        batch_events: &[BufferedBatchEvent],
         now_ms: i64,
     ) -> CoreResult<BatchUpload> {
         let recipients = self.batch_recipients()?;
-        BatchBuilder::build_upload(screenshots, &CryptoEngine, &recipients, now_ms)
+        BatchBuilder::build_upload(batch_events, &CryptoEngine, &recipients, now_ms)
     }
 
     fn retry_pending_work(&mut self) -> CoreResult<()> {
@@ -881,10 +950,12 @@ mod tests {
                     local_id: format!("batch-{index}"),
                     should_be_in_batch: true,
                     requires_hash_upload: false,
-                    payload: AuditLogPayload::for_batch_screenshot(BufferedScreenshot {
+                    payload: AuditLogPayload::for_batch_event(BufferedBatchEvent {
                         event: crate::model::BatchEvent {
                             ts: index as i64,
                             kind: "screenshot".to_string(),
+                            risk: None,
+                            metadata: Vec::new(),
                             data: crate::model::BatchEventData {
                                 image: Vec::new(),
                                 content_type: "image/png".to_string(),
@@ -904,6 +975,45 @@ mod tests {
         assert_eq!(
             candidates[MAX_BATCH_ITEMS_PER_UPLOAD - 1].local_id,
             format!("batch-{}", MAX_BATCH_ITEMS_PER_UPLOAD - 1)
+        );
+
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn queue_batch_log_creates_pending_batch_item_without_hash_upload() {
+        let state_dir = temp_state_dir();
+        let mut service = build_service(state_dir.clone());
+
+        service
+            .queue_batch_log(
+                "developer_log",
+                Some(0.7),
+                vec![
+                    ("source".to_string(), "test".to_string()),
+                    ("title".to_string(), "Developer test".to_string()),
+                ],
+            )
+            .expect("queue batch log");
+
+        let audit_state = service.load_audit_state().expect("load audit state");
+
+        assert_eq!(audit_state.pending_hash_uploads.len(), 0);
+        assert_eq!(audit_state.pending_batch_uploads.len(), 1);
+        let queued = &audit_state.pending_batch_uploads[0];
+        let batch_event = queued
+            .payload
+            .batch_event
+            .as_ref()
+            .expect("queued batch event");
+        assert_eq!(batch_event.event.kind, "developer_log");
+        assert_eq!(batch_event.event.risk, Some(0.7));
+        assert_eq!(
+            batch_event.event.metadata,
+            vec![
+                ("source".to_string(), "test".to_string()),
+                ("title".to_string(), "Developer test".to_string()),
+            ]
         );
 
         let _ = fs::remove_dir_all(state_dir);

--- a/client/core/src/service.rs
+++ b/client/core/src/service.rs
@@ -3,15 +3,14 @@ use crate::audit::{derive_state, generate_local_id};
 use crate::batch::BatchBuilder;
 use crate::config::Config;
 use crate::crypto::{
-    CryptoEngine, prepare_metadata_batch_event, prepare_screenshot_batch_event,
-    prepare_screenshot_event,
+    CryptoEngine, prepare_log_batch_event, prepare_screenshot_batch_event, prepare_screenshot_event,
 };
 use crate::error::{CoreError, CoreResult};
 use crate::image_pipeline::ImagePipeline;
 use crate::model::{
     AuditLogItem, AuditLogPayload, AuditRecord, AuditState, AuthState, BatchRecipient, BatchUpload,
-    BufferedBatchEvent, DeviceCredentials, DeviceSettings, LogEntry, LoginStatus, LoopOutcome,
-    Screenshot, ServiceStatus,
+    BufferedBatchEvent, DeviceCredentials, DeviceSettings, EventData, LogEntry, LoginStatus,
+    LoopOutcome, Screenshot, ServiceStatus,
 };
 use crate::platform::PlatformHooks;
 use crate::storage::FileStateStore;
@@ -137,12 +136,10 @@ impl<P: PlatformHooks> MonitorService<P> {
 
         let now_ms = self.platform.get_time_utc_ms()?;
         let _ = self.send_log(LogEntry {
-            ts_ms: now_ms,
+            ts: now_ms,
             kind: "service_stop".to_string(),
             risk: None,
-            data: serde_json::json!({
-                "event": "shutdown",
-            }),
+            data: EventData::from_pairs([("event".to_string(), "shutdown".to_string())]),
         });
 
         self.status.is_running = false;
@@ -160,11 +157,10 @@ impl<P: PlatformHooks> MonitorService<P> {
         &mut self,
         kind: &str,
         risk: Option<f32>,
-        metadata: Vec<(String, String)>,
+        data: EventData,
     ) -> CoreResult<()> {
         self.ensure_running()?;
-        let event =
-            prepare_metadata_batch_event(self.platform.get_time_utc_ms()?, kind, risk, metadata);
+        let event = prepare_log_batch_event(self.platform.get_time_utc_ms()?, kind, risk, data);
         self.enqueue_batch_event(event, false)?;
         self.persist_state()
     }
@@ -173,11 +169,11 @@ impl<P: PlatformHooks> MonitorService<P> {
         &mut self,
         kind: &str,
         risk: Option<f32>,
-        metadata: Vec<(String, String)>,
+        data: EventData,
     ) -> CoreResult<()> {
         self.ensure_running()?;
         let screenshot = self.platform.take_screenshot()?;
-        let item = self.process_screenshot_with_metadata(screenshot, kind, risk, metadata)?;
+        let item = self.process_screenshot_with_data(screenshot, kind, risk, data)?;
         let item = self.enqueue_batch_event(item, true)?;
         let _ = self.try_upload_hash_for_item(&item);
         self.status.last_screenshot_at_ms = Some(self.platform.get_time_utc_ms()?);
@@ -233,13 +229,13 @@ impl<P: PlatformHooks> MonitorService<P> {
         self.persist_state()?;
 
         let _ = self.send_log(LogEntry {
-            ts_ms: self.platform.get_time_utc_ms()?,
+            ts: self.platform.get_time_utc_ms()?,
             kind: "system_event".to_string(),
             risk: None,
-            data: serde_json::json!({
-                "event": "login",
-                "user": username,
-            }),
+            data: EventData::from_pairs([
+                ("event".to_string(), "login".to_string()),
+                ("user".to_string(), username.to_string()),
+            ]),
         });
 
         Ok(LoginStatus {
@@ -253,12 +249,10 @@ impl<P: PlatformHooks> MonitorService<P> {
 
         if self.device_credentials.is_some() {
             let _ = self.send_log(LogEntry {
-                ts_ms: self.platform.get_time_utc_ms()?,
+                ts: self.platform.get_time_utc_ms()?,
                 kind: "system_event".to_string(),
                 risk: None,
-                data: serde_json::json!({
-                    "event": "logout",
-                }),
+                data: EventData::from_pairs([("event".to_string(), "logout".to_string())]),
             });
         }
 
@@ -290,17 +284,15 @@ impl<P: PlatformHooks> MonitorService<P> {
         Ok(prepare_screenshot_event(processed))
     }
 
-    fn process_screenshot_with_metadata(
+    fn process_screenshot_with_data(
         &self,
         screenshot: Screenshot,
         kind: &str,
         risk: Option<f32>,
-        metadata: Vec<(String, String)>,
+        data: EventData,
     ) -> CoreResult<BufferedBatchEvent> {
         let processed = ImagePipeline.process(screenshot)?;
-        Ok(prepare_screenshot_batch_event(
-            processed, kind, risk, metadata,
-        ))
+        Ok(prepare_screenshot_batch_event(processed, kind, risk, data))
     }
 
     fn enqueue_batch_event(
@@ -341,7 +333,7 @@ impl<P: PlatformHooks> MonitorService<P> {
     }
 
     fn try_upload_hash_for_item(&mut self, item: &AuditLogItem) -> CoreResult<RetryAttemptOutcome> {
-        let Some(batch_event) = item.payload.batch_event.as_ref() else {
+        let Some(batch_event) = item.payload.as_batch_event() else {
             self.log_error(
                 "hash upload skipped; batch payload missing",
                 Some(&item.local_id),
@@ -388,7 +380,7 @@ impl<P: PlatformHooks> MonitorService<P> {
     }
 
     fn try_upload_direct_log(&mut self, item: &AuditLogItem) -> CoreResult<RetryAttemptOutcome> {
-        let Some(log) = item.payload.direct_log.as_ref() else {
+        let Some(log) = item.payload.as_direct_log() else {
             self.log_error(
                 "direct log upload skipped; direct payload missing",
                 Some(&item.local_id),
@@ -435,14 +427,14 @@ impl<P: PlatformHooks> MonitorService<P> {
         let batch_events = items
             .iter()
             .filter_map(|item| {
-                if item.payload.batch_event.is_none() {
+                if item.payload.as_batch_event().is_none() {
                     self.log_error(
                         "batch upload skipped item; batch payload missing",
                         Some(&item.local_id),
                         None,
                     );
                 }
-                item.payload.batch_event.clone()
+                item.payload.as_batch_event().cloned()
             })
             .collect::<Vec<_>>();
         if batch_events.is_empty() {
@@ -462,7 +454,7 @@ impl<P: PlatformHooks> MonitorService<P> {
                         server_id: response.id.clone(),
                     })?;
                 for item in items {
-                    if item.payload.batch_event.is_none() {
+                    if item.payload.as_batch_event().is_none() {
                         continue;
                     }
                     self.storage
@@ -925,10 +917,10 @@ mod tests {
                 should_be_in_batch: false,
                 requires_hash_upload: false,
                 log: AuditLogPayload::for_direct_log(LogEntry {
-                    ts_ms: 1,
+                    ts: 1,
                     kind: "system_event".to_string(),
                     risk: None,
-                    data: serde_json::json!({ "event": "test" }),
+                    data: EventData::from_pairs([("event".to_string(), "test".to_string())]),
                 }),
             })
             .expect("append audit record");
@@ -955,10 +947,10 @@ mod tests {
                             ts: index as i64,
                             kind: "screenshot".to_string(),
                             risk: None,
-                            metadata: Vec::new(),
                             data: crate::model::BatchEventData {
                                 image: Vec::new(),
                                 content_type: "image/png".to_string(),
+                                fields: Default::default(),
                             },
                         },
                         content_hash: [0; 32],
@@ -989,10 +981,10 @@ mod tests {
             .queue_batch_log(
                 "developer_log",
                 Some(0.7),
-                vec![
+                EventData::from_pairs([
                     ("source".to_string(), "test".to_string()),
                     ("title".to_string(), "Developer test".to_string()),
-                ],
+                ]),
             )
             .expect("queue batch log");
 
@@ -1001,19 +993,15 @@ mod tests {
         assert_eq!(audit_state.pending_hash_uploads.len(), 0);
         assert_eq!(audit_state.pending_batch_uploads.len(), 1);
         let queued = &audit_state.pending_batch_uploads[0];
-        let batch_event = queued
-            .payload
-            .batch_event
-            .as_ref()
-            .expect("queued batch event");
+        let batch_event = queued.payload.as_batch_event().expect("queued batch event");
         assert_eq!(batch_event.event.kind, "developer_log");
         assert_eq!(batch_event.event.risk, Some(0.7));
         assert_eq!(
-            batch_event.event.metadata,
-            vec![
+            batch_event.event.data,
+            EventData::from_pairs([
                 ("source".to_string(), "test".to_string()),
                 ("title".to_string(), "Developer test".to_string()),
-            ]
+            ])
         );
 
         let _ = fs::remove_dir_all(state_dir);
@@ -1038,10 +1026,10 @@ mod tests {
                 should_be_in_batch: false,
                 requires_hash_upload: false,
                 log: AuditLogPayload::for_direct_log(LogEntry {
-                    ts_ms: 1,
+                    ts: 1,
                     kind: "system_event".to_string(),
                     risk: None,
-                    data: serde_json::json!({ "event": "test" }),
+                    data: EventData::from_pairs([("event".to_string(), "test".to_string())]),
                 }),
             })
             .expect("append audit record");

--- a/client/linux/README.md
+++ b/client/linux/README.md
@@ -13,6 +13,14 @@
 - `virtue daemon`
   - Background worker used by systemd.
   - On desktop sessions, it also starts a minimal tray icon with hover status.
+- `virtue dev upload-log --risk 0.7 [--title ...] [--details ...]`
+  - Sends a developer log immediately with the provided risk score.
+- `virtue dev add-log --risk 0.7 [--title ...] [--details ...]`
+  - Queues a metadata-only developer log into the next encrypted batch.
+- `virtue dev add-screenshot --risk 0.7 [--title ...] [--details ...]`
+  - Captures a screenshot and queues it into the next encrypted batch.
+- `virtue dev upload-batch`
+  - Forces the currently queued batch items to upload now.
 
 ## Service behavior
 

--- a/client/linux/scripts/build-deb.sh
+++ b/client/linux/scripts/build-deb.sh
@@ -11,7 +11,7 @@ BUILD_LABEL="$(virtue_build_label)"
 ARCH="$(dpkg --print-architecture)"
 PKG_NAME="virtue"
 
-cargo build --release -p virtue-linux
+VIRTUE_BUILD_LABEL="$BUILD_LABEL" cargo build --release -p virtue-linux
 
 
 PKG_DIR="target/debian/${PKG_NAME}_${BUILD_LABEL}_${ARCH}"

--- a/client/linux/src/daemon.rs
+++ b/client/linux/src/daemon.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
-use virtue_core::{LogEntry, MonitorService};
+use virtue_core::{EventData, LogEntry, MonitorService};
 
 use crate::capture::{LinuxPlatformHooks, is_session_unavailable_text};
 use crate::config::{ClientPaths, build_core_config};
@@ -254,7 +254,7 @@ fn emit_shutdown_logs(service: &mut MonitorService<LinuxPlatformHooks>, signal_n
         emit_log_entry(
             service,
             LogEntry {
-                ts_ms: Utc::now().timestamp_millis(),
+                ts: Utc::now().timestamp_millis(),
                 kind: "system_shutdown".to_string(),
                 risk: None,
                 data: metadata_value_owned(metadata),
@@ -280,25 +280,31 @@ fn emit_log_entry(service: &mut MonitorService<LinuxPlatformHooks>, entry: LogEn
 
 fn log_entry(kind: &str, metadata: &[(&str, &str)], created_at: DateTime<Utc>) -> LogEntry {
     LogEntry {
-        ts_ms: created_at.timestamp_millis(),
+        ts: created_at.timestamp_millis(),
         kind: kind.to_string(),
         risk: None,
         data: metadata_value(metadata),
     }
 }
 
-fn metadata_value(metadata: &[(&str, &str)]) -> Value {
-    let mut object = Map::new();
+fn metadata_value(metadata: &[(&str, &str)]) -> EventData {
+    let mut fields = Map::new();
     for (key, value) in metadata {
-        object.insert((*key).to_string(), Value::String((*value).to_string()));
+        fields.insert((*key).to_string(), Value::String((*value).to_string()));
     }
-    Value::Object(object)
+    EventData {
+        fields: fields.into_iter().collect(),
+        ..EventData::default()
+    }
 }
 
-fn metadata_value_owned(metadata: Vec<(String, String)>) -> Value {
+fn metadata_value_owned(metadata: Vec<(String, String)>) -> EventData {
     let mut object = Map::new();
     for (key, value) in metadata {
         object.insert(key, Value::String(value));
     }
-    Value::Object(object)
+    EventData {
+        fields: object.into_iter().collect(),
+        ..EventData::default()
+    }
 }

--- a/client/linux/src/daemon.rs
+++ b/client/linux/src/daemon.rs
@@ -292,10 +292,7 @@ fn metadata_value(metadata: &[(&str, &str)]) -> EventData {
     for (key, value) in metadata {
         fields.insert((*key).to_string(), Value::String((*value).to_string()));
     }
-    EventData {
-        fields: fields.into_iter().collect(),
-        ..EventData::default()
-    }
+    EventData(fields.into_iter().collect())
 }
 
 fn metadata_value_owned(metadata: Vec<(String, String)>) -> EventData {
@@ -303,8 +300,5 @@ fn metadata_value_owned(metadata: Vec<(String, String)>) -> EventData {
     for (key, value) in metadata {
         object.insert(key, Value::String(value));
     }
-    EventData {
-        fields: object.into_iter().collect(),
-        ..EventData::default()
-    }
+    EventData(object.into_iter().collect())
 }

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 use virtue_core::audit::derive_state;
 use virtue_core::storage::FileStateStore;
-use virtue_core::{AuthState, LogEntry, MonitorService, ServiceStatus};
+use virtue_core::{AuthState, EventData, LogEntry, MonitorService, ServiceStatus};
 
 use crate::capture::{CaptureBackend, LinuxPlatformHooks, detect_backend, probe_backend};
 use crate::config::{ClientPaths, build_core_config};
@@ -205,7 +205,7 @@ fn dev_upload_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
         .unwrap_or_else(|| "Developer CLI log".to_string());
     let mut service = MonitorService::setup(build_core_config(&paths), LinuxPlatformHooks::new())?;
     service.send_log(LogEntry {
-        ts_ms: current_time_utc_ms()?,
+        ts: current_time_utc_ms()?,
         kind: "developer_log".to_string(),
         risk: Some(args.risk),
         data: developer_log_data("upload_log", &title, args.details.as_deref()),
@@ -226,7 +226,7 @@ fn dev_add_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
     service.queue_batch_log(
         "developer_log",
         Some(args.risk),
-        developer_metadata("add_log", &title, args.details.as_deref()),
+        developer_log_data("add_log", &title, args.details.as_deref()),
     )?;
 
     println!(
@@ -244,7 +244,7 @@ fn dev_add_screenshot(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()
     service.capture_batch_screenshot(
         "developer_screenshot",
         Some(args.risk),
-        developer_metadata("add_screenshot", &title, args.details.as_deref()),
+        developer_log_data("add_screenshot", &title, args.details.as_deref()),
     )?;
 
     println!(
@@ -331,28 +331,14 @@ fn format_risk(risk: f32) -> String {
     value
 }
 
-fn developer_metadata(command: &str, title: &str, details: Option<&str>) -> Vec<(String, String)> {
-    let mut metadata = vec![
+fn developer_log_data(command: &str, title: &str, details: Option<&str>) -> EventData {
+    let mut data = EventData::from_pairs([
         ("source".to_string(), "linux_dev_cli".to_string()),
         ("command".to_string(), command.to_string()),
         ("title".to_string(), title.to_string()),
-    ];
+    ]);
     if let Some(details) = details.filter(|value| !value.trim().is_empty()) {
-        metadata.push(("details".to_string(), details.to_string()));
-    }
-    metadata
-}
-
-fn developer_log_data(command: &str, title: &str, details: Option<&str>) -> serde_json::Value {
-    let mut data = serde_json::json!({
-        "source": "linux_dev_cli",
-        "command": command,
-        "title": title,
-    });
-    if let Some(details) = details.filter(|value| !value.trim().is_empty())
-        && let Some(object) = data.as_object_mut()
-    {
-        object.insert(
+        data.fields.insert(
             "details".to_string(),
             serde_json::Value::String(details.to_string()),
         );

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -338,10 +338,7 @@ fn developer_log_data(command: &str, title: &str, details: Option<&str>) -> Even
         ("title".to_string(), title.to_string()),
     ]);
     if let Some(details) = details.filter(|value| !value.trim().is_empty()) {
-        data.fields.insert(
-            "details".to_string(),
-            serde_json::Value::String(details.to_string()),
-        );
+        data.insert("details", serde_json::Value::String(details.to_string()));
     }
     data
 }

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -5,17 +5,18 @@ mod tray;
 
 use std::io::{self, Write};
 use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use virtue_core::audit::derive_state;
 use virtue_core::storage::FileStateStore;
-use virtue_core::{AuthState, MonitorService, ServiceStatus};
+use virtue_core::{AuthState, LogEntry, MonitorService, ServiceStatus};
 
 use crate::capture::{CaptureBackend, LinuxPlatformHooks, detect_backend, probe_backend};
 use crate::config::{ClientPaths, build_core_config};
 
-const BUILD_LABEL: &str = env!("CARGO_PKG_VERSION");
+const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
 
 #[derive(Debug, Parser)]
 #[command(name = "virtue")]
@@ -28,16 +29,47 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    #[command(about = "Log in and register this Linux device")]
     Login {
         #[arg(long)]
         email: Option<String>,
     },
+    #[command(about = "Log out and disable monitoring on this device")]
     Logout {
         #[arg(long)]
         yes: bool,
     },
+    #[command(about = "Run the background monitoring daemon")]
     Daemon,
+    #[command(about = "Show current auth, capture, and upload status")]
     Status,
+    #[command(about = "Developer-only commands for test logs and batch uploads")]
+    Dev {
+        #[command(subcommand)]
+        command: DevCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum DevCommands {
+    #[command(about = "Upload a developer log immediately")]
+    UploadLog(DeveloperEventArgs),
+    #[command(about = "Queue a developer log into the next encrypted batch")]
+    AddLog(DeveloperEventArgs),
+    #[command(about = "Capture a screenshot and queue it into the next encrypted batch")]
+    AddScreenshot(DeveloperEventArgs),
+    #[command(about = "Upload any queued batch items right now")]
+    UploadBatch,
+}
+
+#[derive(Debug, Args)]
+struct DeveloperEventArgs {
+    #[arg(long, default_value_t = 0.5_f32, value_parser = parse_risk)]
+    risk: f32,
+    #[arg(long)]
+    title: Option<String>,
+    #[arg(long)]
+    details: Option<String>,
 }
 
 #[tokio::main]
@@ -61,6 +93,7 @@ async fn run() -> Result<()> {
         Commands::Logout { yes } => logout(paths, yes),
         Commands::Daemon => daemon::run_daemon(&paths).await,
         Commands::Status => status(paths),
+        Commands::Dev { command } => dev(paths, command),
     }
 }
 
@@ -157,6 +190,88 @@ fn status(paths: ClientPaths) -> Result<()> {
     Ok(())
 }
 
+fn dev(paths: ClientPaths, command: DevCommands) -> Result<()> {
+    match command {
+        DevCommands::UploadLog(args) => dev_upload_log(paths, args),
+        DevCommands::AddLog(args) => dev_add_log(paths, args),
+        DevCommands::AddScreenshot(args) => dev_add_screenshot(paths, args),
+        DevCommands::UploadBatch => dev_upload_batch(paths),
+    }
+}
+
+fn dev_upload_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
+    let title = args
+        .title
+        .unwrap_or_else(|| "Developer CLI log".to_string());
+    let mut service = MonitorService::setup(build_core_config(&paths), LinuxPlatformHooks::new())?;
+    service.send_log(LogEntry {
+        ts_ms: current_time_utc_ms()?,
+        kind: "developer_log".to_string(),
+        risk: Some(args.risk),
+        data: developer_log_data("upload_log", &title, args.details.as_deref()),
+    })?;
+
+    println!(
+        "Recorded immediate developer log with risk {}.",
+        format_risk(args.risk)
+    );
+    Ok(())
+}
+
+fn dev_add_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
+    let title = args
+        .title
+        .unwrap_or_else(|| "Developer CLI batched log".to_string());
+    let mut service = MonitorService::setup(build_core_config(&paths), LinuxPlatformHooks::new())?;
+    service.queue_batch_log(
+        "developer_log",
+        Some(args.risk),
+        developer_metadata("add_log", &title, args.details.as_deref()),
+    )?;
+
+    println!(
+        "Queued developer log in the next batch with risk {}.",
+        format_risk(args.risk)
+    );
+    Ok(())
+}
+
+fn dev_add_screenshot(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
+    let title = args
+        .title
+        .unwrap_or_else(|| "Developer CLI screenshot".to_string());
+    let mut service = MonitorService::setup(build_core_config(&paths), LinuxPlatformHooks::new())?;
+    service.capture_batch_screenshot(
+        "developer_screenshot",
+        Some(args.risk),
+        developer_metadata("add_screenshot", &title, args.details.as_deref()),
+    )?;
+
+    println!(
+        "Captured and queued a developer screenshot with risk {}.",
+        format_risk(args.risk)
+    );
+    Ok(())
+}
+
+fn dev_upload_batch(paths: ClientPaths) -> Result<()> {
+    let mut service = MonitorService::setup(build_core_config(&paths), LinuxPlatformHooks::new())?;
+    let (attempted, remaining) = service.upload_pending_batch_now()?;
+
+    if attempted == 0 {
+        println!("No pending batch items to upload.");
+        return Ok(());
+    }
+
+    if remaining == 0 {
+        println!("Processed {attempted} batch item(s); no batch items remain queued.");
+    } else {
+        println!("Processed {attempted} batch item(s); {remaining} batch item(s) remain queued.");
+    }
+
+    Ok(())
+}
+
 fn prompt_line(label: &str) -> Result<String> {
     print!("{label}: ");
     io::stdout().flush().context("failed flushing stdout")?;
@@ -193,6 +308,63 @@ fn prompt_yes_no(prompt: &str, default_yes: bool) -> Result<bool> {
 
         println!("Please answer y or n.");
     }
+}
+
+fn parse_risk(raw: &str) -> std::result::Result<f32, String> {
+    let risk = raw
+        .parse::<f32>()
+        .map_err(|_| "risk must be a number between 0 and 1".to_string())?;
+    if !risk.is_finite() || !(0.0..=1.0).contains(&risk) {
+        return Err("risk must be a number between 0 and 1".to_string());
+    }
+    Ok(risk)
+}
+
+fn format_risk(risk: f32) -> String {
+    let mut value = format!("{risk:.3}");
+    while value.contains('.') && value.ends_with('0') {
+        value.pop();
+    }
+    if value.ends_with('.') {
+        value.pop();
+    }
+    value
+}
+
+fn developer_metadata(command: &str, title: &str, details: Option<&str>) -> Vec<(String, String)> {
+    let mut metadata = vec![
+        ("source".to_string(), "linux_dev_cli".to_string()),
+        ("command".to_string(), command.to_string()),
+        ("title".to_string(), title.to_string()),
+    ];
+    if let Some(details) = details.filter(|value| !value.trim().is_empty()) {
+        metadata.push(("details".to_string(), details.to_string()));
+    }
+    metadata
+}
+
+fn developer_log_data(command: &str, title: &str, details: Option<&str>) -> serde_json::Value {
+    let mut data = serde_json::json!({
+        "source": "linux_dev_cli",
+        "command": command,
+        "title": title,
+    });
+    if let Some(details) = details.filter(|value| !value.trim().is_empty())
+        && let Some(object) = data.as_object_mut()
+    {
+        object.insert(
+            "details".to_string(),
+            serde_json::Value::String(details.to_string()),
+        );
+    }
+    data
+}
+
+fn current_time_utc_ms() -> Result<i64> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX epoch")?;
+    i64::try_from(duration.as_millis()).context("system clock overflow")
 }
 
 fn load_service_status(store: &FileStateStore, auth: &AuthState) -> Result<ServiceStatus> {

--- a/client/mac/scripts/build-app.sh
+++ b/client/mac/scripts/build-app.sh
@@ -26,7 +26,7 @@ if [[ ! -f "$ICON_SOURCE" ]]; then
   exit 1
 fi
 
-cargo build --release -p virtue-mac
+VIRTUE_BUILD_LABEL="$BUILD_LABEL" cargo build --release -p virtue-mac
 
 rm -rf "$APP_ROOT"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"

--- a/client/mac/src/daemon.rs
+++ b/client/mac/src/daemon.rs
@@ -15,7 +15,7 @@ use objc2_foundation::{NSDate, NSRunLoop};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::time::sleep;
-use virtue_core::{LogEntry, MonitorService};
+use virtue_core::{EventData, LogEntry, MonitorService};
 
 use crate::capture::{MacPlatformHooks, has_screen_capture_access, is_permission_missing_error};
 use crate::config::{
@@ -295,20 +295,16 @@ fn save_lifecycle_state(path: &Path, state: &LifecycleState) -> Result<()> {
 }
 
 fn log_entry(kind: &str, metadata: &[(&str, &str)], ts: DateTime<Utc>) -> LogEntry {
-    let data = metadata
-        .iter()
-        .map(|(key, value)| {
-            (
-                (*key).to_string(),
-                serde_json::Value::String((*value).to_string()),
-            )
-        })
-        .collect::<serde_json::Map<_, _>>();
+    let data = EventData::from_pairs(
+        metadata
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
+    );
 
     LogEntry {
-        ts_ms: ts.timestamp_millis(),
+        ts: ts.timestamp_millis(),
         kind: kind.to_string(),
         risk: None,
-        data: serde_json::Value::Object(data),
+        data,
     }
 }

--- a/client/mac/src/main.rs
+++ b/client/mac/src/main.rs
@@ -24,7 +24,7 @@ use crate::config::{
 };
 use crate::runtime_env::apply_runtime_env;
 
-const BUILD_LABEL: &str = env!("CARGO_PKG_VERSION");
+const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
 
 #[derive(Debug, Parser)]
 #[command(name = "virtue-mac")]

--- a/client/mac/src/main.rs
+++ b/client/mac/src/main.rs
@@ -15,7 +15,7 @@ use tray_icon::menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem};
 use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use virtue_core::audit::derive_state;
 use virtue_core::storage::FileStateStore;
-use virtue_core::{AuthState, CoreError, LogEntry, MonitorService, ServiceStatus};
+use virtue_core::{AuthState, CoreError, EventData, LogEntry, MonitorService, ServiceStatus};
 
 use crate::capture::MacPlatformHooks;
 use crate::config::{
@@ -246,13 +246,13 @@ fn send_close_alert(paths: &ClientPaths) -> Result<()> {
 
     let mut service = MonitorService::setup(build_core_config(paths), MacPlatformHooks::new())?;
     let _ = service.send_log(LogEntry {
-        ts_ms: Utc::now().timestamp_millis(),
+        ts: Utc::now().timestamp_millis(),
         kind: "manual_override".to_string(),
         risk: None,
-        data: serde_json::json!({
-            "source": "mac_tray_menu",
-            "reason": "tray_close_requested",
-        }),
+        data: EventData::from_pairs([
+            ("source".to_string(), "mac_tray_menu".to_string()),
+            ("reason".to_string(), "tray_close_requested".to_string()),
+        ]),
     });
     Ok(())
 }

--- a/client/windows/src/bin/virtue-auth-ui.rs
+++ b/client/windows/src/bin/virtue-auth-ui.rs
@@ -146,7 +146,7 @@ slint::slint! {
     }
 }
 
-const BUILD_LABEL: &str = env!("CARGO_PKG_VERSION");
+const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
 
 fn main() -> Result<()> {
     let paths = ClientPaths::discover()?;

--- a/client/windows/src/bin/virtue-service.rs
+++ b/client/windows/src/bin/virtue-service.rs
@@ -29,7 +29,7 @@ use virtue_windows::service_log::ServiceLogger;
 
 const SERVICE_NAME: &str = "VirtueLifecycleService";
 const LIFECYCLE_INSTANCE_MUTEX_NAME: windows::core::PCWSTR = w!("Local\\VirtueLifecycleConsole");
-const BUILD_LABEL: &str = env!("CARGO_PKG_VERSION");
+const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Mode {

--- a/client/windows/src/bin/virtue-tray.rs
+++ b/client/windows/src/bin/virtue-tray.rs
@@ -34,7 +34,7 @@ use virtue_windows::win_text::to_wide;
 
 const WINDOW_CLASS: PCWSTR = w!("VirtueTrayWindow");
 const WINDOW_TITLE: PCWSTR = w!("Virtue");
-const BUILD_LABEL: &str = env!("CARGO_PKG_VERSION");
+const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
 
 const ID_TRAY_OPEN: u16 = 2001;
 const ID_TRAY_EXIT: u16 = 2002;

--- a/client/windows/src/daemon.rs
+++ b/client/windows/src/daemon.rs
@@ -9,7 +9,9 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use virtue_core::{CoreError, CoreResult, LogEntry, MonitorService, PlatformHooks, Screenshot};
+use virtue_core::{
+    CoreError, CoreResult, EventData, LogEntry, MonitorService, PlatformHooks, Screenshot,
+};
 use windows::Win32::System::SystemInformation::GetTickCount64;
 
 use crate::capture_control;
@@ -166,7 +168,7 @@ fn detect_system_startup_event(paths: &ClientPaths) -> Option<LogEntry> {
     }
 
     Some(LogEntry {
-        ts_ms: started_at.timestamp_millis(),
+        ts: started_at.timestamp_millis(),
         kind: "system_startup".to_string(),
         risk: None,
         data: metadata_value(&[
@@ -182,7 +184,7 @@ fn emit_log(paths: &ClientPaths, logger: &ServiceLogger, kind: &str, metadata: &
         paths,
         logger,
         LogEntry {
-            ts_ms: Utc::now().timestamp_millis(),
+            ts: Utc::now().timestamp_millis(),
             kind: kind.to_string(),
             risk: None,
             data: metadata_value(metadata),
@@ -206,17 +208,11 @@ fn emit_log_entry(paths: &ClientPaths, logger: &ServiceLogger, entry: LogEntry) 
     }
 }
 
-fn metadata_value(metadata: &[(&str, &str)]) -> serde_json::Value {
-    serde_json::Value::Object(
+fn metadata_value(metadata: &[(&str, &str)]) -> EventData {
+    EventData::from_pairs(
         metadata
             .iter()
-            .map(|(key, value)| {
-                (
-                    (*key).to_string(),
-                    serde_json::Value::String((*value).to_string()),
-                )
-            })
-            .collect::<serde_json::Map<_, _>>(),
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string())),
     )
 }
 

--- a/web/src/crypto.ts
+++ b/web/src/crypto.ts
@@ -268,11 +268,7 @@ async function computeBatchEventHash(event: {
   ts: number;
   type: string;
   risk?: number;
-  metadata?: [string, string][];
-  data?: {
-    image?: unknown;
-    content_type?: unknown;
-  };
+  data?: Record<string, unknown>;
 }) {
   const parts: Uint8Array[] = [];
   appendU64(parts, event.ts);
@@ -288,21 +284,21 @@ async function computeBatchEventHash(event: {
   const contentType =
     typeof data.content_type === "string" ? data.content_type : "";
 
-  for (const [key, value] of [
-    ["content_type", textEncoder.encode(contentType)],
-    ["image", image],
-  ] as const) {
-    parts.push(textEncoder.encode(key));
-    parts.push(value);
+  if (contentType) {
+    parts.push(textEncoder.encode("content_type"));
+    parts.push(textEncoder.encode(contentType));
+  }
+  if (image.length > 0) {
+    parts.push(textEncoder.encode("image"));
+    parts.push(image);
   }
 
-  const metadata = [...(event.metadata ?? [])].sort(([leftKey, leftValue], [rightKey, rightValue]) =>
-    leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue),
-  );
-  for (const [key, value] of metadata) {
-    parts.push(textEncoder.encode("metadata"));
+  const fieldEntries = Object.entries(data)
+    .filter(([key]) => key !== "content_type" && key !== "image")
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+  for (const [key, value] of fieldEntries) {
     parts.push(textEncoder.encode(key));
-    parts.push(textEncoder.encode(value));
+    appendJsonValue(parts, value);
   }
 
   const totalLen = parts.reduce((sum, part) => sum + part.length, 0);
@@ -314,6 +310,50 @@ async function computeBatchEventHash(event: {
   }
 
   return new Uint8Array(await crypto.subtle.digest("SHA-256", buf));
+}
+
+function appendJsonValue(parts: Uint8Array[], value: unknown) {
+  if (value === null || value === undefined) {
+    parts.push(textEncoder.encode("n"));
+    return;
+  }
+  if (typeof value === "boolean") {
+    parts.push(textEncoder.encode("b"));
+    parts.push(Uint8Array.of(value ? 1 : 0));
+    return;
+  }
+  if (typeof value === "number") {
+    parts.push(textEncoder.encode("#"));
+    parts.push(textEncoder.encode(JSON.stringify(value)));
+    return;
+  }
+  if (typeof value === "string") {
+    parts.push(textEncoder.encode("s"));
+    parts.push(textEncoder.encode(value));
+    return;
+  }
+  if (Array.isArray(value)) {
+    parts.push(textEncoder.encode("["));
+    for (const item of value) {
+      appendJsonValue(parts, item);
+    }
+    parts.push(textEncoder.encode("]"));
+    return;
+  }
+  if (typeof value === "object") {
+    parts.push(textEncoder.encode("{"));
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([leftKey], [rightKey]) => leftKey.localeCompare(rightKey),
+    );
+    for (const [key, item] of entries) {
+      parts.push(textEncoder.encode(key));
+      appendJsonValue(parts, item);
+    }
+    parts.push(textEncoder.encode("}"));
+    return;
+  }
+
+  parts.push(textEncoder.encode("n"));
 }
 
 /**
@@ -330,11 +370,7 @@ export async function verifyBatch(
     ts: number;
     type: string;
     risk?: number;
-    metadata?: [string, string][];
-    data?: {
-      image?: unknown;
-      content_type?: unknown;
-    };
+    data?: Record<string, unknown>;
   }[],
   startChainHash: string,
   endChainHash: string,

--- a/web/src/crypto.ts
+++ b/web/src/crypto.ts
@@ -230,38 +230,97 @@ const ZEROS_HEX = "0".repeat(64);
 
 export type BatchVerification = "verified" | "failed" | "unknown";
 
-type BatchLogValue = string | number | boolean | Uint8Array;
+function appendU64(parts: Uint8Array[], value: number) {
+  const bytes = new Uint8Array(8);
+  const dv = new DataView(bytes.buffer);
+  const lo = value >>> 0;
+  const hi = Math.floor(value / 0x100000000);
+  dv.setUint32(0, lo, true);
+  dv.setUint32(4, hi, true);
+  parts.push(bytes);
+}
 
-function appendBatchLogValue(parts: Uint8Array[], value: BatchLogValue) {
+function appendF32(parts: Uint8Array[], value: number) {
+  const bytes = new Uint8Array(4);
+  const dv = new DataView(bytes.buffer);
+  dv.setFloat32(0, value, true);
+  parts.push(bytes);
+}
+
+function eventImageBytes(value: unknown): Uint8Array {
   if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return new Uint8Array(value as number[]);
+  }
+  if (typeof value === "string") {
+    try {
+      return Uint8Array.fromBase64(value);
+    } catch {
+      return textEncoder.encode(value);
+    }
+  }
+  return new Uint8Array();
+}
+
+async function computeBatchEventHash(event: {
+  ts: number;
+  type: string;
+  risk?: number;
+  metadata?: [string, string][];
+  data?: {
+    image?: unknown;
+    content_type?: unknown;
+  };
+}) {
+  const parts: Uint8Array[] = [];
+  appendU64(parts, event.ts);
+  parts.push(textEncoder.encode(event.type));
+
+  if (typeof event.risk === "number") {
+    parts.push(textEncoder.encode("risk"));
+    appendF32(parts, event.risk);
+  }
+
+  const data = event.data ?? {};
+  const image = eventImageBytes(data.image);
+  const contentType =
+    typeof data.content_type === "string" ? data.content_type : "";
+
+  for (const [key, value] of [
+    ["content_type", textEncoder.encode(contentType)],
+    ["image", image],
+  ] as const) {
+    parts.push(textEncoder.encode(key));
     parts.push(value);
-    return;
   }
 
-  if (typeof value === "number") {
-    const bytes = new Uint8Array(8);
-    const dv = new DataView(bytes.buffer);
-    const lo = value >>> 0;
-    const hi = Math.floor(value / 0x100000000);
-    dv.setUint32(0, lo, true);
-    dv.setUint32(4, hi, true);
-    parts.push(bytes);
-    return;
+  const metadata = [...(event.metadata ?? [])].sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+    leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue),
+  );
+  for (const [key, value] of metadata) {
+    parts.push(textEncoder.encode("metadata"));
+    parts.push(textEncoder.encode(key));
+    parts.push(textEncoder.encode(value));
   }
 
-  if (typeof value === "boolean") {
-    parts.push(new Uint8Array([Number(value)]));
-    return;
+  const totalLen = parts.reduce((sum, part) => sum + part.length, 0);
+  const buf = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const part of parts) {
+    buf.set(part, offset);
+    offset += part.length;
   }
 
-  parts.push(new TextEncoder().encode(value));
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", buf));
 }
 
 /**
  * Verify the hash chain for a batch.
  *
- * Every item advances the chain (including missed captures):
- *   new_state = sha256(current_state || sha256(ts_le[8] || type_utf8 || data_key || data_value || ...))
+ * Every item advances the chain:
+ *   new_state = sha256(current_state || sha256(core_compute_event_hash_payload))
  *
  * If the final state matches end_chain_hash the batch is verified.
  * Returns 'unknown' when the server has no state tracking (both hashes are zeros).
@@ -270,13 +329,18 @@ export async function verifyBatch(
   events: {
     ts: number;
     type: string;
-    data: Record<string, BatchLogValue>;
+    risk?: number;
+    metadata?: [string, string][];
+    data?: {
+      image?: unknown;
+      content_type?: unknown;
+    };
   }[],
   startChainHash: string,
   endChainHash: string,
 ): Promise<BatchVerification> {
   if (startChainHash === ZEROS_HEX && endChainHash === ZEROS_HEX)
-    return "failed";
+    return "unknown";
 
   const sortedEvents = [...events].sort((a, b) => a.ts - b.ts);
 
@@ -286,42 +350,9 @@ export async function verifyBatch(
     startBytes[i] = parseInt(startChainHash.slice(i * 2, i * 2 + 2), 16);
   }
 
-  const enc = new TextEncoder();
-
   let state: Uint8Array = startBytes;
   for (const event of sortedEvents) {
-    // Replicate BatchItem::sha256():
-    //   ts_le[8] || type_utf8 || data_key || data_value ...
-    const tsBytes = new Uint8Array(8);
-    const dv = new DataView(tsBytes.buffer);
-    const lo = event.ts >>> 0;
-    const hi = Math.floor(event.ts / 0x100000000);
-    dv.setUint32(0, lo, true);
-    dv.setUint32(4, hi, true);
-
-    const typeBytes = enc.encode(event.type);
-    const dataParts: Uint8Array[] = [];
-    for (const [key, value] of Object.entries(event.data).sort(([a], [b]) =>
-      a.localeCompare(b),
-    )) {
-      dataParts.push(enc.encode(key));
-      appendBatchLogValue(dataParts, value);
-    }
-
-    const totalLen =
-      tsBytes.length +
-      typeBytes.length +
-      dataParts.reduce((s, p) => s + p.length, 0);
-    const buf = new Uint8Array(totalLen);
-    let off = 0;
-    for (const part of [tsBytes, typeBytes, ...dataParts]) {
-      buf.set(part, off);
-      off += part.length;
-    }
-
-    const contentHash = new Uint8Array(
-      await crypto.subtle.digest("SHA-256", buf),
-    );
+    const contentHash = await computeBatchEventHash(event);
     state = await computeNewState(state, contentHash);
   }
 

--- a/web/src/crypto.ts
+++ b/web/src/crypto.ts
@@ -230,155 +230,31 @@ const ZEROS_HEX = "0".repeat(64);
 
 export type BatchVerification = "verified" | "failed" | "unknown";
 
-function appendU64(parts: Uint8Array[], value: number) {
-  const bytes = new Uint8Array(8);
-  const dv = new DataView(bytes.buffer);
-  const lo = value >>> 0;
-  const hi = Math.floor(value / 0x100000000);
-  dv.setUint32(0, lo, true);
-  dv.setUint32(4, hi, true);
-  parts.push(bytes);
-}
-
-function appendF32(parts: Uint8Array[], value: number) {
-  const bytes = new Uint8Array(4);
-  const dv = new DataView(bytes.buffer);
-  dv.setFloat32(0, value, true);
-  parts.push(bytes);
-}
-
-function eventImageBytes(value: unknown): Uint8Array {
-  if (value instanceof Uint8Array) {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return new Uint8Array(value as number[]);
-  }
-  if (typeof value === "string") {
-    try {
-      return Uint8Array.fromBase64(value);
-    } catch {
-      return textEncoder.encode(value);
-    }
-  }
-  return new Uint8Array();
-}
-
-async function computeBatchEventHash(event: {
-  ts: number;
-  type: string;
-  risk?: number;
-  data?: Record<string, unknown>;
-}) {
-  const parts: Uint8Array[] = [];
-  appendU64(parts, event.ts);
-  parts.push(textEncoder.encode(event.type));
-
-  if (typeof event.risk === "number") {
-    parts.push(textEncoder.encode("risk"));
-    appendF32(parts, event.risk);
-  }
-
-  const data = event.data ?? {};
-  const image = eventImageBytes(data.image);
-  const contentType =
-    typeof data.content_type === "string" ? data.content_type : "";
-
-  if (contentType) {
-    parts.push(textEncoder.encode("content_type"));
-    parts.push(textEncoder.encode(contentType));
-  }
-  if (image.length > 0) {
-    parts.push(textEncoder.encode("image"));
-    parts.push(image);
-  }
-
-  const fieldEntries = Object.entries(data)
-    .filter(([key]) => key !== "content_type" && key !== "image")
-    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
-  for (const [key, value] of fieldEntries) {
-    parts.push(textEncoder.encode(key));
-    appendJsonValue(parts, value);
-  }
-
-  const totalLen = parts.reduce((sum, part) => sum + part.length, 0);
-  const buf = new Uint8Array(totalLen);
-  let offset = 0;
-  for (const part of parts) {
-    buf.set(part, offset);
-    offset += part.length;
-  }
-
-  return new Uint8Array(await crypto.subtle.digest("SHA-256", buf));
-}
-
-function appendJsonValue(parts: Uint8Array[], value: unknown) {
-  if (value === null || value === undefined) {
-    parts.push(textEncoder.encode("n"));
-    return;
-  }
-  if (typeof value === "boolean") {
-    parts.push(textEncoder.encode("b"));
-    parts.push(Uint8Array.of(value ? 1 : 0));
-    return;
-  }
-  if (typeof value === "number") {
-    parts.push(textEncoder.encode("#"));
-    parts.push(textEncoder.encode(JSON.stringify(value)));
-    return;
-  }
-  if (typeof value === "string") {
-    parts.push(textEncoder.encode("s"));
-    parts.push(textEncoder.encode(value));
-    return;
-  }
-  if (Array.isArray(value)) {
-    parts.push(textEncoder.encode("["));
-    for (const item of value) {
-      appendJsonValue(parts, item);
-    }
-    parts.push(textEncoder.encode("]"));
-    return;
-  }
-  if (typeof value === "object") {
-    parts.push(textEncoder.encode("{"));
-    const entries = Object.entries(value as Record<string, unknown>).sort(
-      ([leftKey], [rightKey]) => leftKey.localeCompare(rightKey),
-    );
-    for (const [key, item] of entries) {
-      parts.push(textEncoder.encode(key));
-      appendJsonValue(parts, item);
-    }
-    parts.push(textEncoder.encode("}"));
-    return;
-  }
-
-  parts.push(textEncoder.encode("n"));
+async function sha256Bytes(
+  value: ArrayBufferLike | ArrayBufferView,
+): Promise<Uint8Array> {
+  const normalized = toUint8Array(value);
+  const input = new Uint8Array(normalized.byteLength);
+  input.set(normalized);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", input));
 }
 
 /**
  * Verify the hash chain for a batch.
  *
  * Every item advances the chain:
- *   new_state = sha256(current_state || sha256(core_compute_event_hash_payload))
+ *   new_state = sha256(current_state || sha256(raw_event_msgpack_bytes))
  *
  * If the final state matches end_chain_hash the batch is verified.
  * Returns 'unknown' when the server has no state tracking (both hashes are zeros).
  */
 export async function verifyBatch(
-  events: {
-    ts: number;
-    type: string;
-    risk?: number;
-    data?: Record<string, unknown>;
-  }[],
+  events: Array<ArrayBufferLike | ArrayBufferView>,
   startChainHash: string,
   endChainHash: string,
 ): Promise<BatchVerification> {
   if (startChainHash === ZEROS_HEX && endChainHash === ZEROS_HEX)
     return "unknown";
-
-  const sortedEvents = [...events].sort((a, b) => a.ts - b.ts);
 
   // Convert startChainHash hex to bytes
   const startBytes = new Uint8Array(32);
@@ -387,8 +263,8 @@ export async function verifyBatch(
   }
 
   let state: Uint8Array = startBytes;
-  for (const event of sortedEvents) {
-    const contentHash = await computeBatchEventHash(event);
+  for (const event of events) {
+    const contentHash = await sha256Bytes(event);
     state = await computeNewState(state, contentHash);
   }
 

--- a/web/src/pages/Logs/index.tsx
+++ b/web/src/pages/Logs/index.tsx
@@ -119,17 +119,15 @@ async function decryptAndFlattenBatch(
   const decrypted = await decryptBatch(batchKey, raw);
   const decompressed = await decompressGzip(decrypted);
   const decoded = decode(decompressed) as unknown;
-  const record =
-    decoded && typeof decoded === "object"
-      ? (decoded as Record<string, unknown>)
-      : {};
-  const events = Array.isArray(record.events)
-    ? (record.events as Record<string, unknown>[])
-    : Array.isArray(record.items)
-      ? (record.items as Record<string, unknown>[])
-      : [];
+  const eventBytes = Array.isArray(decoded) ? decoded : [];
 
-  return events.map((event, index) => {
+  return eventBytes.map((encodedEvent, index) => {
+    const rawEvent = toUint8Array(encodedEvent);
+    if (!rawEvent) {
+      throw new Error(`Batch event ${index} is not a byte array`);
+    }
+
+    const event = decode(rawEvent) as Record<string, unknown>;
     const data =
       event.data && typeof event.data === "object"
         ? (event.data as Record<string, unknown>)
@@ -139,12 +137,7 @@ async function decryptAndFlattenBatch(
 
     return {
       id: typeof event.id === "string" ? event.id : `${batch.id}:${index}`,
-      taken_at:
-        typeof event.ts === "number"
-          ? event.ts
-          : typeof event.taken_at === "number"
-            ? event.taken_at
-            : batch.end_time,
+      taken_at: typeof event.ts === "number" ? event.ts : batch.end_time,
       device_id: batch.device_id,
       kind: typeof event.type === "string" ? event.type : "unknown",
       image,

--- a/web/src/pages/Logs/index.tsx
+++ b/web/src/pages/Logs/index.tsx
@@ -101,19 +101,6 @@ function toMetadata(data: Record<string, unknown>) {
     );
 }
 
-function toMetadataEntries(value: unknown): [string, string][] {
-  if (!Array.isArray(value)) return [];
-
-  return value.flatMap((entry) => {
-    if (!Array.isArray(entry) || entry.length < 2) return [];
-    const [key, rawValue] = entry;
-    if (typeof key !== "string") return [];
-    return [
-      [key, typeof rawValue === "string" ? rawValue : JSON.stringify(rawValue)],
-    ];
-  });
-}
-
 async function decryptAndFlattenBatch(
   batch: Batch,
   openBatchKey: (encryptedKey: string) => Promise<CryptoKey>,
@@ -147,13 +134,8 @@ async function decryptAndFlattenBatch(
       event.data && typeof event.data === "object"
         ? (event.data as Record<string, unknown>)
         : {};
-    const metadata =
-      "metadata" in event
-        ? toMetadataEntries(event.metadata)
-        : toMetadata(data);
-    const image =
-      toUint8Array("image" in event ? event.image : undefined) ??
-      toUint8Array(data.image);
+    const metadata = toMetadata(data);
+    const image = toUint8Array(data.image);
 
     return {
       id: typeof event.id === "string" ? event.id : `${batch.id}:${index}`,
@@ -164,12 +146,7 @@ async function decryptAndFlattenBatch(
             ? event.taken_at
             : batch.end_time,
       device_id: batch.device_id,
-      kind:
-        typeof event.type === "string"
-          ? event.type
-          : typeof event.kind === "string"
-            ? event.kind
-            : "unknown",
+      kind: typeof event.type === "string" ? event.type : "unknown",
       image,
       metadata,
       batch_status: "unknown" as const,


### PR DESCRIPTION
- Fixes #274 
- Fixes #287 

```
Virtue Linux client

Usage: virtue <COMMAND>

Commands:
  login   Log in and register this Linux device
  logout  Log out and disable monitoring on this device
  daemon  Run the background monitoring daemon
  status  Show current auth, capture, and upload status
  dev     Developer-only commands for test logs and batch uploads
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

```
Developer-only commands for test logs and batch uploads

Usage: virtue dev <COMMAND>

Commands:
  upload-log      Upload a developer log immediately
  add-log         Queue a developer log into the next encrypted batch
  add-screenshot  Capture a screenshot and queue it into the next encrypted batch
  upload-batch    Upload any queued batch items right now
  help            Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

```
$ virtue --version
virtue 0.0.2-dev-2026-04-04-05c27af
```