### PR TITLE
Log rotation

### DIFF
--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -10,6 +10,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 aes-gcm = "0.10"
 argon2 = "0.5"
 base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = "1.1"
 hex = "0.4"
 hkdf = "0.12.4"

--- a/client/core/src/audit.rs
+++ b/client/core/src/audit.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use rand_core::{OsRng, TryRngCore};
 
-use crate::model::{AuditLogItem, AuditRecord, AuditState};
+use crate::model::{AuditLogItem, AuditRecord, AuditState, StoredAuditRecord};
 
 pub fn generate_local_id() -> String {
     let mut bytes = [0_u8; 16];
@@ -12,14 +12,14 @@ pub fn generate_local_id() -> String {
     hex::encode(bytes)
 }
 
-pub fn derive_state(records: &[AuditRecord]) -> AuditState {
+pub fn derive_state(records: &[StoredAuditRecord]) -> AuditState {
     let mut by_id = HashMap::<String, AuditLogItem>::new();
     let mut order = Vec::<String>::new();
     let mut hash_uploaded = HashSet::<String>::new();
     let mut log_uploaded = HashSet::<String>::new();
 
     for record in records {
-        match record {
+        match &record.record {
             AuditRecord::Log {
                 local_id,
                 should_be_in_batch,
@@ -32,6 +32,7 @@ pub fn derive_state(records: &[AuditRecord]) -> AuditState {
                 by_id.insert(
                     local_id.clone(),
                     AuditLogItem {
+                        audit_day: record.audit_day.clone(),
                         local_id: local_id.clone(),
                         should_be_in_batch: *should_be_in_batch,
                         requires_hash_upload: *requires_hash_upload,

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -122,6 +122,12 @@ pub enum AuditRecord {
     },
 }
 
+#[derive(Debug, Clone)]
+pub struct StoredAuditRecord {
+    pub audit_day: String,
+    pub record: AuditRecord,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchUpload {
     pub start_time_ms: i64,
@@ -209,6 +215,7 @@ pub struct LoopOutcome {
 
 #[derive(Debug, Clone)]
 pub struct AuditLogItem {
+    pub audit_day: String,
     pub local_id: String,
     pub should_be_in_batch: bool,
     pub requires_hash_upload: bool,

--- a/client/core/src/service.rs
+++ b/client/core/src/service.rs
@@ -931,7 +931,7 @@ mod tests {
             .expect("save stale status");
         service
             .storage
-            .append_audit_record(&AuditRecord::Log {
+            .append_audit_log_record(&AuditRecord::Log {
                 local_id: "pending-log".to_string(),
                 should_be_in_batch: false,
                 requires_hash_upload: false,
@@ -1038,7 +1038,7 @@ mod tests {
         service.status.device_id = Some("device-1".to_string());
         service
             .storage
-            .append_audit_record(&AuditRecord::Log {
+            .append_audit_log_record(&AuditRecord::Log {
                 local_id: "pending-log".to_string(),
                 should_be_in_batch: false,
                 requires_hash_upload: false,

--- a/client/core/src/service.rs
+++ b/client/core/src/service.rs
@@ -47,7 +47,8 @@ impl<P: PlatformHooks> MonitorService<P> {
         let storage = FileStateStore::new(&config.state_dir)?;
         let auth_state = storage.load_auth_state()?;
         let device_settings = storage.load_device_settings()?;
-        let audit_state = derive_state(&storage.load_audit_records()?);
+        let audit_state =
+            derive_state(&storage.load_audit_records_at(platform.get_time_utc_ms()?)?);
 
         let mut status = storage.load_status()?.unwrap_or(ServiceStatus {
             is_authenticated: auth_state.device_credentials.is_some(),
@@ -313,23 +314,29 @@ impl<P: PlatformHooks> MonitorService<P> {
         requires_hash_upload: bool,
         payload: AuditLogPayload,
     ) -> CoreResult<AuditLogItem> {
-        let item = AuditLogItem {
-            local_id: generate_local_id(),
+        let local_id = generate_local_id();
+        let record = AuditRecord::Log {
+            local_id: local_id.clone(),
             should_be_in_batch,
             requires_hash_upload,
-            payload: payload.clone(),
+            log: payload.clone(),
         };
-        self.storage.append_audit_record(&AuditRecord::Log {
-            local_id: item.local_id.clone(),
+        let audit_day = self.storage.append_audit_log_record(&record)?;
+        Ok(AuditLogItem {
+            audit_day,
+            local_id,
             should_be_in_batch,
             requires_hash_upload,
-            log: payload,
-        })?;
-        Ok(item)
+            payload,
+        })
     }
 
     fn load_audit_state(&self) -> CoreResult<AuditState> {
-        Ok(derive_state(&self.storage.load_audit_records()?))
+        Ok(derive_state(
+            &self
+                .storage
+                .load_audit_records_at(self.platform.get_time_utc_ms()?)?,
+        ))
     }
 
     fn try_upload_hash_for_item(&mut self, item: &AuditLogItem) -> CoreResult<RetryAttemptOutcome> {
@@ -354,10 +361,12 @@ impl<P: PlatformHooks> MonitorService<P> {
             )
         }) {
             Ok(()) => {
-                self.storage
-                    .append_audit_record(&AuditRecord::HashUploaded {
+                self.storage.append_audit_record_for_day(
+                    &item.audit_day,
+                    &AuditRecord::HashUploaded {
                         local_id: item.local_id.clone(),
-                    })?;
+                    },
+                )?;
                 Ok(RetryAttemptOutcome::Uploaded)
             }
             Err(err) if err.is_not_found() => {
@@ -392,12 +401,14 @@ impl<P: PlatformHooks> MonitorService<P> {
         match self.with_device_token_retry(|api, access_token, _| api.upload_log(access_token, log))
         {
             Ok(response) => {
-                self.storage
-                    .append_audit_record(&AuditRecord::LogUploaded {
+                self.storage.append_audit_record_for_day(
+                    &item.audit_day,
+                    &AuditRecord::LogUploaded {
                         local_id: item.local_id.clone(),
                         server_id: Some(response.id),
                         batch_id: None,
-                    })?;
+                    },
+                )?;
                 Ok(RetryAttemptOutcome::Uploaded)
             }
             Err(err) if err.is_not_found() => {
@@ -449,20 +460,28 @@ impl<P: PlatformHooks> MonitorService<P> {
             .with_device_token_retry(|api, access_token, _| api.upload_batch(access_token, &batch))
         {
             Ok(response) => {
-                self.storage
-                    .append_audit_record(&AuditRecord::BatchUploaded {
+                let batch_day = items
+                    .first()
+                    .map(|item| item.audit_day.as_str())
+                    .unwrap_or("1970-01-01");
+                self.storage.append_audit_record_for_day(
+                    batch_day,
+                    &AuditRecord::BatchUploaded {
                         server_id: response.id.clone(),
-                    })?;
+                    },
+                )?;
                 for item in items {
                     if item.payload.as_batch_event().is_none() {
                         continue;
                     }
-                    self.storage
-                        .append_audit_record(&AuditRecord::LogUploaded {
+                    self.storage.append_audit_record_for_day(
+                        &item.audit_day,
+                        &AuditRecord::LogUploaded {
                             local_id: item.local_id.clone(),
                             server_id: None,
                             batch_id: Some(response.id.clone()),
-                        })?;
+                        },
+                    )?;
                 }
                 self.complete_batch_upload(now_ms);
                 Ok(())
@@ -939,6 +958,7 @@ mod tests {
         let audit_state = AuditState {
             pending_batch_uploads: (0..(MAX_BATCH_ITEMS_PER_UPLOAD + 5))
                 .map(|index| AuditLogItem {
+                    audit_day: "1970-01-01".to_string(),
                     local_id: format!("batch-{index}"),
                     should_be_in_batch: true,
                     requires_hash_upload: false,

--- a/client/core/src/storage.rs
+++ b/client/core/src/storage.rs
@@ -3,8 +3,18 @@ use std::io::Write;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, NaiveDate, Utc};
+
 use crate::error::CoreResult;
-use crate::model::{AuditRecord, AuthState, DeviceSettings, ServiceStatus};
+use crate::model::{
+    AuditLogPayload, AuditRecord, AuthState, DeviceSettings, ServiceStatus, StoredAuditRecord,
+};
+
+const LEGACY_AUDIT_LOG_NAME: &str = "audit.jsonl";
+const AUDIT_LOG_PREFIX: &str = "audit-";
+const AUDIT_LOG_SUFFIX: &str = ".jsonl";
+const COMPLETED_AUDIT_RETENTION_DAYS: i64 = 7;
+const MAX_AUDIT_RETENTION_DAYS: i64 = 30;
 
 #[derive(Debug, Clone)]
 pub struct FileStateStore {
@@ -34,46 +44,60 @@ impl FileStateStore {
         Ok(self.read_json("auth.json")?.unwrap_or_default())
     }
 
-    pub fn append_audit_record(&self, record: &AuditRecord) -> CoreResult<()> {
-        let path = self.root.join("audit.jsonl");
-        let mut file = fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)?;
-        serde_json::to_writer(&mut file, record)?;
-        writeln!(file)?;
-        file.flush()?;
-        Ok(())
+    pub fn append_audit_log_record(&self, record: &AuditRecord) -> CoreResult<String> {
+        let Some(audit_day) = audit_day_for_log_record(record) else {
+            return Err(crate::error::CoreError::InvalidState(
+                "audit log record missing timestamp",
+            ));
+        };
+        self.append_audit_record_for_day(&audit_day, record)?;
+        Ok(audit_day)
     }
 
-    pub fn load_audit_records(&self) -> CoreResult<Vec<AuditRecord>> {
-        let path = self.root.join("audit.jsonl");
-        if !path.exists() {
-            return Ok(Vec::new());
-        }
+    pub fn append_audit_record(&self, record: &AuditRecord) -> CoreResult<()> {
+        self.append_audit_log_record(record).map(|_| ())
+    }
 
-        let file = fs::File::open(path)?;
-        let reader = BufReader::new(file);
+    pub fn append_audit_record_for_day(
+        &self,
+        audit_day: &str,
+        record: &AuditRecord,
+    ) -> CoreResult<()> {
+        self.append_record_to_path(&self.audit_log_path(audit_day), record)
+    }
+
+    pub fn load_audit_records(&self) -> CoreResult<Vec<StoredAuditRecord>> {
+        self.load_audit_records_at(current_time_utc_ms()?)
+    }
+
+    pub fn load_audit_records_at(&self, now_ms: i64) -> CoreResult<Vec<StoredAuditRecord>> {
+        self.migrate_legacy_audit_log(now_ms)?;
+        self.prune_audit_logs(now_ms)?;
+
         let mut records = Vec::new();
-        for line in reader.lines() {
-            let line = line?;
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
+        for path in self.audit_log_paths()? {
+            let Some(audit_day) = audit_day_from_path(&path) else {
                 continue;
-            }
-            match serde_json::from_str(trimmed) {
-                Ok(record) => records.push(record),
-                Err(err) if err.is_eof() => break,
-                Err(err) => return Err(err.into()),
+            };
+            for record in self.read_records_from_path(&path)? {
+                records.push(StoredAuditRecord {
+                    audit_day: audit_day.clone(),
+                    record,
+                });
             }
         }
         Ok(records)
     }
 
     pub fn clear_audit_records(&self) -> CoreResult<()> {
-        let path = self.root.join("audit.jsonl");
-        if path.exists() {
-            fs::remove_file(path)?;
+        for path in self.audit_log_paths()? {
+            if path.exists() {
+                fs::remove_file(path)?;
+            }
+        }
+        let legacy_path = self.root.join(LEGACY_AUDIT_LOG_NAME);
+        if legacy_path.exists() {
+            fs::remove_file(legacy_path)?;
         }
         Ok(())
     }
@@ -114,6 +138,206 @@ impl FileStateStore {
         let bytes = fs::read(path)?;
         Ok(Some(serde_json::from_slice(&bytes)?))
     }
+
+    fn append_record_to_path(&self, path: &Path, record: &AuditRecord) -> CoreResult<()> {
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        serde_json::to_writer(&mut file, record)?;
+        writeln!(file)?;
+        file.flush()?;
+        Ok(())
+    }
+
+    fn read_records_from_path(&self, path: &Path) -> CoreResult<Vec<AuditRecord>> {
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = fs::File::open(path)?;
+        let reader = BufReader::new(file);
+        let mut records = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str(trimmed) {
+                Ok(record) => records.push(record),
+                Err(err) if err.is_eof() => break,
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(records)
+    }
+
+    fn audit_log_path(&self, audit_day: &str) -> PathBuf {
+        self.root
+            .join(format!("{AUDIT_LOG_PREFIX}{audit_day}{AUDIT_LOG_SUFFIX}"))
+    }
+
+    fn audit_log_paths(&self) -> CoreResult<Vec<PathBuf>> {
+        let mut paths = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if name.starts_with(AUDIT_LOG_PREFIX) && name.ends_with(AUDIT_LOG_SUFFIX) {
+                paths.push(path);
+            }
+        }
+        paths.sort();
+        Ok(paths)
+    }
+
+    fn migrate_legacy_audit_log(&self, now_ms: i64) -> CoreResult<()> {
+        let legacy_path = self.root.join(LEGACY_AUDIT_LOG_NAME);
+        if !legacy_path.exists() {
+            return Ok(());
+        }
+
+        let records = self.read_records_from_path(&legacy_path)?;
+        if records.is_empty() {
+            fs::remove_file(legacy_path)?;
+            return Ok(());
+        }
+
+        let fallback_day = file_modified_day(&legacy_path)
+            .or_else(|| day_key_from_ms(now_ms).ok())
+            .unwrap_or_else(|| "1970-01-01".to_string());
+
+        let mut log_days = std::collections::HashMap::<String, String>::new();
+        for record in &records {
+            if let AuditRecord::Log { local_id, log, .. } = record {
+                log_days.insert(local_id.clone(), day_key_from_payload(log)?);
+            }
+        }
+
+        let mut grouped = std::collections::BTreeMap::<String, Vec<AuditRecord>>::new();
+        for record in records {
+            let audit_day = match &record {
+                AuditRecord::Log { log, .. } => day_key_from_payload(log)?,
+                AuditRecord::HashUploaded { local_id }
+                | AuditRecord::LogUploaded { local_id, .. } => log_days
+                    .get(local_id)
+                    .cloned()
+                    .unwrap_or_else(|| fallback_day.clone()),
+                AuditRecord::BatchUploaded { .. } => fallback_day.clone(),
+            };
+            grouped.entry(audit_day).or_default().push(record);
+        }
+
+        for (audit_day, records) in grouped {
+            let path = self.audit_log_path(&audit_day);
+            for record in records {
+                self.append_record_to_path(&path, &record)?;
+            }
+        }
+
+        fs::remove_file(legacy_path)?;
+        Ok(())
+    }
+
+    fn prune_audit_logs(&self, now_ms: i64) -> CoreResult<()> {
+        let current_day = parse_day_key(&day_key_from_ms(now_ms)?)?;
+        for path in self.audit_log_paths()? {
+            let Some(audit_day) = audit_day_from_path(&path) else {
+                continue;
+            };
+            let age_days = current_day
+                .signed_duration_since(parse_day_key(&audit_day)?)
+                .num_days();
+            if age_days < 0 {
+                continue;
+            }
+            if age_days >= MAX_AUDIT_RETENTION_DAYS {
+                fs::remove_file(path)?;
+                continue;
+            }
+            if age_days < COMPLETED_AUDIT_RETENTION_DAYS {
+                continue;
+            }
+            let records = self.read_records_from_path(&path)?;
+            if audit_day_fully_uploaded(&records) {
+                fs::remove_file(path)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn current_time_utc_ms() -> CoreResult<i64> {
+    Ok(Utc::now().timestamp_millis())
+}
+
+fn audit_day_fully_uploaded(records: &[AuditRecord]) -> bool {
+    let mut log_ids = std::collections::HashSet::<&str>::new();
+    let mut uploaded_ids = std::collections::HashSet::<&str>::new();
+
+    for record in records {
+        match record {
+            AuditRecord::Log { local_id, .. } => {
+                log_ids.insert(local_id.as_str());
+            }
+            AuditRecord::LogUploaded { local_id, .. } => {
+                uploaded_ids.insert(local_id.as_str());
+            }
+            AuditRecord::HashUploaded { .. } | AuditRecord::BatchUploaded { .. } => {}
+        }
+    }
+
+    !log_ids.is_empty()
+        && log_ids
+            .iter()
+            .all(|local_id| uploaded_ids.contains(local_id))
+}
+
+fn audit_day_for_log_record(record: &AuditRecord) -> Option<String> {
+    match record {
+        AuditRecord::Log { log, .. } => day_key_from_payload(log).ok(),
+        _ => None,
+    }
+}
+
+fn day_key_from_payload(payload: &AuditLogPayload) -> CoreResult<String> {
+    let ts_ms = match payload {
+        AuditLogPayload::Direct(log) => log.ts,
+        AuditLogPayload::Batch(event) => event.event.ts,
+    };
+    day_key_from_ms(ts_ms)
+}
+
+fn day_key_from_ms(ts_ms: i64) -> CoreResult<String> {
+    let date_time = DateTime::<Utc>::from_timestamp_millis(ts_ms).ok_or(
+        crate::error::CoreError::InvalidState("invalid audit timestamp"),
+    )?;
+    Ok(date_time.format("%Y-%m-%d").to_string())
+}
+
+fn parse_day_key(value: &str) -> CoreResult<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| crate::error::CoreError::InvalidState("invalid audit day"))
+}
+
+fn audit_day_from_path(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let day = name
+        .strip_prefix(AUDIT_LOG_PREFIX)?
+        .strip_suffix(AUDIT_LOG_SUFFIX)?;
+    Some(day.to_string())
+}
+
+fn file_modified_day(path: &Path) -> Option<String> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    let modified = DateTime::<Utc>::from(modified);
+    Some(modified.format("%Y-%m-%d").to_string())
 }
 
 #[cfg(test)]
@@ -149,14 +373,95 @@ mod tests {
             ),
         )
         .expect("write audit log");
+        let expected_day = file_modified_day(&path).expect("legacy file modified day");
 
-        let records = store.load_audit_records().expect("load audit records");
+        let records = store.load_audit_records_at(0).expect("load audit records");
 
         assert_eq!(records.len(), 1);
-        match &records[0] {
+        match &records[0].record {
             AuditRecord::HashUploaded { local_id } => assert_eq!(local_id, "ok"),
             other => panic!("unexpected record: {other:?}"),
         }
+        assert_eq!(records[0].audit_day, expected_day);
+
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn load_audit_records_migrates_legacy_audit_log_by_day() {
+        let state_dir = temp_state_dir();
+        let store = FileStateStore::new(&state_dir).expect("create store");
+        let path = state_dir.join("audit.jsonl");
+        fs::write(
+            &path,
+            format!(
+                concat!(
+                    "{{\"type\":\"log\",\"local_id\":\"day-1\",\"should_be_in_batch\":false,\"log\":{{\"type\":\"direct\",\"data\":{{\"ts\":{},\"type\":\"system_event\",\"data\":{{}}}}}}}}\n",
+                    "{{\"type\":\"log_uploaded\",\"local_id\":\"day-1\",\"server_id\":\"server-1\"}}\n",
+                    "{{\"type\":\"log\",\"local_id\":\"day-2\",\"should_be_in_batch\":false,\"log\":{{\"type\":\"direct\",\"data\":{{\"ts\":{},\"type\":\"system_event\",\"data\":{{}}}}}}}}\n"
+                ),
+                86_400_000_i64,
+                172_800_000_i64
+            ),
+        )
+        .expect("write legacy audit log");
+
+        let records = store
+            .load_audit_records_at(172_800_000_i64)
+            .expect("load migrated audit records");
+
+        assert!(!path.exists());
+        assert!(state_dir.join("audit-1970-01-02.jsonl").exists());
+        assert!(state_dir.join("audit-1970-01-03.jsonl").exists());
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].audit_day, "1970-01-02");
+        assert_eq!(records[1].audit_day, "1970-01-02");
+        assert_eq!(records[2].audit_day, "1970-01-03");
+
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn load_audit_records_prunes_completed_days_after_local_retention() {
+        let state_dir = temp_state_dir();
+        let store = FileStateStore::new(&state_dir).expect("create store");
+        let path = state_dir.join("audit-1970-01-01.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"log\",\"local_id\":\"done\",\"should_be_in_batch\":false,\"log\":{\"type\":\"direct\",\"data\":{\"ts\":0,\"type\":\"system_event\",\"data\":{}}}}\n",
+                "{\"type\":\"log_uploaded\",\"local_id\":\"done\",\"server_id\":\"server-1\"}\n"
+            ),
+        )
+        .expect("write rotated audit log");
+
+        let records = store
+            .load_audit_records_at(8 * 86_400_000_i64)
+            .expect("load pruned audit records");
+
+        assert!(records.is_empty());
+        assert!(!path.exists());
+
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn load_audit_records_hard_prunes_old_unfinished_days() {
+        let state_dir = temp_state_dir();
+        let store = FileStateStore::new(&state_dir).expect("create store");
+        let path = state_dir.join("audit-1970-01-01.jsonl");
+        fs::write(
+            &path,
+            "{\"type\":\"log\",\"local_id\":\"stale\",\"should_be_in_batch\":false,\"log\":{\"type\":\"direct\",\"data\":{\"ts\":0,\"type\":\"system_event\",\"data\":{}}}}\n",
+        )
+        .expect("write rotated audit log");
+
+        let records = store
+            .load_audit_records_at(31 * 86_400_000_i64)
+            .expect("load pruned audit records");
+
+        assert!(records.is_empty());
+        assert!(!path.exists());
 
         let _ = fs::remove_dir_all(state_dir);
     }

--- a/client/core/src/storage.rs
+++ b/client/core/src/storage.rs
@@ -54,10 +54,6 @@ impl FileStateStore {
         Ok(audit_day)
     }
 
-    pub fn append_audit_record(&self, record: &AuditRecord) -> CoreResult<()> {
-        self.append_audit_log_record(record).map(|_| ())
-    }
-
     pub fn append_audit_record_for_day(
         &self,
         audit_day: &str,


### PR DESCRIPTION
Adds local log rotation. Fixes #263 

AI summary of what was done:

The audit store now rotates into UTC day files, keeps each day’s log records and later upload markers together, migrates legacy audit.jsonl on first load, deletes fully uploaded day files after 7 days, and hard-deletes any audit day once it is 30 days old to match the retention cap.