### PR TITLE
Add link to site in tray apps

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "virtue-core",
+ "zbus",
 ]
 
 [[package]]

--- a/client/linux/Cargo.toml
+++ b/client/linux/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 virtue_core = { package = "virtue-core", path = "../core" }
+zbus = "5.14.0"
 
 [package.metadata.deb]
 name = "virtue"

--- a/client/linux/src/tray.rs
+++ b/client/linux/src/tray.rs
@@ -193,7 +193,7 @@ impl ksni::Tray for VirtueTray {
 
     fn tool_tip(&self) -> ksni::ToolTip {
         ksni::ToolTip {
-            title: "Virtue".to_string(),
+            title: "Virtue - virtueinitiative.org".to_string(),
             description: self.tooltip.clone(),
             ..Default::default()
         }

--- a/client/linux/src/tray.rs
+++ b/client/linux/src/tray.rs
@@ -11,8 +11,6 @@ use crate::config::ClientPaths;
 const TOOLTIP_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const RETRY_INTERVAL: Duration = Duration::from_secs(30);
 const LOG_THROTTLE_INTERVAL: Duration = Duration::from_secs(10 * 60);
-const STATUS_NOTIFIER_WATCHER_NAME: &str = "org.kde.StatusNotifierWatcher";
-const DBUS_SERVICE_UNKNOWN_ERROR: &str = "org.freedesktop.DBus.Error.ServiceUnknown";
 
 pub struct DaemonTray {
     shutdown: Arc<AtomicBool>,
@@ -54,8 +52,7 @@ fn spawn_tray_worker(paths: ClientPaths, shutdown: Arc<AtomicBool>) -> thread::J
             match run_one_tray_session(&paths, &shutdown) {
                 Ok(()) => break,
                 Err(err) => {
-                    let message = err.to_string();
-                    let error_kind = classify_tray_error(&message);
+                    let message = err.message();
                     let should_log = last_error_message.as_deref() != Some(message.as_str())
                         || last_error_log_at.elapsed() >= LOG_THROTTLE_INTERVAL;
                     if should_log {
@@ -64,7 +61,7 @@ fn spawn_tray_worker(paths: ClientPaths, shutdown: Arc<AtomicBool>) -> thread::J
                         last_error_log_at = std::time::Instant::now();
                     }
 
-                    if matches!(error_kind, TrayErrorKind::MissingWatcher) {
+                    if matches!(err.kind(), TrayErrorKind::MissingWatcher) {
                         break;
                     }
                 }
@@ -75,12 +72,15 @@ fn spawn_tray_worker(paths: ClientPaths, shutdown: Arc<AtomicBool>) -> thread::J
     })
 }
 
-fn run_one_tray_session(paths: &ClientPaths, shutdown: &Arc<AtomicBool>) -> anyhow::Result<()> {
+fn run_one_tray_session(
+    paths: &ClientPaths,
+    shutdown: &Arc<AtomicBool>,
+) -> Result<(), TraySessionError> {
     let mut tooltip = build_tooltip(paths);
     let tray = VirtueTray {
         tooltip: tooltip.clone(),
     };
-    let handle = tray.spawn()?;
+    let handle = tray.spawn().map_err(TraySessionError::from_spawn_error)?;
 
     let mut elapsed = Duration::ZERO;
     while !shutdown.load(Ordering::SeqCst) {
@@ -102,7 +102,7 @@ fn run_one_tray_session(paths: &ClientPaths, shutdown: &Arc<AtomicBool>) -> anyh
             })
             .is_none()
         {
-            return Err(anyhow::anyhow!("tray host disconnected"));
+            return Err(TraySessionError::retryable("tray host disconnected"));
         }
 
         tooltip = next;
@@ -157,13 +157,10 @@ fn sleep_interruptible(shutdown: &Arc<AtomicBool>, duration: Duration) {
     }
 }
 
-fn classify_tray_error(message: &str) -> TrayErrorKind {
-    if message.contains(DBUS_SERVICE_UNKNOWN_ERROR)
-        && message.contains(STATUS_NOTIFIER_WATCHER_NAME)
-    {
-        TrayErrorKind::MissingWatcher
-    } else {
-        TrayErrorKind::Retryable
+fn classify_spawn_error(error: &ksni::Error) -> TrayErrorKind {
+    match error {
+        ksni::Error::Watcher(zbus::fdo::Error::ServiceUnknown(_)) => TrayErrorKind::MissingWatcher,
+        _ => TrayErrorKind::Retryable,
     }
 }
 
@@ -171,6 +168,36 @@ fn classify_tray_error(message: &str) -> TrayErrorKind {
 enum TrayErrorKind {
     MissingWatcher,
     Retryable,
+}
+
+#[derive(Debug)]
+struct TraySessionError {
+    kind: TrayErrorKind,
+    message: String,
+}
+
+impl TraySessionError {
+    fn from_spawn_error(error: ksni::Error) -> Self {
+        Self {
+            kind: classify_spawn_error(&error),
+            message: error.to_string(),
+        }
+    }
+
+    fn retryable(message: impl Into<String>) -> Self {
+        Self {
+            kind: TrayErrorKind::Retryable,
+            message: message.into(),
+        }
+    }
+
+    fn kind(&self) -> TrayErrorKind {
+        self.kind
+    }
+
+    fn message(&self) -> String {
+        self.message.clone()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -239,22 +266,22 @@ fn build_icon() -> ksni::Icon {
 
 #[cfg(test)]
 mod tests {
-    use super::{TrayErrorKind, classify_tray_error};
+    use super::{TrayErrorKind, classify_spawn_error};
 
     #[test]
     fn classifies_missing_status_notifier_watcher_as_non_retryable() {
-        let message = "failed to register to the StatusNotifierWatcher: \
-                       org.freedesktop.DBus.Error.ServiceUnknown: \
-                       The name org.kde.StatusNotifierWatcher was not provided by any .service files";
+        let error = ksni::Error::Watcher(zbus::fdo::Error::ServiceUnknown(
+            "The name org.kde.StatusNotifierWatcher was not provided by any .service files"
+                .to_string(),
+        ));
 
-        assert_eq!(classify_tray_error(message), TrayErrorKind::MissingWatcher);
+        assert_eq!(classify_spawn_error(&error), TrayErrorKind::MissingWatcher);
     }
 
     #[test]
-    fn leaves_other_tray_errors_retryable() {
-        assert_eq!(
-            classify_tray_error("failed to connect to tray host"),
-            TrayErrorKind::Retryable
-        );
+    fn leaves_other_spawn_errors_retryable() {
+        let error = ksni::Error::WontShow;
+
+        assert_eq!(classify_spawn_error(&error), TrayErrorKind::Retryable);
     }
 }

--- a/client/mac/src/main.rs
+++ b/client/mac/src/main.rs
@@ -87,7 +87,7 @@ fn run_tray(paths: ClientPaths) -> Result<()> {
     menu.append(&close_item)?;
 
     let _tray_icon = TrayIconBuilder::new()
-        .with_tooltip(format!("Virtue {BUILD_LABEL}"))
+        .with_tooltip(format!("Virtue {BUILD_LABEL} - virtueinitiative.org"))
         .with_icon(build_tray_icon()?)
         .with_menu_on_left_click(false)
         .with_menu(Box::new(menu))

--- a/client/mac/src/ui.rs
+++ b/client/mac/src/ui.rs
@@ -16,6 +16,7 @@ const LOGIN_RESPONSE_CANCEL: NSModalResponse = 0;
 const ACTION_RESPONSE_CLOSE: NSModalResponse = 1;
 const ACTION_RESPONSE_RESTART: NSModalResponse = 2;
 const ACTION_RESPONSE_LOGOUT: NSModalResponse = 3;
+const VIRTUE_WEBSITE_URL: &str = "https://virtueinitiative.org";
 
 #[derive(Debug, Clone)]
 pub struct LoginInput {
@@ -65,6 +66,11 @@ define_class!(
         #[unsafe(method(cancel:))]
         fn cancel(&self, _sender: Option<&AnyObject>) {
             self.finish_modal(LOGIN_RESPONSE_CANCEL);
+        }
+
+        #[unsafe(method(openWebsite:))]
+        fn open_website(&self, _sender: Option<&AnyObject>) {
+            let _ = open_virtue_website();
         }
     }
 
@@ -165,6 +171,11 @@ define_class!(
         fn logout(&self, _sender: Option<&AnyObject>) {
             self.finish_modal(ACTION_RESPONSE_LOGOUT);
         }
+
+        #[unsafe(method(openWebsite:))]
+        fn open_website(&self, _sender: Option<&AnyObject>) {
+            let _ = open_virtue_website();
+        }
     }
 
     unsafe impl NSObjectProtocol for ActionWindowController {}
@@ -196,14 +207,18 @@ pub fn prompt_login<F>(
 where
     F: FnMut(&LoginInput) -> std::result::Result<String, String>,
 {
-    let title = format!("Virtue login ({build_label})");
+    let title = format!("Virtue login - virtueinitiative.org ({build_label})");
     show_login_window(&title, default_email.unwrap_or_default(), attempt_login)
 }
 
 pub fn prompt_logged_in_action(
     details: &LoggedInDialogDetails<'_>,
 ) -> Result<Option<LoggedInAction>> {
-    show_action_window("Virtue", &format_status_message(details), false)
+    show_action_window(
+        "Virtue - virtueinitiative.org",
+        &format_status_message(details),
+        false,
+    )
 }
 
 pub fn prompt_permission_issue_action(
@@ -213,7 +228,11 @@ pub fn prompt_permission_issue_action(
     message.push_str(
         "\n\nScreen Recording permission appears to be missing for the Virtue background service.\n\nOpen System Settings > Privacy & Security > Screen Recording, enable Virtue, then click Restart daemon. Restart is required even if you selected Quit & Reopen earlier.",
     );
-    show_action_window("Virtue permission required", &message, true)
+    show_action_window(
+        "Virtue permission required - virtueinitiative.org",
+        &message,
+        true,
+    )
 }
 
 pub fn show_info(message: &str) -> Result<()> {
@@ -284,10 +303,18 @@ where
     let sign_in_button = button(
         mtm,
         "Sign in",
-        NSRect::new(NSPoint::new(270.0, 14.0), NSSize::new(90.0, 28.0)),
+        NSRect::new(NSPoint::new(174.0, 14.0), NSSize::new(90.0, 28.0)),
         &controller,
         sel!(submit:),
         Some("\r"),
+    );
+    let website_button = button(
+        mtm,
+        "Open website",
+        NSRect::new(NSPoint::new(270.0, 14.0), NSSize::new(90.0, 28.0)),
+        &controller,
+        sel!(openWebsite:),
+        None,
     );
     let cancel_button = button(
         mtm,
@@ -305,12 +332,14 @@ where
     content.addSubview(&password_label);
     content.addSubview(&password_field);
     content.addSubview(&sign_in_button);
+    content.addSubview(&website_button);
     content.addSubview(&cancel_button);
 
     unsafe {
         email_field.setNextKeyView(Some(&password_field));
         password_field.setNextKeyView(Some(&sign_in_button));
-        sign_in_button.setNextKeyView(Some(&cancel_button));
+        sign_in_button.setNextKeyView(Some(&website_button));
+        website_button.setNextKeyView(Some(&cancel_button));
         cancel_button.setNextKeyView(Some(&email_field));
     }
 
@@ -372,15 +401,23 @@ fn show_action_window(
     let close_button = button(
         mtm,
         "Close",
-        NSRect::new(NSPoint::new(224.0, 18.0), NSSize::new(120.0, 28.0)),
+        NSRect::new(NSPoint::new(128.0, 18.0), NSSize::new(120.0, 28.0)),
         &controller,
         sel!(closeWindow:),
         if emphasize_restart { None } else { Some("\r") },
     );
+    let website_button = button(
+        mtm,
+        "Open website",
+        NSRect::new(NSPoint::new(256.0, 18.0), NSSize::new(120.0, 28.0)),
+        &controller,
+        sel!(openWebsite:),
+        None,
+    );
     let restart_button = button(
         mtm,
         "Restart daemon",
-        NSRect::new(NSPoint::new(352.0, 18.0), NSSize::new(120.0, 28.0)),
+        NSRect::new(NSPoint::new(384.0, 18.0), NSSize::new(120.0, 28.0)),
         &controller,
         sel!(restartDaemon:),
         if emphasize_restart { Some("\r") } else { None },
@@ -388,7 +425,7 @@ fn show_action_window(
     let logout_button = button(
         mtm,
         "Logout",
-        NSRect::new(NSPoint::new(480.0, 18.0), NSSize::new(120.0, 28.0)),
+        NSRect::new(NSPoint::new(512.0, 18.0), NSSize::new(88.0, 28.0)),
         &controller,
         sel!(logout:),
         None,
@@ -396,6 +433,7 @@ fn show_action_window(
 
     content.addSubview(&message_label);
     content.addSubview(&close_button);
+    content.addSubview(&website_button);
     content.addSubview(&restart_button);
     content.addSubview(&logout_button);
 
@@ -547,6 +585,18 @@ fn format_status_message(details: &LoggedInDialogDetails<'_>) -> String {
             .filter(|value| !value.trim().is_empty())
             .unwrap_or("<none>")
     )
+}
+
+fn open_virtue_website() -> Result<()> {
+    let status = Command::new("open")
+        .arg(VIRTUE_WEBSITE_URL)
+        .status()
+        .context("failed to launch website opener")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("website opener exited with status {status}"))
+    }
 }
 
 fn appkit_thread_marker() -> Result<MainThreadMarker> {

--- a/client/windows/src/bin/virtue-auth-ui.rs
+++ b/client/windows/src/bin/virtue-auth-ui.rs
@@ -3,6 +3,9 @@
 
 use anyhow::Result;
 use i_slint_backend_winit::WinitWindowAccessor;
+use windows::Win32::UI::Shell::ShellExecuteW;
+use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+use windows::core::PCWSTR;
 use winit::dpi::PhysicalSize;
 use winit::platform::windows::{IconExtWindows, WindowExtWindows};
 use winit::window::Icon;
@@ -11,6 +14,7 @@ use virtue_windows::config::{ClientPaths, build_core_config};
 use virtue_windows::runtime_env::apply_runtime_env;
 use virtue_windows::service_log::ServiceLogger;
 use virtue_windows::session::SessionManager;
+use virtue_windows::win_text::to_wide;
 
 slint::slint! {
     import { Button, LineEdit, VerticalBox, HorizontalBox } from "std-widgets.slint";
@@ -18,7 +22,7 @@ slint::slint! {
     export component AuthWindow inherits Window {
         in property <string> build_label;
 
-        title: "Virtue " + build_label;
+        title: "Virtue - virtueinitiative.org " + build_label;
         width: 420px;
         height: 320px;
 
@@ -32,6 +36,7 @@ slint::slint! {
         callback login_request(string, string);
         callback logout_request();
         callback close_request();
+        callback open_website_request();
 
         Rectangle {
             background: #eef3f8;
@@ -89,6 +94,13 @@ slint::slint! {
                             font-size: 14px;
                         }
 
+                        Button {
+                            text: "Open virtueinitiative.org";
+                            clicked => {
+                                root.open_website_request();
+                            }
+                        }
+
                         HorizontalBox {
                             spacing: 10px;
 
@@ -122,6 +134,13 @@ slint::slint! {
                             input-type: InputType.password;
                         }
 
+                        Button {
+                            text: "Open virtueinitiative.org";
+                            clicked => {
+                                root.open_website_request();
+                            }
+                        }
+
                         HorizontalBox {
                             spacing: 10px;
 
@@ -147,6 +166,7 @@ slint::slint! {
 }
 
 const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
+const VIRTUE_WEBSITE_URL: &str = "https://virtueinitiative.org";
 
 fn main() -> Result<()> {
     let paths = ClientPaths::discover()?;
@@ -182,6 +202,10 @@ fn main() -> Result<()> {
 
     ui.on_close_request(|| {
         let _ = slint::quit_event_loop();
+    });
+
+    ui.on_open_website_request(|| {
+        let _ = open_virtue_website();
     });
 
     let login_weak = ui.as_weak();
@@ -281,4 +305,28 @@ fn configure_taskbar_icon(ui: &AuthWindow) {
         winit_window.set_taskbar_icon(Some(icon.clone()));
         winit_window.set_window_icon(Some(icon));
     });
+}
+
+fn open_virtue_website() -> Result<()> {
+    let operation = to_wide("open");
+    let target = to_wide(VIRTUE_WEBSITE_URL);
+    let result = unsafe {
+        ShellExecuteW(
+            None,
+            PCWSTR(operation.as_ptr()),
+            PCWSTR(target.as_ptr()),
+            None,
+            None,
+            SW_SHOWNORMAL,
+        )
+    };
+
+    if (result.0 as usize) <= 32 {
+        Err(anyhow::anyhow!(
+            "ShellExecuteW failed with code {}",
+            result.0 as usize
+        ))
+    } else {
+        Ok(())
+    }
 }

--- a/client/windows/src/bin/virtue-tray.rs
+++ b/client/windows/src/bin/virtue-tray.rs
@@ -89,7 +89,7 @@ impl AppState {
             ..Default::default()
         };
 
-        let tip = to_wide(&format!("Virtue {BUILD_LABEL}"));
+        let tip = to_wide(&format!("Virtue {BUILD_LABEL} - virtueinitiative.org"));
         for (idx, ch) in tip.iter().take(data.szTip.len()).enumerate() {
             data.szTip[idx] = *ch;
         }


### PR DESCRIPTION
* Fixes #171 

Also removes hard coded `org.kde.StatusNotifierWatcher` since that was breaking the tray from running at all under cinnamon.

Mac is untested but we'll get around to testing that at some point with a mac app cleanup.

Windows (added "Open virtueinitiative.org" button):
<img width="486" height="408" alt="image" src="https://github.com/user-attachments/assets/2d95a009-0843-457f-8165-164fc8ae60ab" />

Linux (added text):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0fbb237f-599f-4238-8cb2-f2d9857c9a76" />
