### PR TITLE
Timezone fixes

### DIFF
--- a/client/linux/Cargo.toml
+++ b/client/linux/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0.4", features = ["clock", "serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 futures-util = "0.3"

--- a/client/linux/packaging/systemd/virtue.service
+++ b/client/linux/packaging/systemd/virtue.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Virtue Monitoring Agent
 Wants=network-online.target
-After=network-online.target graphical-session.target
+After=network-online.target graphical-session.target time-sync.target
 PartOf=graphical-session.target
 
 [Service]


### PR DESCRIPTION
This should fix the timezone bug by having virtue wait to start until the actually time is known (based on systemd). Sometimes the system has a local hardware clock (instead of utc) which messes up the time right after boot.

- Fixes #376 

This needs tested on my laptop (which is where I first saw the issue)