### PR TITLE
Added optional device name to login

### DIFF
--- a/.claude/skills/virtue-login/SKILL.md
+++ b/.claude/skills/virtue-login/SKILL.md
@@ -8,6 +8,8 @@ description: Build, install, and log in to the Virtue Initiative Linux client ag
 Builds the Linux client `.deb`, installs it with `dpkg`, points it at the local
 dev API, and logs in with the dev account. The password prompt is read from a raw
 terminal, so a pty helper (`login.py`) types it in — a plain stdin pipe will not work.
+After the password, `virtue login` also prompts for a device name; `login.py`
+answers it automatically (see step 5/6).
 
 Credentials live in `credentials.json` (gitignored), NOT in the script. The dev
 account is:
@@ -63,8 +65,9 @@ systemctl --user restart virtue.service
 
 ### 5. Ensure the credentials file exists
 
-`login.py` reads `email`/`password` from `.claude/skills/virtue-login/credentials.json`
-(gitignored). On first use, if it is missing, create it from the dev account:
+`login.py` reads `email`/`password` (and an optional `device_name`) from
+`.claude/skills/virtue-login/credentials.json` (gitignored). On first use, if it
+is missing, create it from the dev account:
 
 ```bash
 cat > .claude/skills/virtue-login/credentials.json <<'EOF'
@@ -77,6 +80,13 @@ EOF
 
 See `credentials.example.json` for the format. To point at a different file, set
 `VIRTUE_LOGIN_CONFIG=/path/to/creds.json`.
+
+`device_name` is optional:
+
+- omitted/empty — `login.py` presses Enter at the device-name prompt, registering
+  the device under the machine hostname (the default).
+- set — `login.py` passes it as `virtue login --device-name <name>`, so the device
+  registers under that exact name.
 
 ### 6. Log in
 

--- a/.claude/skills/virtue-login/credentials.example.json
+++ b/.claude/skills/virtue-login/credentials.example.json
@@ -1,4 +1,5 @@
 {
   "email": "you@example.org",
-  "password": "your-password"
+  "password": "your-password",
+  "device_name": ""
 }

--- a/.claude/skills/virtue-login/login.py
+++ b/.claude/skills/virtue-login/login.py
@@ -3,11 +3,15 @@
 
 The Linux client reads the password from the controlling terminal in raw mode
 (crossterm), so it cannot be fed over a normal stdin pipe. This allocates a pty,
-runs `virtue login --email <email>`, waits for the "Password:" prompt, and types
-the password followed by Enter.
+runs `virtue login --email <email>`, waits for the "Password:" prompt, types the
+password, then answers the "Device name [...]:" prompt that follows.
 
 Credentials are read from a JSON config file (NOT committed):
-  { "email": "...", "password": "..." }
+  { "email": "...", "password": "...", "device_name": "..." }
+
+`device_name` is optional:
+  - omitted/empty -> press Enter at the prompt to accept the default (hostname)
+  - set          -> pass it via --device-name (no interactive prompt appears)
 
 Config path resolution:
   1. $VIRTUE_LOGIN_CONFIG if set
@@ -40,26 +44,35 @@ def load_credentials():
         cfg = json.load(f)
     email = cfg.get("email")
     password = cfg.get("password")
+    device_name = (cfg.get("device_name") or "").strip()
     if not email or not password:
         sys.stderr.write(
             f"Config {CONFIG_PATH} must set both 'email' and 'password'.\n"
         )
         sys.exit(2)
-    return email, password
+    return email, password, device_name
 
 
 def main() -> int:
-    email, password = load_credentials()
+    email, password, device_name = load_credentials()
+
+    argv = ["virtue", "login", "--email", email]
+    # When a name is provided we pass it as a flag, so no device-name prompt
+    # appears. When it is absent we answer the interactive prompt with Enter
+    # (accepting the hostname default).
+    if device_name:
+        argv += ["--device-name", device_name]
 
     pid, fd = pty.fork()
     if pid == 0:
         # Child: become the virtue client with the pty as its controlling tty.
-        os.execvp("virtue", ["virtue", "login", "--email", email])
+        os.execvp("virtue", argv)
         os._exit(127)  # unreachable on success
 
-    # Parent: relay output, send the password when prompted.
+    # Parent: relay output, answer the password and device-name prompts.
     buf = b""
-    sent = False
+    sent_password = False
+    answered_device = device_name != ""  # nothing to answer when flag was passed
     while True:
         try:
             ready, _, _ = select.select([fd], [], [], 60)
@@ -75,10 +88,14 @@ def main() -> int:
             break
         os.write(sys.stdout.fileno(), data)  # mirror prompt/output to our stdout
         buf += data
-        if not sent and b"Password:" in buf:
+        if not sent_password and b"Password:" in buf:
             time.sleep(0.2)  # let raw mode engage before sending
             os.write(fd, (password + "\r").encode())
-            sent = True
+            sent_password = True
+        if sent_password and not answered_device and b"Device name [" in buf:
+            time.sleep(0.2)
+            os.write(fd, b"\r")  # accept the default (hostname)
+            answered_device = True
 
     _, status = os.waitpid(pid, 0)
     return os.waitstatus_to_exitcode(status)

--- a/client/android/app/src/main/java/org/virtueinitiative/virtue/MainActivity.kt
+++ b/client/android/app/src/main/java/org/virtueinitiative/virtue/MainActivity.kt
@@ -41,6 +41,10 @@ class MainActivity : AppCompatActivity() {
 
         populateOverrideInputs()
 
+        if (binding.deviceNameInput.text.isNullOrBlank()) {
+            binding.deviceNameInput.setText(deviceName())
+        }
+
         val initError = NativeBridge.ensureInitialized(this)
         if (initError != null) {
             setStatus("Core init failed: $initError")
@@ -77,6 +81,8 @@ class MainActivity : AppCompatActivity() {
 
         val email = binding.emailInput.text?.toString()?.trim().orEmpty()
         val password = binding.passwordInput.text?.toString().orEmpty()
+        val deviceName = binding.deviceNameInput.text?.toString()?.trim()
+            ?.ifBlank { null } ?: deviceName()
 
         if (email.isBlank() || password.isBlank()) {
             setStatus("Email and password are required")
@@ -86,12 +92,12 @@ class MainActivity : AppCompatActivity() {
         binding.loginButton.isEnabled = false
         lifecycleScope.launch {
             val error = withContext(Dispatchers.IO) {
-                var result = NativeBridge.nativeLogin(email, password, deviceName())
+                var result = NativeBridge.nativeLogin(email, password, deviceName)
                 if (result != null && result.contains("serialization error")) {
                     // Corrupted state files — wipe core-data and retry
                     android.util.Log.w("MainActivity", "Login serialization error, wiping core-data and retrying")
                     filesDir.resolve("core-data").deleteRecursively()
-                    result = NativeBridge.nativeLogin(email, password, deviceName())
+                    result = NativeBridge.nativeLogin(email, password, deviceName)
                 }
                 result
             }

--- a/client/android/app/src/main/res/layout/activity_main.xml
+++ b/client/android/app/src/main/res/layout/activity_main.xml
@@ -197,6 +197,20 @@
                         android:autofillHints="password" />
                 </com.google.android.material.textfield.TextInputLayout>
 
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    app:boxBackgroundMode="outline">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/deviceNameInput"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/device_name_hint"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="account_device_id">Device ID: %s</string>
     <string name="email_hint">Email</string>
     <string name="password_hint">Password</string>
+    <string name="device_name_hint">Device name</string>
 
     <!-- Buttons -->
     <string name="btn_sign_in">Sign In</string>

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -237,10 +237,11 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeLogin
         let password: String = env.get_string(&password)?.into();
         let device_name: String = env.get_string(&device_name)?.into();
         let core = core()?;
-        let (mut bus, state_path) = build_bus(core, &device_name)?;
+        let (mut bus, state_path) = build_bus(core)?;
         let result = bus.request::<LoginRequested, LoginResult>(LoginRequested {
             email,
             password: Redacted(password),
+            device_name: Some(device_name),
         })?;
         if !result.success {
             return Err(anyhow!(result.error.unwrap_or_else(|| {
@@ -262,7 +263,7 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeLogou
 ) -> jstring {
     let result = (|| -> Result<()> {
         let core = core()?;
-        let (mut bus, state_path) = build_bus(core, "android-device")?;
+        let (mut bus, state_path) = build_bus(core)?;
         bus.send(LogoutRequested)?;
         let state = bus.iter()?;
         store_state(&state_path, &state)?;
@@ -360,7 +361,7 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeNoteU
     let result = (|| -> Result<()> {
         let core = core()?;
         let source: String = env.get_string(&source)?.into();
-        let (mut bus, state_path) = build_bus(core, "android-device")?;
+        let (mut bus, state_path) = build_bus(core)?;
         bus.send(UserStopRequested { source })?;
         let state = bus.iter()?;
         store_state(&state_path, &state)?;
@@ -378,7 +379,7 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeGetSt
 ) -> jstring {
     let json = (|| -> Result<String> {
         let core = core()?;
-        let (mut bus, _) = build_bus(core, "android-device")?;
+        let (mut bus, _) = build_bus(core)?;
         let response = bus.request::<StatusRequest, StatusResponse>(StatusRequest)?;
         Ok(serde_json::to_string(&response.status)?)
     })()
@@ -423,8 +424,8 @@ pub fn is_interactive(env: &mut JNIEnv) -> jni::errors::Result<bool> {
     Ok(interactive)
 }
 
-fn build_bus(core: &AndroidCore, device: &str) -> Result<(EventBus, PathBuf)> {
-    let cfg = build_core_config(core, device);
+fn build_bus(core: &AndroidCore) -> Result<(EventBus, PathBuf)> {
+    let cfg = build_core_config(core);
     let modules = build_default_modules_reqwest(
         cfg,
         AndroidPlatformHooks {
@@ -437,7 +438,7 @@ fn build_bus(core: &AndroidCore, device: &str) -> Result<(EventBus, PathBuf)> {
 }
 
 fn run_daemon_loop(core: &AndroidCore) -> Result<()> {
-    let (mut bus, state_path) = build_bus(core, "android-device")?;
+    let (mut bus, state_path) = build_bus(core)?;
     bus.send(ProcessStarted)?;
     let state = bus.iter()?;
     store_state(&state_path, &state)?;
@@ -494,10 +495,13 @@ fn sleep_interruptible(stop: &AtomicBool, duration: Duration) {
     }
 }
 
-fn build_core_config(core: &AndroidCore, device_name: &str) -> Config {
+fn build_core_config(core: &AndroidCore) -> Config {
+    // The device name passed at construction is only a placeholder: device
+    // registration happens on login, which carries the user-chosen name on the
+    // `LoginRequested` event.
     Config::new(
         DEFAULT_BASE_API_URL,
-        device_name,
+        "android",
         "android",
         core.state_dir.clone(),
         Some(core.runtime_config_file.clone()),

--- a/client/core/src/controller.rs
+++ b/client/core/src/controller.rs
@@ -29,10 +29,16 @@ impl<C: EventChannel> ClientController<C> {
 
     /// Send `LoginRequested` and block until `LoginResult` is received.
     /// Returns the device ID on success.
-    pub fn login(&mut self, email: &str, password: &str) -> CoreResult<String> {
+    pub fn login(
+        &mut self,
+        email: &str,
+        password: &str,
+        device_name: Option<&str>,
+    ) -> CoreResult<String> {
         let r: LoginResult = self.channel.request(LoginRequested {
             email: email.into(),
             password: Redacted(password.into()),
+            device_name: device_name.map(|name| name.into()),
         })?;
         if r.success {
             Ok(r.device_id.unwrap_or_default())

--- a/client/core/src/module/auth.rs
+++ b/client/core/src/module/auth.rs
@@ -24,6 +24,11 @@ pub struct Logout;
 pub struct LoginRequested {
     pub email: String,
     pub password: Redacted<String>,
+    /// Optional device-name override chosen by the user at login. When `Some`
+    /// and non-empty, it takes precedence over the construction-time
+    /// `AuthModule::device_name` (hostname / OS device name).
+    #[serde(default)]
+    pub device_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,8 +96,14 @@ impl<A: ApiTransport + Send + Sync + 'static> AuthModule<A> {
         }
     }
 
-    fn handle_login_requested(&mut self, email: &str, password: &str, emitter: &Emitter) {
-        match self.do_login(email, password) {
+    fn handle_login_requested(
+        &mut self,
+        email: &str,
+        password: &str,
+        device_name: Option<&str>,
+        emitter: &Emitter,
+    ) {
+        match self.do_login(email, password, device_name) {
             Ok((credentials, settings)) => {
                 let device_id = credentials.device_id.clone();
                 let _ = emitter.send(Login {
@@ -119,11 +130,18 @@ impl<A: ApiTransport + Send + Sync + 'static> AuthModule<A> {
         &mut self,
         email: &str,
         password: &str,
+        device_name: Option<&str>,
     ) -> CoreResult<(DeviceCredentials, crate::model::DeviceSettings)> {
         let access_token = self.api.login(email, password)?;
+        // Use the user-supplied override when present and non-empty (trimmed),
+        // otherwise fall back to the construction-time device name (hostname).
+        let resolved_name = device_name
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .unwrap_or(self.device_name.as_str());
         let mut device =
             self.api
-                .register_device(&access_token, &self.device_name, &self.platform_name)?;
+                .register_device(&access_token, resolved_name, &self.platform_name)?;
         let settings = with_device_token_retry(&self.api, &mut device, |api, token| {
             api.get_device_settings(token)
         })?;
@@ -218,7 +236,12 @@ impl<A: ApiTransport + Send + Sync + 'static> Observer for AuthModule<A> {
     fn on_event(&mut self, event: &dyn Any, emitter: &Emitter) -> CoreResult<()> {
         crate::dispatch_event!(event, {
             ev: LoginRequested => {
-                self.handle_login_requested(&ev.email, &ev.password, emitter);
+                self.handle_login_requested(
+                    &ev.email,
+                    &ev.password,
+                    ev.device_name.as_deref(),
+                    emitter,
+                );
                 Ok(())
             },
             _: LogoutRequested => {
@@ -271,6 +294,7 @@ mod tests {
             LoginRequested {
                 email: "alice@example.org".into(),
                 password: Redacted("secret".into()),
+                device_name: None,
             },
         );
         assert_eq!(t.captured::<Login>().len(), 1, "expected Login event");
@@ -280,6 +304,58 @@ mod tests {
         assert!(
             results[0].device_id.is_some(),
             "login result should carry device_id"
+        );
+    }
+
+    #[test]
+    fn login_uses_device_name_override_when_present() {
+        let mut b = EventTester::builder();
+        b.capture::<LoginResult>();
+        b.add(AuthModule::new(
+            b.api(),
+            "test-device".into(),
+            "test-platform".into(),
+        ));
+        let mut t = b.build();
+        t.emit(
+            1,
+            LoginRequested {
+                email: "alice@example.org".into(),
+                password: Redacted("secret".into()),
+                device_name: Some("  My Laptop  ".into()),
+            },
+        );
+        let calls = t.api.state().register_device_calls.clone();
+        assert_eq!(calls.len(), 1, "expected one register_device call");
+        assert_eq!(
+            calls[0].name, "My Laptop",
+            "override name should be used (trimmed)"
+        );
+    }
+
+    #[test]
+    fn login_falls_back_to_construction_name_when_override_blank() {
+        let mut b = EventTester::builder();
+        b.capture::<LoginResult>();
+        b.add(AuthModule::new(
+            b.api(),
+            "test-device".into(),
+            "test-platform".into(),
+        ));
+        let mut t = b.build();
+        t.emit(
+            1,
+            LoginRequested {
+                email: "alice@example.org".into(),
+                password: Redacted("secret".into()),
+                device_name: Some("   ".into()),
+            },
+        );
+        let calls = t.api.state().register_device_calls.clone();
+        assert_eq!(calls.len(), 1, "expected one register_device call");
+        assert_eq!(
+            calls[0].name, "test-device",
+            "blank override should fall back to construction-time name"
         );
     }
 
@@ -300,6 +376,7 @@ mod tests {
             LoginRequested {
                 email: "alice@example.org".into(),
                 password: Redacted("wrong".into()),
+                device_name: None,
             },
         );
         let results = t.captured::<LoginResult>();

--- a/client/ios/app/Sources/MonitoringCoordinator.swift
+++ b/client/ios/app/Sources/MonitoringCoordinator.swift
@@ -43,6 +43,7 @@ private struct CoreLifecycleSnapshot: Decodable {
 final class MonitoringCoordinator: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
+    @Published var deviceName: String = UIDevice.current.name
     @Published var baseApiUrlOverride: String = ""
     @Published var captureIntervalOverride: String = ""
     @Published var batchWindowOverride: String = ""
@@ -140,8 +141,9 @@ final class MonitoringCoordinator: ObservableObject {
             return
         }
 
-        let deviceName = UIDevice.current.name
-        if let error = NativeBridge.login(email: email, password: password, deviceName: deviceName) {
+        let trimmedDeviceName = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedDeviceName = trimmedDeviceName.isEmpty ? UIDevice.current.name : trimmedDeviceName
+        if let error = NativeBridge.login(email: email, password: password, deviceName: resolvedDeviceName) {
             statusMessage = "Login failed: \(error)"
             return
         }

--- a/client/ios/app/Sources/VirtueIOSApp.swift
+++ b/client/ios/app/Sources/VirtueIOSApp.swift
@@ -150,6 +150,10 @@ struct ContentView: View {
                         SecureField("Password", text: $coordinator.password)
                             .textFieldStyle(.roundedBorder)
 
+                        TextField("Device name", text: $coordinator.deviceName)
+                            .autocorrectionDisabled()
+                            .textFieldStyle(.roundedBorder)
+
                         HStack(spacing: 10) {
                             Button("Sign In") {
                                 coordinator.login()

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -37,13 +37,6 @@ const CAPTURE_STATUS_PERMISSION_MISSING: c_int = 1;
 const CAPTURE_STATUS_SESSION_UNAVAILABLE: c_int = 2;
 const CAPTURE_STATUS_UNKNOWN: c_int = 3;
 
-#[derive(Clone, Debug)]
-struct StopRequest {
-    raw_reason: String,
-    detected_by: String,
-    explicit_user_stop: bool,
-}
-
 unsafe extern "C" {
     fn virtue_ios_capture_status() -> c_int;
     fn virtue_ios_capture_png_write(out_ptr: *mut *const u8, out_len: *mut usize) -> c_int;
@@ -55,7 +48,10 @@ struct IosCore {
     runtime_config_file: PathBuf,
     stop: AtomicBool,
     daemon_running: Mutex<bool>,
-    stop_request: Mutex<Option<StopRequest>>,
+    /// `Some(explicit_user_stop)` once a stop has been requested: `true` when the
+    /// user paused monitoring, `false` for a system-driven stop. `None` until a
+    /// stop is requested.
+    stop_request: Mutex<Option<bool>>,
 }
 
 #[derive(Clone)]
@@ -205,10 +201,11 @@ pub extern "C" fn virtue_ios_native_login(
         let password = c_string_or_empty(password);
         let device_name = c_string_or_empty(device_name);
         let core = core()?;
-        let (mut bus, state_path) = build_bus(core, &device_name)?;
+        let (mut bus, state_path) = build_bus(core)?;
         let result = bus.request::<LoginRequested, LoginResult>(LoginRequested {
             email,
             password: Redacted(password),
+            device_name: Some(device_name),
         })?;
         if !result.success {
             return Err(anyhow!(result.error.unwrap_or_else(|| {
@@ -227,7 +224,7 @@ pub extern "C" fn virtue_ios_native_login(
 pub extern "C" fn virtue_ios_native_logout() -> *mut c_char {
     let result = (|| -> Result<()> {
         let core = core()?;
-        let (mut bus, state_path) = build_bus(core, "ios-device")?;
+        let (mut bus, state_path) = build_bus(core)?;
         bus.send(LogoutRequested)?;
         let state = bus.iter()?;
         store_state(&state_path, &state)?;
@@ -275,7 +272,7 @@ pub extern "C" fn virtue_ios_native_get_device_id() -> *mut c_char {
 pub extern "C" fn virtue_ios_native_get_status_json() -> *mut c_char {
     let json = (|| -> Result<String> {
         let core = core()?;
-        let (mut bus, _) = build_bus(core, "ios-device")?;
+        let (mut bus, _) = build_bus(core)?;
         let response = bus.request::<StatusRequest, StatusResponse>(StatusRequest)?;
         Ok(serde_json::to_string(&response.status)?)
     })();
@@ -319,14 +316,8 @@ pub extern "C" fn virtue_ios_native_run_daemon_loop() -> *mut c_char {
 pub extern "C" fn virtue_ios_native_stop_daemon() -> *mut c_char {
     let result = (|| -> Result<()> {
         let core = core()?;
-        set_stop_request(
-            core,
-            StopRequest {
-                raw_reason: "ios_stop_request".to_string(),
-                detected_by: "ios_extension_daemon".to_string(),
-                explicit_user_stop: false,
-            },
-        )?;
+        // System-driven stop (not an explicit user pause).
+        set_stop_request(core, false)?;
         core.stop.store(true, Ordering::SeqCst);
         Ok(())
     })();
@@ -342,14 +333,8 @@ pub extern "C" fn virtue_ios_native_pause_monitoring(source: *const c_char) -> *
             "" => "ios_pause_button".to_string(),
             value => value.to_string(),
         };
-        set_stop_request(
-            core,
-            StopRequest {
-                raw_reason: "user_pause".to_string(),
-                detected_by: "ios_extension_daemon".to_string(),
-                explicit_user_stop: true,
-            },
-        )?;
+        // Explicit user pause.
+        set_stop_request(core, true)?;
         core.stop.store(true, Ordering::SeqCst);
         Ok(())
     })();
@@ -365,7 +350,7 @@ pub extern "C" fn virtue_ios_native_request_pause_monitoring(source: *const c_ch
             "" => "ios_pause_button".to_string(),
             value => value.to_string(),
         };
-        let (mut bus, state_path) = build_bus(core, "ios-device")?;
+        let (mut bus, state_path) = build_bus(core)?;
         bus.send(UserStopRequested { source })?;
         let state = bus.iter()?;
         store_state(&state_path, &state)?;
@@ -388,7 +373,7 @@ pub unsafe extern "C" fn virtue_ios_free_string(value: *mut c_char) {
 }
 
 fn run_daemon_loop(core: &IosCore) -> Result<()> {
-    let (mut bus, state_path) = build_bus(core, "ios-device")?;
+    let (mut bus, state_path) = build_bus(core)?;
     bus.send(ProcessStarted)?;
     // Enable screenshot capture. The screenshot module only captures while it is
     // "enabled", which the lifecycle module otherwise flips on via
@@ -418,12 +403,8 @@ fn run_daemon_loop(core: &IosCore) -> Result<()> {
         sleep_interruptible(&core.stop, sleep_duration);
     }
 
-    let stop_request = take_stop_request(core)?.unwrap_or_else(|| StopRequest {
-        raw_reason: "ios_stop_request".to_string(),
-        detected_by: "ios_extension_daemon".to_string(),
-        explicit_user_stop: false,
-    });
-    let reason = if stop_request.explicit_user_stop {
+    let explicit_user_stop = take_stop_request(core)?.unwrap_or(false);
+    let reason = if explicit_user_stop {
         ProcessStoppedReason::User
     } else {
         ProcessStoppedReason::Other
@@ -443,18 +424,21 @@ fn sleep_interruptible(stop: &AtomicBool, duration: Duration) {
     }
 }
 
-fn build_bus(core: &IosCore, device: &str) -> Result<(EventBus, PathBuf)> {
-    let cfg = build_core_config(core, device);
+fn build_bus(core: &IosCore) -> Result<(EventBus, PathBuf)> {
+    let cfg = build_core_config(core);
     let modules = build_default_modules_reqwest(cfg, IosPlatformHooks)?;
     let state_path = core.state_dir.join("event_state.json");
     let bus = EventBus::new(modules, load_state(&state_path)?)?;
     Ok((bus, state_path))
 }
 
-fn build_core_config(core: &IosCore, device_name: &str) -> Config {
+fn build_core_config(core: &IosCore) -> Config {
+    // The device name passed at construction is only a placeholder: device
+    // registration happens on login, which carries the user-chosen name on the
+    // `LoginRequested` event.
     Config::new(
         DEFAULT_BASE_API_URL,
-        device_name,
+        "ios",
         "ios",
         core.state_dir.clone(),
         Some(core.runtime_config_file.clone()),
@@ -463,16 +447,16 @@ fn build_core_config(core: &IosCore, device_name: &str) -> Config {
     )
 }
 
-fn set_stop_request(core: &IosCore, request: StopRequest) -> Result<()> {
+fn set_stop_request(core: &IosCore, explicit_user_stop: bool) -> Result<()> {
     let mut guard = core
         .stop_request
         .lock()
         .map_err(|_| anyhow!("stop request lock poisoned"))?;
-    *guard = Some(request);
+    *guard = Some(explicit_user_stop);
     Ok(())
 }
 
-fn take_stop_request(core: &IosCore) -> Result<Option<StopRequest>> {
+fn take_stop_request(core: &IosCore) -> Result<Option<bool>> {
     let mut guard = core
         .stop_request
         .lock()

--- a/client/linux/src/config.rs
+++ b/client/linux/src/config.rs
@@ -48,16 +48,20 @@ impl ClientPaths {
     }
 }
 
-pub fn build_core_config(paths: &ClientPaths) -> Config {
-    let device_name = hostname::get()
+/// Default device name used at registration: the system hostname, or
+/// `"linux-device"` if it can't be resolved.
+pub fn default_device_name() -> String {
+    hostname::get()
         .ok()
         .and_then(|value| value.into_string().ok())
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "linux-device".to_string());
+        .unwrap_or_else(|| "linux-device".to_string())
+}
 
+pub fn build_core_config(paths: &ClientPaths) -> Config {
     Config::new(
         DEFAULT_BASE_API_URL,
-        device_name,
+        default_device_name(),
         "linux",
         paths.state_dir.clone(),
         Some(paths.runtime_config_file.clone()),

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -21,7 +21,7 @@ use virtue_core::{
 };
 
 use crate::capture::{CaptureBackend, LinuxPlatformHooks, detect_backend, probe_backend};
-use crate::config::{ClientPaths, build_core_config};
+use crate::config::{ClientPaths, build_core_config, default_device_name};
 
 const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
 
@@ -40,6 +40,8 @@ enum Commands {
     Login {
         #[arg(long)]
         email: Option<String>,
+        #[arg(long)]
+        device_name: Option<String>,
     },
     #[command(about = "Log out and disable monitoring on this device")]
     Logout {
@@ -143,7 +145,9 @@ async fn run() -> Result<()> {
     paths.ensure_dirs()?;
 
     match cli.command {
-        Commands::Login { email } => tokio::task::block_in_place(|| login(paths, email)),
+        Commands::Login { email, device_name } => {
+            tokio::task::block_in_place(|| login(paths, email, device_name))
+        }
         Commands::Logout { yes } => tokio::task::block_in_place(|| logout(paths, yes)),
         Commands::Daemon { command } => daemon_command(paths, command).await,
         Commands::Status { json } => status(paths, json),
@@ -161,7 +165,7 @@ async fn daemon_command(paths: ClientPaths, command: Option<DaemonCommands>) -> 
     }
 }
 
-fn login(paths: ClientPaths, email: Option<String>) -> Result<()> {
+fn login(paths: ClientPaths, email: Option<String>, device_name: Option<String>) -> Result<()> {
     let email = match email {
         Some(email) => email,
         None => {
@@ -171,10 +175,29 @@ fn login(paths: ClientPaths, email: Option<String>) -> Result<()> {
     };
     let password = prompt_password("Password: ")?;
 
+    // Resolve the device name: use the flag if given, otherwise prompt
+    // interactively with the hostname as the blank-accepts default.
+    let default_name = default_device_name();
+    let device_name = match device_name {
+        Some(name) => name,
+        None => {
+            let mut rl = rustyline::DefaultEditor::new()?;
+            let entered = rl.readline(&format!("Device name [{default_name}]: "))?;
+            let entered = entered.trim();
+            if entered.is_empty() {
+                default_name
+            } else {
+                entered.to_string()
+            }
+        }
+    };
+
     let sock = paths.state_dir.join("daemon.sock");
     let mut client =
         ClientController::connect(&sock).context("failed to connect to daemon (is it running?)")?;
-    let device_id = client.login(&email, &password).context("login failed")?;
+    let device_id = client
+        .login(&email, &password, Some(&device_name))
+        .context("login failed")?;
 
     let probe = probe_backend();
     println!("{}", probe.guidance);
@@ -699,7 +722,26 @@ mod tests {
     #[test]
     fn cli_accepts_login_command() {
         let cli = Cli::try_parse_from(["virtue", "login"]).expect("login command should parse");
-        assert!(matches!(cli.command, Commands::Login { email: None }));
+        assert!(matches!(
+            cli.command,
+            Commands::Login {
+                email: None,
+                device_name: None
+            }
+        ));
+    }
+
+    #[test]
+    fn cli_accepts_login_device_name_flag() {
+        let cli = Cli::try_parse_from(["virtue", "login", "--device-name", "My Box"])
+            .expect("login --device-name should parse");
+        assert!(matches!(
+            cli.command,
+            Commands::Login {
+                email: None,
+                device_name: Some(name)
+            } if name == "My Box"
+        ));
     }
 
     #[test]

--- a/client/mac/src/config.rs
+++ b/client/mac/src/config.rs
@@ -61,16 +61,20 @@ impl ClientPaths {
     }
 }
 
-pub fn build_core_config(paths: &ClientPaths) -> Config {
-    let device_name = hostname::get()
+/// Default device name used at registration: the system hostname, or
+/// `"mac-device"` if it can't be resolved.
+pub fn default_device_name() -> String {
+    hostname::get()
         .ok()
         .and_then(|value| value.into_string().ok())
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "mac-device".to_string());
+        .unwrap_or_else(|| "mac-device".to_string())
+}
 
+pub fn build_core_config(paths: &ClientPaths) -> Config {
     Config::new(
         DEFAULT_BASE_API_URL,
-        device_name,
+        default_device_name(),
         "macos",
         paths.state_dir.clone(),
         Some(paths.runtime_config_file.clone()),

--- a/client/mac/src/main.rs
+++ b/client/mac/src/main.rs
@@ -18,7 +18,9 @@ use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEv
 use virtue_core::{AuthState, ClientController, CoreError, ServiceStatus};
 
 use crate::capture::{has_screen_capture_access, request_screen_capture_access};
-use crate::config::{ClientPaths, ClientState, build_core_config, load_state, save_state};
+use crate::config::{
+    ClientPaths, ClientState, build_core_config, default_device_name, load_state, save_state,
+};
 use crate::runtime_env::apply_runtime_env;
 
 const BUILD_LABEL: &str = virtue_core::BUILD_LABEL;
@@ -279,7 +281,7 @@ fn run_tray(paths: ClientPaths) -> Result<()> {
                         match result {
                             Ok(()) => {
                                 if let Some(window) = main_window.as_ref() {
-                                    window.switch_to_login(&saved_email);
+                                    window.switch_to_login(&saved_email, &default_device_name());
                                 }
                             }
                             Err(err) => {
@@ -364,6 +366,7 @@ fn open_app_dialog(
 
     let app_status = collect_status(paths)?;
     let default_email = app_status.email.clone().unwrap_or_default();
+    let default_device = default_device_name();
     let email_str = app_status
         .email
         .as_deref()
@@ -375,6 +378,7 @@ fn open_app_dialog(
             build_label: BUILD_LABEL,
             mode: ui::MainWindowMode::Login {
                 default_email: &default_email,
+                default_device_name: &default_device,
             },
         }
     } else {
@@ -407,11 +411,15 @@ fn handle_main_window_event(
             *main_window = None;
             Ok(false)
         }
-        ui::MainWindowEvent::LoginSubmitted { email, password } => {
+        ui::MainWindowEvent::LoginSubmitted {
+            email,
+            password,
+            device_name,
+        } => {
             // Runs synchronously on the event-loop thread; the app intentionally
             // blocks (and no status poll spawns or is processed) until login
             // resolves, since the daemon is busy with the login network call.
-            match login(paths, &email, &password) {
+            match login(paths, &email, &password, &device_name) {
                 Ok(_) => {
                     // Do not auto-request screen-capture access here: macOS shows
                     // its prompt only once per launch, so triggering it now would
@@ -512,7 +520,7 @@ fn handle_main_window_event(
             // can spawn or be processed during the logout IPC call.
             logout(paths)?;
             if let Some(window) = main_window.as_ref() {
-                window.switch_to_login(&saved_email);
+                window.switch_to_login(&saved_email, &default_device_name());
             }
             Ok(false)
         }
@@ -531,11 +539,13 @@ fn permission_phase(has_capture_permission: bool) -> Option<ui::PermissionPhase>
     }
 }
 
-fn login(paths: &ClientPaths, email: &str, password: &str) -> Result<String> {
+fn login(paths: &ClientPaths, email: &str, password: &str, device_name: &str) -> Result<String> {
     let sock = paths.state_dir.join("daemon.sock");
     let mut client =
         ClientController::connect(&sock).context("failed to connect to daemon (is it running?)")?;
-    let device_id = client.login(email, password).context("login failed")?;
+    let device_id = client
+        .login(email, password, Some(device_name))
+        .context("login failed")?;
     save_state(
         &paths.ui_state_file,
         &ClientState {

--- a/client/mac/src/ui.rs
+++ b/client/mac/src/ui.rs
@@ -66,6 +66,7 @@ pub enum MainWindowEvent {
     LoginSubmitted {
         email: String,
         password: String,
+        device_name: String,
     },
     /// Sent from background thread when relaunch completes. `None` = success.
     RelaunchDone(Option<String>),
@@ -94,6 +95,7 @@ pub struct MainWindowDetails<'a> {
 pub enum MainWindowMode<'a> {
     Login {
         default_email: &'a str,
+        default_device_name: &'a str,
     },
     LoggedIn {
         email: &'a str,
@@ -152,6 +154,7 @@ struct MainWindowIvars {
     login_container: OnceCell<Retained<NSView>>,
     login_email_field: OnceCell<Retained<NSTextField>>,
     login_password_field: OnceCell<Retained<NSSecureTextField>>,
+    login_device_name_field: OnceCell<Retained<NSTextField>>,
     login_error_label: OnceCell<Retained<NSTextField>>,
     // Logged-in mode
     logged_in_container: OnceCell<Retained<NSView>>,
@@ -184,13 +187,25 @@ define_class!(
                 .expect("login_password_field must be set")
                 .stringValue()
                 .to_string();
+            let device_name = self
+                .ivars()
+                .login_device_name_field
+                .get()
+                .expect("login_device_name_field must be set")
+                .stringValue()
+                .to_string();
             let email = email.trim().to_string();
+            let device_name = device_name.trim().to_string();
             if email.is_empty() || password.is_empty() {
                 self.set_login_error("Email and password are required.");
                 return;
             }
             self.set_login_error("");
-            let _ = self.emit(MainWindowEvent::LoginSubmitted { email, password });
+            let _ = self.emit(MainWindowEvent::LoginSubmitted {
+                email,
+                password,
+                device_name,
+            });
         }
 
         #[unsafe(method(stopMonitoring:))]
@@ -253,6 +268,7 @@ impl MainWindowController {
         login_container: Retained<NSView>,
         login_email_field: Retained<NSTextField>,
         login_password_field: Retained<NSSecureTextField>,
+        login_device_name_field: Retained<NSTextField>,
         login_error_label: Retained<NSTextField>,
         logged_in_container: Retained<NSView>,
         message_label: Retained<NSTextField>,
@@ -277,6 +293,10 @@ impl MainWindowController {
             .login_password_field
             .set(login_password_field)
             .expect("login_password_field already set");
+        self.ivars()
+            .login_device_name_field
+            .set(login_device_name_field)
+            .expect("login_device_name_field already set");
         self.ivars()
             .login_error_label
             .set(login_error_label)
@@ -311,7 +331,7 @@ impl MainWindowController {
             .setStringValue(&NSString::from_str(msg));
     }
 
-    fn switch_to_login_mode(&self, default_email: &str) {
+    fn switch_to_login_mode(&self, default_email: &str, default_device_name: &str) {
         let ivars = self.ivars();
         ivars
             .login_error_label
@@ -328,6 +348,11 @@ impl MainWindowController {
             .get()
             .expect("login_password_field must be set")
             .setStringValue(&NSString::from_str(""));
+        ivars
+            .login_device_name_field
+            .get()
+            .expect("login_device_name_field must be set")
+            .setStringValue(&NSString::from_str(default_device_name));
         ivars
             .logged_in_container
             .get()
@@ -465,8 +490,9 @@ impl MainWindowHandle {
         self.controller.set_relaunch_button_state(title, enabled);
     }
 
-    pub fn switch_to_login(&self, default_email: &str) {
-        self.controller.switch_to_login_mode(default_email);
+    pub fn switch_to_login(&self, default_email: &str, default_device_name: &str) {
+        self.controller
+            .switch_to_login_mode(default_email, default_device_name);
     }
 }
 
@@ -474,7 +500,7 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
     let mtm = appkit_thread_marker()?;
     let controller = MainWindowController::new(mtm);
     let window_width = 700.0_f64;
-    let window_height = 290.0_f64;
+    let window_height = 360.0_f64;
     let rail_width = 160.0_f64;
     let content_x = rail_width + 24.0;
     let content_width = window_width - content_x - 20.0; // 496
@@ -510,7 +536,7 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
     );
     let logo_view = build_logo_view(
         mtm,
-        NSRect::new(NSPoint::new(28.0, 96.0), NSSize::new(104.0, 104.0)),
+        NSRect::new(NSPoint::new(28.0, 166.0), NSSize::new(104.0, 104.0)),
     )?;
 
     // -- Login container -------------------------------------------------------
@@ -525,26 +551,42 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
         mtm,
         "Sign in to your Virtue account to start monitoring.",
         0.0,
-        206.0,
+        276.0,
         content_width,
         54.0,
     );
-    let login_error_label = wrapping_label(mtm, "", 0.0, 174.0, content_width, 24.0);
-    let email_label = label(mtm, "Email", 0.0, 148.0, 120.0, 20.0);
+    let login_error_label = wrapping_label(mtm, "", 0.0, 244.0, content_width, 24.0);
+    let email_label = label(mtm, "Email", 0.0, 218.0, 120.0, 20.0);
     let login_email_field = text_input(
         mtm,
         match &details.mode {
-            MainWindowMode::Login { default_email } => default_email,
+            MainWindowMode::Login { default_email, .. } => default_email,
             _ => "",
         },
         Some("name@example.com"),
         0.0,
-        122.0,
+        192.0,
         content_width,
         24.0,
     );
-    let password_label = label(mtm, "Password", 0.0, 88.0, 120.0, 20.0);
-    let login_password_field = secure_input(mtm, Some("Password"), 0.0, 62.0, content_width, 24.0);
+    let password_label = label(mtm, "Password", 0.0, 158.0, 120.0, 20.0);
+    let login_password_field = secure_input(mtm, Some("Password"), 0.0, 132.0, content_width, 24.0);
+    let device_name_label = label(mtm, "Device name", 0.0, 98.0, 120.0, 20.0);
+    let login_device_name_field = text_input(
+        mtm,
+        match &details.mode {
+            MainWindowMode::Login {
+                default_device_name,
+                ..
+            } => default_device_name,
+            _ => "",
+        },
+        Some("This device"),
+        0.0,
+        72.0,
+        content_width,
+        24.0,
+    );
     let sign_in_button = button(
         mtm,
         "Sign In",
@@ -564,7 +606,8 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
 
     unsafe {
         login_email_field.setNextKeyView(Some(&login_password_field));
-        login_password_field.setNextKeyView(Some(&sign_in_button));
+        login_password_field.setNextKeyView(Some(&login_device_name_field));
+        login_device_name_field.setNextKeyView(Some(&sign_in_button));
         sign_in_button.setNextKeyView(Some(&login_website_button));
         login_website_button.setNextKeyView(Some(&login_email_field));
     }
@@ -575,6 +618,8 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
     login_container.addSubview(&login_email_field);
     login_container.addSubview(&password_label);
     login_container.addSubview(&login_password_field);
+    login_container.addSubview(&device_name_label);
+    login_container.addSubview(&login_device_name_field);
     login_container.addSubview(&sign_in_button);
     login_container.addSubview(&login_website_button);
 
@@ -586,8 +631,8 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
             NSSize::new(window_width - content_x, window_height),
         ),
     );
-    let message_label = wrapping_label(mtm, "", 0.0, 156.0, content_width, 74.0);
-    let permission_label = wrapping_label(mtm, "", 0.0, 108.0, content_width, 36.0);
+    let message_label = wrapping_label(mtm, "", 0.0, 226.0, content_width, 74.0);
+    let permission_label = wrapping_label(mtm, "", 0.0, 178.0, content_width, 36.0);
     let status_button = button(
         mtm,
         "Status",
@@ -624,7 +669,7 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
     let request_permissions_button = button(
         mtm,
         "Request Permissions",
-        NSRect::new(NSPoint::new(0.0, 64.0), NSSize::new(170.0, 28.0)),
+        NSRect::new(NSPoint::new(0.0, 134.0), NSSize::new(170.0, 28.0)),
         &controller,
         sel!(requestPermissions:),
         None,
@@ -632,7 +677,7 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
     let relaunch_button = button(
         mtm,
         "Relaunch to Accept Permissions",
-        NSRect::new(NSPoint::new(0.0, 64.0), NSSize::new(240.0, 28.0)),
+        NSRect::new(NSPoint::new(0.0, 134.0), NSSize::new(240.0, 28.0)),
         &controller,
         sel!(relaunchToAcceptPermissions:),
         None,
@@ -664,6 +709,7 @@ pub fn show_main_window(details: &MainWindowDetails<'_>) -> Result<MainWindowHan
         login_container.clone(),
         login_email_field.clone(),
         login_password_field.clone(),
+        login_device_name_field.clone(),
         login_error_label.clone(),
         logged_in_container.clone(),
         message_label.clone(),

--- a/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
+++ b/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
@@ -14,6 +14,7 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     private string _accountEmail = string.Empty;
     private string _emailInput = string.Empty;
     private string _passwordInput = string.Empty;
+    private string _deviceNameInput = Environment.MachineName;
     private string _statusText = "Starting Virtue...";
     private string _monitorState = "stopped";
     private string? _monitorError;
@@ -108,6 +109,12 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     {
         get => _passwordInput;
         set => SetProperty(ref _passwordInput, value);
+    }
+
+    public string DeviceNameInput
+    {
+        get => _deviceNameInput;
+        set => SetProperty(ref _deviceNameInput, value);
     }
 
     public string StatusText
@@ -244,10 +251,14 @@ public sealed class SessionViewModel : INotifyPropertyChanged
             return;
         }
 
+        var deviceName = string.IsNullOrWhiteSpace(DeviceNameInput)
+            ? Environment.MachineName
+            : DeviceNameInput.Trim();
+
         await RunBusyAsync(async () =>
         {
             StatusText = "Signing in...";
-            _interopClient.Login(EmailInput.Trim(), PasswordInput, Environment.MachineName);
+            _interopClient.Login(EmailInput.Trim(), PasswordInput, deviceName);
             PasswordInput = string.Empty;
             await RefreshInternalAsync();
         });

--- a/client/windows/Virtue.WindowsApp/MainWindow.xaml.cs
+++ b/client/windows/Virtue.WindowsApp/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ public sealed partial class MainWindow : Window
     private readonly StackPanel _signedInActionsPanel;
     private readonly TextBox _emailTextBox;
     private readonly PasswordBox _passwordBox;
+    private readonly TextBox _deviceNameTextBox;
     private bool _allowClose;
 
     public MainWindow(SessionViewModel viewModel)
@@ -42,6 +43,7 @@ public sealed partial class MainWindow : Window
         _accountSummaryTextBlock = new TextBlock();
         _emailTextBox = new TextBox();
         _passwordBox = new PasswordBox();
+        _deviceNameTextBox = new TextBox();
         _loginPanel = new StackPanel();
         _accountActionsPanel = new StackPanel();
         _signedInActionsPanel = new StackPanel();
@@ -89,6 +91,10 @@ public sealed partial class MainWindow : Window
         _passwordBox.PlaceholderText = "Password";
         _passwordBox.PasswordRevealMode = PasswordRevealMode.Hidden;
         _passwordBox.PasswordChanged += PasswordBox_OnPasswordChanged;
+
+        _deviceNameTextBox.PlaceholderText = "Device name";
+        _deviceNameTextBox.Text = ViewModel.DeviceNameInput;
+        _deviceNameTextBox.TextChanged += (_, _) => ViewModel.DeviceNameInput = _deviceNameTextBox.Text;
 
         var root = new Grid
         {
@@ -207,6 +213,7 @@ public sealed partial class MainWindow : Window
         _loginPanel.Margin = new Thickness(0, 12, 0, 0);
         _loginPanel.Children.Add(_emailTextBox);
         _loginPanel.Children.Add(_passwordBox);
+        _loginPanel.Children.Add(_deviceNameTextBox);
 
         var signInButton = CreatePrimaryButton("Sign In");
         signInButton.Click += SignInButton_OnClick;
@@ -444,6 +451,11 @@ public sealed partial class MainWindow : Window
         if (_passwordBox.Password != ViewModel.PasswordInput)
         {
             _passwordBox.Password = ViewModel.PasswordInput;
+        }
+
+        if (_deviceNameTextBox.Text != ViewModel.DeviceNameInput)
+        {
+            _deviceNameTextBox.Text = ViewModel.DeviceNameInput;
         }
     }
 

--- a/client/windows/src/config.rs
+++ b/client/windows/src/config.rs
@@ -65,16 +65,20 @@ impl ClientPaths {
     }
 }
 
-pub fn build_core_config(paths: &ClientPaths) -> Config {
-    let device_name = hostname::get()
+/// Default device name used at registration: the system hostname, or
+/// `"windows-device"` if it can't be resolved.
+pub fn default_device_name() -> String {
+    hostname::get()
         .ok()
         .and_then(|value| value.into_string().ok())
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "windows-device".to_string());
+        .unwrap_or_else(|| "windows-device".to_string())
+}
 
+pub fn build_core_config(paths: &ClientPaths) -> Config {
     Config::new(
         DEFAULT_BASE_API_URL,
-        device_name,
+        default_device_name(),
         "windows",
         paths.state_dir.clone(),
         Some(paths.runtime_config_file.clone()),

--- a/client/windows/src/ffi.rs
+++ b/client/windows/src/ffi.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{
-    ClientPaths, ResolvedRuntimeConfig, RuntimeConfigOverrides, load_runtime_overrides,
-    resolved_runtime_config, save_runtime_overrides,
+    ClientPaths, ResolvedRuntimeConfig, RuntimeConfigOverrides, default_device_name,
+    load_runtime_overrides, resolved_runtime_config, save_runtime_overrides,
 };
 use crate::resident_monitor::{self, MonitorStatusSnapshot};
 use crate::session::{SessionManager, SessionStatus};
@@ -198,7 +198,7 @@ pub extern "C" fn virtue_windows_login(request_json: *const c_char) -> *mut c_ch
         let device_name = request
             .device_name
             .filter(|value| !value.trim().is_empty())
-            .unwrap_or_else(|| "windows-device".to_string());
+            .unwrap_or_else(default_device_name);
 
         let manager = with_session_manager()?;
         manager.login_blocking(&request.email, &request.password, &device_name)?;

--- a/client/windows/src/resident_monitor.rs
+++ b/client/windows/src/resident_monitor.rs
@@ -59,6 +59,7 @@ enum MonitorCommand {
     AppLogin {
         email: String,
         password: String,
+        device_name: String,
         response: mpsc::SyncSender<virtue_core::CoreResult<String>>,
     },
     AppLogout {
@@ -215,7 +216,7 @@ pub fn note_login_state(logged_in: bool) {
     });
 }
 
-pub fn app_login(email: &str, password: &str) -> Result<String> {
+pub fn app_login(email: &str, password: &str, device_name: &str) -> Result<String> {
     let (tx, rx) = mpsc::sync_channel(1);
     {
         let state = controller().state.lock().expect("monitor controller lock");
@@ -224,6 +225,7 @@ pub fn app_login(email: &str, password: &str) -> Result<String> {
                 let _ = worker.command_tx.send(MonitorCommand::AppLogin {
                     email: email.to_string(),
                     password: password.to_string(),
+                    device_name: device_name.to_string(),
                     response: tx,
                 });
             }
@@ -393,11 +395,13 @@ fn handle_command(bus: &mut EventBus, state_path: &Path, command: MonitorCommand
         MonitorCommand::AppLogin {
             email,
             password,
+            device_name,
             response,
         } => {
             let request_result = bus.request::<LoginRequested, LoginResult>(LoginRequested {
                 email,
                 password: Redacted(password),
+                device_name: Some(device_name),
             });
             let _ = store_state(state_path, &bus.iter()?);
             let result = request_result.and_then(|r| {

--- a/client/windows/src/session.rs
+++ b/client/windows/src/session.rs
@@ -33,13 +33,9 @@ impl SessionManager {
         })
     }
 
-    pub fn login_blocking(
-        &self,
-        email: &str,
-        password: &str,
-        _device_name: &str,
-    ) -> Result<String> {
-        let device_id = resident_monitor::app_login(email, password).context("login failed")?;
+    pub fn login_blocking(&self, email: &str, password: &str, device_name: &str) -> Result<String> {
+        let device_id =
+            resident_monitor::app_login(email, password, device_name).context("login failed")?;
 
         save_state(
             &self.paths.ui_state_file,


### PR DESCRIPTION
Tested that device name input exists, defaults to hostname, and is uploaded on
- [x] Linux
- [x] Mac
- [x] Windows
- [x] iOS
- [x] Android

```
> virtue login
Email: test1@virtueinitiative.org
Password: **************************
Device name [deepblue]: deepblue 3
X11 capture probe succeeded.
Logged in. Device id: e538033f-c8a9-43c2-a609-1a841bae9705
```

- Fixes #407 
- Fixes #408 
- Fixes #409 
- Fixes #410 
- Fixes #411