### PR TITLE
Fix busy loop after logout

### DIFF
--- a/client/core/src/service.rs
+++ b/client/core/src/service.rs
@@ -82,6 +82,9 @@ impl<P: PlatformHooks> MonitorService<P> {
             status,
         };
 
+        if service.device_credentials.is_none() {
+            service.clear_capture_schedule();
+        }
         if service.device_credentials.is_some() {
             let _ = service.refresh_device_settings();
         }
@@ -220,8 +223,7 @@ impl<P: PlatformHooks> MonitorService<P> {
         self.user_access_token = Some(access_token.clone());
         self.device_credentials = Some(device.clone());
         self.post_login_proof_batches_remaining = POST_LOGIN_PROOF_BATCH_COUNT;
-        self.status.last_screenshot_at_ms = None;
-        self.status.last_batch_at_ms = None;
+        self.clear_capture_schedule();
         self.status.is_authenticated = true;
         self.status.device_id = Some(device.device_id.clone());
         self.persist_auth_state()?;
@@ -268,6 +270,7 @@ impl<P: PlatformHooks> MonitorService<P> {
         self.storage.clear_audit_records()?;
         self.status.is_authenticated = false;
         self.status.device_id = None;
+        self.clear_capture_schedule();
         self.persist_state()
     }
 
@@ -611,8 +614,7 @@ impl<P: PlatformHooks> MonitorService<P> {
         self.storage.clear_audit_records()?;
         self.status.is_authenticated = false;
         self.status.device_id = None;
-        self.status.last_screenshot_at_ms = None;
-        self.status.last_batch_at_ms = None;
+        self.clear_capture_schedule();
         self.persist_state()
     }
 
@@ -627,9 +629,8 @@ impl<P: PlatformHooks> MonitorService<P> {
 
         let proof_burst_started = previous_post_login_proof_batches_remaining == 0
             && self.post_login_proof_batches_remaining > 0;
-        if proof_burst_started {
-            self.status.last_screenshot_at_ms = None;
-            self.status.last_batch_at_ms = None;
+        if self.device_credentials.is_none() || proof_burst_started {
+            self.clear_capture_schedule();
         }
         Ok(())
     }
@@ -697,6 +698,10 @@ impl<P: PlatformHooks> MonitorService<P> {
     }
 
     fn next_run_at_ms(&self, now_ms: i64) -> i64 {
+        if self.device_credentials.is_none() {
+            return now_ms + self.config.screenshot_interval.as_millis() as i64;
+        }
+
         let screenshot_due = self.status.last_screenshot_at_ms.map_or(
             now_ms + self.config.screenshot_interval.as_millis() as i64,
             |last| last + self.config.screenshot_interval.as_millis() as i64,
@@ -706,6 +711,11 @@ impl<P: PlatformHooks> MonitorService<P> {
             |last| last + self.config.batch_interval.as_millis() as i64,
         );
         screenshot_due.min(batch_due)
+    }
+
+    fn clear_capture_schedule(&mut self) {
+        self.status.last_screenshot_at_ms = None;
+        self.status.last_batch_at_ms = None;
     }
 
     fn batch_recipients(&self) -> CoreResult<Vec<BatchRecipient>> {
@@ -909,6 +919,52 @@ mod tests {
         service.complete_batch_upload(1003);
         assert_eq!(service.post_login_proof_batches_remaining, 0);
         assert_eq!(service.status.last_batch_at_ms, Some(1003));
+
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn setup_clears_stale_capture_schedule_when_logged_out() {
+        let state_dir = temp_state_dir();
+        let storage = FileStateStore::new(&state_dir).expect("create file state store");
+        storage
+            .save_status(&ServiceStatus {
+                is_authenticated: false,
+                is_running: true,
+                device_id: None,
+                last_loop_at_ms: Some(1),
+                last_screenshot_at_ms: Some(1000),
+                last_batch_at_ms: Some(2000),
+                pending_request_count: 0,
+            })
+            .expect("save stale status");
+
+        let service = MonitorService::setup(test_config(state_dir.clone()), TestPlatform)
+            .expect("setup service");
+
+        assert_eq!(service.status.last_screenshot_at_ms, None);
+        assert_eq!(service.status.last_batch_at_ms, None);
+
+        let persisted_status = storage
+            .load_status()
+            .expect("load persisted status")
+            .expect("persisted status");
+        assert_eq!(persisted_status.last_screenshot_at_ms, None);
+        assert_eq!(persisted_status.last_batch_at_ms, None);
+
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn next_run_stays_in_future_when_logged_out_with_stale_timestamps() {
+        let state_dir = temp_state_dir();
+        let mut service = build_service(state_dir.clone());
+        service.status.last_screenshot_at_ms = Some(1);
+        service.status.last_batch_at_ms = Some(1);
+
+        let next_run_at_ms = service.next_run_at_ms(10_000);
+
+        assert_eq!(next_run_at_ms, 10_000 + 300_000);
 
         let _ = fs::remove_dir_all(state_dir);
     }

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -5,7 +5,7 @@ mod tray;
 
 use std::io::{self, Write};
 use std::process::ExitCode;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -153,10 +153,10 @@ fn logout(paths: ClientPaths, yes: bool) -> Result<()> {
 fn status(paths: ClientPaths) -> Result<()> {
     let store = FileStateStore::new(&paths.state_dir)?;
     let auth = store.load_auth_state()?;
-    let status = load_service_status(&store, &auth)?;
-    let device_settings = store.load_device_settings()?;
     let mut config = build_core_config(&paths);
     config.refresh_from_runtime_file()?;
+    let status = load_service_status(&store, &auth, &config)?;
+    let device_settings = store.load_device_settings()?;
 
     println!("logged_in: {}", auth.device_credentials.is_some());
     println!("running: {}", status.is_running);
@@ -350,7 +350,11 @@ fn current_time_utc_ms() -> Result<i64> {
     i64::try_from(duration.as_millis()).context("system clock overflow")
 }
 
-fn load_service_status(store: &FileStateStore, auth: &AuthState) -> Result<ServiceStatus> {
+fn load_service_status(
+    store: &FileStateStore,
+    auth: &AuthState,
+    config: &virtue_core::Config,
+) -> Result<ServiceStatus> {
     let pending_request_count = derive_state(&store.load_audit_records()?).pending_request_count;
     let mut status = store.load_status()?.unwrap_or(ServiceStatus {
         is_authenticated: auth.device_credentials.is_some(),
@@ -364,6 +368,92 @@ fn load_service_status(store: &FileStateStore, auth: &AuthState) -> Result<Servi
         last_batch_at_ms: None,
         pending_request_count,
     });
+    status.is_running =
+        status.is_running && has_fresh_status_heartbeat(&status, config, current_time_utc_ms()?);
     status.pending_request_count = pending_request_count;
     Ok(status)
+}
+
+fn has_fresh_status_heartbeat(
+    status: &ServiceStatus,
+    config: &virtue_core::Config,
+    now_ms: i64,
+) -> bool {
+    let Some(last_loop_at_ms) = status.last_loop_at_ms else {
+        return false;
+    };
+
+    let heartbeat_window_ms = status_heartbeat_window(config).as_millis() as i64;
+    now_ms.saturating_sub(last_loop_at_ms) <= heartbeat_window_ms
+}
+
+fn status_heartbeat_window(config: &virtue_core::Config) -> Duration {
+    let base_interval = config
+        .screenshot_interval
+        .min(config.batch_interval)
+        .max(Duration::from_secs(30));
+    base_interval.checked_mul(2).unwrap_or(base_interval)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_fresh_status_heartbeat, status_heartbeat_window};
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use virtue_core::{Config, ServiceStatus};
+
+    fn test_config() -> Config {
+        Config::new(
+            "https://example.invalid",
+            "test-device",
+            "linux",
+            PathBuf::from("/tmp/virtue-status-test"),
+            None,
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+        )
+    }
+
+    fn test_status(last_loop_at_ms: Option<i64>) -> ServiceStatus {
+        ServiceStatus {
+            is_authenticated: true,
+            is_running: true,
+            device_id: Some("device-1".to_string()),
+            last_loop_at_ms,
+            last_screenshot_at_ms: None,
+            last_batch_at_ms: None,
+            pending_request_count: 0,
+        }
+    }
+
+    #[test]
+    fn status_heartbeat_window_uses_fastest_loop_interval_with_grace() {
+        let config = test_config();
+
+        assert_eq!(status_heartbeat_window(&config), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn heartbeat_is_stale_when_last_loop_is_too_old() {
+        let config = test_config();
+        let status = test_status(Some(1_000));
+
+        assert!(!has_fresh_status_heartbeat(&status, &config, 62_000));
+    }
+
+    #[test]
+    fn heartbeat_is_fresh_when_last_loop_is_recent() {
+        let config = test_config();
+        let status = test_status(Some(5_000));
+
+        assert!(has_fresh_status_heartbeat(&status, &config, 64_000));
+    }
+
+    #[test]
+    fn heartbeat_is_stale_when_status_has_never_looped() {
+        let config = test_config();
+        let status = test_status(None);
+
+        assert!(!has_fresh_status_heartbeat(&status, &config, 64_000));
+    }
 }


### PR DESCRIPTION
* Fixes #309 

When logged out it tries to send the last batch in a busy loop. This clears those events on logout. This is a fix in core.

Also found another problem in the linux client where stale status.json reports are trusted. Now "running" is only trusted if the file is written within the expected heartbeat, otherwise it is reported by the CLI as not running.
