### PR TITLE
Improve detecting inactivity

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -4556,6 +4556,8 @@ dependencies = [
  "image",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "serde",
  "serde_json",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,3 +6,56 @@ members = [
   "windows",
 ]
 resolver = "2"
+
+# Optimize heavy dependencies even in debug builds. The workspace crates stay at
+# the dev profile's opt-level 0 (fast incremental rebuilds + good debugging); only
+# these compute-bound deps are compiled with optimizations. Their source rarely
+# changes, so the cost is paid once and reused across rebuilds. Hot code lives in
+# the decoder / numeric-kernel sub-crates rather than the umbrella crates, so we
+# name those directly.
+
+# ONNX risk classifier (tract) + its linear-algebra / ndarray backend.
+[profile.dev.package.tract-core]
+opt-level = 3
+[profile.dev.package.tract-linalg]
+opt-level = 3
+[profile.dev.package.tract-data]
+opt-level = 3
+[profile.dev.package.ndarray]
+opt-level = 3
+
+# Screenshot image decode/blur/resize + WebP encode.
+[profile.dev.package.image]
+opt-level = 3
+[profile.dev.package.png]
+opt-level = 3
+[profile.dev.package.zune-jpeg]
+opt-level = 3
+[profile.dev.package.image-webp]
+opt-level = 3
+[profile.dev.package.libwebp-sys]
+opt-level = 3
+
+# Compression: gzip batch payloads + PNG deflate.
+[profile.dev.package.miniz_oxide]
+opt-level = 3
+[profile.dev.package.fdeflate]
+opt-level = 3
+
+# Crypto: argon2 login KDF (deliberately CPU-heavy), AES-GCM, hashing, X25519.
+[profile.dev.package.argon2]
+opt-level = 3
+[profile.dev.package.blake2]
+opt-level = 3
+[profile.dev.package.sha2]
+opt-level = 3
+[profile.dev.package.aes]
+opt-level = 3
+[profile.dev.package.aes-gcm]
+opt-level = 3
+[profile.dev.package.ghash]
+opt-level = 3
+[profile.dev.package.polyval]
+opt-level = 3
+[profile.dev.package.curve25519-dalek]
+opt-level = 3

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -16,8 +16,7 @@ use virtue_core::{
     build_default_modules_reqwest, load_state, store_state, AuthState, Config, CoreError,
     CoreResult, DeviceSettings, EventBus, EventChannel, LoginRequested, LoginResult,
     LogoutRequested, Ping, PlatformHooks, ProcessStarted, ProcessStopped, ProcessStoppedReason,
-    Redacted, Screenshot, ScreenshotHooks, ScreenshotPaused, ScreenshotResumed, StatusRequest,
-    StatusResponse, UserStopRequested,
+    Redacted, Screenshot, ScreenshotHooks, StatusRequest, StatusResponse, UserStopRequested,
 };
 
 static CORE: OnceCell<AndroidCore> = OnceCell::new();
@@ -117,6 +116,19 @@ impl ScreenshotHooks for AndroidPlatformHooks {
 
     fn get_last_shutdown_time_utc_ms(&self) -> CoreResult<Option<i64>> {
         Ok(None)
+    }
+
+    fn is_locked_or_screensaver(&self) -> CoreResult<bool> {
+        let mut env = self.java_vm.attach_current_thread().map_err(|err| {
+            CoreError::CommandFailed(format!("attach_current_thread failed: {err}"))
+        })?;
+        // Screen off (non-interactive) is the mobile equivalent of a locked/asleep
+        // desktop. Fail-safe to `false` (treat as viewable → fall back to the diff gate)
+        // when the state can't be read, never silently suppress.
+        match is_interactive(&mut env) {
+            Ok(interactive) => Ok(!interactive),
+            Err(_) => Ok(false),
+        }
     }
 
     fn get_last_startup_time_utc_ms(&self) -> CoreResult<Option<i64>> {
@@ -442,23 +454,10 @@ fn run_daemon_loop(core: &AndroidCore) -> Result<()> {
     let state = bus.iter()?;
     store_state(&state_path, &state)?;
 
-    // Starts as false since we assume we're booting or something similar
-    // Otherwise it stays paused until the state is updated
-    let mut was_interactive = false;
-
     while !core.stop.load(Ordering::SeqCst) {
-        let mut env = core.java_vm.attach_current_thread()?;
-        let current_interactive = is_interactive(&mut env)?;
-
-        if current_interactive != was_interactive {
-            was_interactive = current_interactive;
-            if !current_interactive {
-                bus.send(ScreenshotPaused)?;
-            } else {
-                bus.send(ScreenshotResumed)?;
-            }
-        }
-
+        // Screen-off is now handled inside the bus via the `is_locked_or_screensaver`
+        // hook: the screenshot module records a `ScreenshotSkipped` and the upload
+        // module defers network I/O while the screen is off.
         let sleep_duration = match (|| -> Result<()> {
             bus.send(Ping)?;
             let state = bus.iter()?;

--- a/client/core/architecture.md
+++ b/client/core/architecture.md
@@ -96,6 +96,35 @@ to pattern-match typed events without boilerplate.
 | `StatusModule`              | `StatusRequest`, `PartialStatus` (from 3 sources)                                       | `StatusResponse`                                                                                   |
 | `ConfigModule`              | `Ping`                                                                                  | `ConfigChanged`                                                                                    |
 
+### Screenshot dedup (two gates)
+
+`ScreenshotModule` still captures on the normal cadence, but a frame is only _uploaded_
+when it carries new information. Two gates run on each due `Ping`:
+
+1. **Lock / screensaver gate** — checked _before_ capturing via the
+   `is_locked_or_screensaver()` platform hook. While the session is locked or a screensaver
+   is active the user cannot be viewing real content, so the capture is skipped entirely (no
+   `take_screenshot`, no classification, no `Upload`). The cadence clock still advances so we
+   re-check next interval. The hook fails safe to `false` (fall back to the diff gate) when
+   the state is unknown. Per platform: Linux uses `org.freedesktop.ScreenSaver` /
+   `org.gnome.ScreenSaver` `GetActive()` over D-Bus; macOS reads `CGSSessionScreenIsLocked`
+   and detects the screensaver process; Windows uses `SPI_GETSCREENSAVERRUNNING` plus an
+   `OpenInputDesktop` lock check.
+
+2. **Screen-change diff gate** — after capturing, the frame is reduced to a grayscale grid
+   fingerprint (`module/screenshot/fingerprint.rs`). If it has not materially changed from the
+   **last uploaded** fingerprint, the upload is suppressed. A frame counts as changed if either
+   the **mean** per-cell delta is high (a broad change, including low-contrast ones such as a
+   terminal filling with text) OR a **number of cells** changed strongly (a concentrated change
+   such as a video window — the count, not a single max, ignores a 1–2 cell clock/cursor while
+   still catching a small corner video, which is what makes the gate abuse-resistant). The grid
+   resolution is **derived from the image size** (each cell ≈ a fixed source-pixel block, aspect
+   preserved); a fixed grid would make each cell average thousands of pixels on a large/wide
+   display and dilute real changes below threshold. Anchoring to the last _uploaded_ frame — not
+   the previous capture — means slow sub-threshold drift eventually accumulates past the
+   threshold and forces a fresh upload. `last_uploaded_fingerprint` is persisted in
+   `event_state.json`.
+
 ### Request/response status flow
 
 `StatusRequest` triggers the three modules that contribute to service status
@@ -229,15 +258,19 @@ Keep the trait minimal. Platforms implement only:
 
 ```rust
 fn take_screenshot(&self) -> CoreResult<Screenshot>;
-fn get_time_utc_ms(&self) -> CoreResult<i64>;          // default: SystemTime::now()
+fn get_time_utc_ms(&self) -> CoreResult<i64>;            // default: SystemTime::now()
 fn get_last_shutdown_time_utc_ms(&self) -> CoreResult<Option<i64>>;
 fn get_last_startup_time_utc_ms(&self) -> CoreResult<Option<i64>>;
+fn is_locked_or_screensaver(&self) -> CoreResult<bool>;  // default: Ok(false)
 ```
 
 `get_time_utc_ms` has a default implementation using `SystemTime::now()` that is correct for
 all production platforms. Only `TestPlatformHooks` overrides it (delegates to `MockClock` for
-time-controlled tests). Platform crates implement only `take_screenshot`,
-`get_last_shutdown_time_utc_ms`, and `get_last_startup_time_utc_ms`.
+time-controlled tests). `is_locked_or_screensaver` defaults to `Ok(false)` (the fail-safe);
+desktop platforms override it for the screenshot dedup lock/screensaver gate, while mobile
+platforms keep the default. Platform crates implement `take_screenshot`,
+`get_last_shutdown_time_utc_ms`, `get_last_startup_time_utc_ms`, and (on desktop)
+`is_locked_or_screensaver`.
 
 Everything else belongs in `core`.
 

--- a/client/core/src/controller.rs
+++ b/client/core/src/controller.rs
@@ -7,7 +7,6 @@ use crate::module::lifecycle::{
     ComputerResumed, ComputerSuspended, ProcessStopped, UserSessionLogin, UserSessionLogout,
     UserStopRequested,
 };
-use crate::module::screenshot::{ScreenshotPaused, ScreenshotResumed};
 use crate::module::status::{StatusRequest, StatusResponse};
 
 /// High-level client for communicating with a daemon over any [`EventChannel`].
@@ -85,14 +84,6 @@ impl<C: EventChannel> ClientController<C> {
 
     pub fn note_process_stopped(&self, reason: ProcessStoppedReason) -> CoreResult<()> {
         self.channel.publish(ProcessStopped(reason))
-    }
-
-    pub fn pause_screenshots(&self) -> CoreResult<()> {
-        self.channel.publish(ScreenshotPaused)
-    }
-
-    pub fn resume_screenshots(&self) -> CoreResult<()> {
-        self.channel.publish(ScreenshotResumed)
     }
 
     /// Register a handler for events the daemon pushes unprompted.

--- a/client/core/src/ipc_bridge.rs
+++ b/client/core/src/ipc_bridge.rs
@@ -8,7 +8,6 @@ use crate::module::lifecycle::{
     ComputerResumed, ComputerSuspended, ProcessStopped, UserSessionLogin, UserSessionLogout,
     UserStopRequested,
 };
-use crate::module::screenshot::{ScreenshotPaused, ScreenshotResumed};
 use crate::module::status::{StatusRequest, StatusResponse};
 
 pub struct IpcBridge {
@@ -96,8 +95,6 @@ impl IpcBridge {
             ComputerSuspended,
             ComputerResumed,
             ProcessStopped,
-            ScreenshotPaused,
-            ScreenshotResumed,
         );
     }
 

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -31,7 +31,7 @@ pub use events::{IpcError, IpcListener, RemoteEventBus, RemoteSender};
 pub use ipc_bridge::IpcBridge;
 pub use model::{
     AlertReason, DeviceCredentials, DeviceSettings, LifecycleKind, PartialStatus,
-    ProcessStoppedReason, Redacted, UploadKind,
+    ProcessStoppedReason, Redacted, ScreenshotSkipReason, UploadKind,
 };
 pub use model::{
     AuthState, BatchUpload, EventData, LogEntry, LoginStatus, LoopOutcome, Screenshot,
@@ -46,7 +46,7 @@ pub use module::lifecycle::{
     ComputerResumed, ComputerSuspended, ProcessStarted, ProcessStopped, UserSessionLogin,
     UserSessionLogout, UserStopRequested,
 };
-pub use module::screenshot::{CaptureFailed, ScreenshotPaused, ScreenshotResumed};
+pub use module::screenshot::CaptureFailed;
 pub use module::status::{StatusRequest, StatusResponse};
 pub use module::upload::FlushBatchNow;
 pub use module::upload::Upload;

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -52,11 +52,16 @@ pub enum LifecycleKind {
     ProcessStoppedOther,
     ComputerSuspended,
     ComputerResumed,
-    ScreenshotPaused,
-    ScreenshotResumed,
     Login,
     Logout,
     ComputerBooted,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenshotSkipReason {
+    StaticScreen,        // duplicate frame (fingerprint unchanged)
+    LockedOrScreensaver, // session locked / screensaver / screen off
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -82,6 +87,9 @@ pub enum UploadKind {
     },
     LifecycleAlert {
         reason: AlertReason,
+    },
+    ScreenshotSkipped {
+        reason: ScreenshotSkipReason,
     },
     Alert {
         message: String,

--- a/client/core/src/module/lifecycle.rs
+++ b/client/core/src/module/lifecycle.rs
@@ -8,7 +8,6 @@ use crate::events::bus::{Emitter, EventBus, Observer, StateType};
 use crate::model::{AlertReason, PartialStatus};
 use crate::model::{LifecycleKind, ProcessStoppedReason, UploadKind};
 use crate::module::auth::Login;
-use crate::module::screenshot::{ScreenshotPaused, ScreenshotResumed};
 use crate::module::status::StatusRequest;
 use crate::module::upload::Upload;
 
@@ -365,7 +364,6 @@ impl Observer for LifecycleModule {
                         risk: 0.0,
                         kind: UploadKind::Lifecycle { kind: LifecycleKind::Login },
                     });
-                    let _ = emitter.send(ScreenshotResumed {});
                     self.state.last_login = now_ms;
                 }
                 Ok(())
@@ -375,7 +373,6 @@ impl Observer for LifecycleModule {
                     risk: EXTRA_HIGH_RISK,
                     kind: UploadKind::Lifecycle { kind: LifecycleKind::Logout },
                 });
-                let _ = emitter.send(ScreenshotPaused {});
                 Ok(())
             },
             _: StatusRequest => {

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -1,3 +1,4 @@
+pub mod fingerprint;
 pub mod image_pipeline;
 pub mod risk_classifier;
 
@@ -5,11 +6,10 @@ use std::any::Any;
 
 use serde::{Deserialize, Serialize};
 
-use crate::LifecycleKind;
 use crate::error::CoreResult;
 use crate::events::Ping;
 use crate::events::bus::{Emitter, EventBus, Observer, StateType};
-use crate::model::UploadKind;
+use crate::model::{ScreenshotSkipReason, UploadKind};
 use crate::module::auth::{Login, Logout};
 use crate::module::config::ConfigChanged;
 use crate::module::upload::Upload;
@@ -22,17 +22,34 @@ const MODEL_BYTES: &[u8] = include_bytes!("../../models/nsfw_small_v1.onnx");
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CaptureFailed;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScreenshotPaused;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScreenshotResumed;
-
 #[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(default)]
 pub struct ScreenshotObserverState {
     pub last_screenshot_at_ms: Option<i64>,
     pub enabled: bool,
+    /// Grayscale grid fingerprint of the last frame we actually uploaded (size scales
+    /// with the screen resolution; see [`fingerprint`]). Used to dedup: a capture whose
+    /// fingerprint hasn't materially changed from this one is suppressed. Always compared
+    /// against the last *uploaded* frame (never the previous capture) so cumulative
+    /// sub-threshold drift eventually crosses the threshold and forces a fresh upload.
+    #[serde(default, deserialize_with = "deserialize_fingerprint_lenient")]
+    pub last_uploaded_fingerprint: Option<fingerprint::Fingerprint>,
+}
+
+/// Lenient deserializer for the dedup fingerprint: any value that doesn't match the current
+/// [`fingerprint::Fingerprint`] shape — e.g. a fingerprint written by an older build whose
+/// format has since changed — decodes to `None` instead of failing the whole observer's
+/// state load. The fingerprint is only a dedup hint, so dropping it merely forces the next
+/// frame to upload and re-baseline; that is far cheaper than failing `init` and crash-looping
+/// the daemon on every start.
+fn deserialize_fingerprint_lenient<'de, D>(
+    deserializer: D,
+) -> Result<Option<fingerprint::Fingerprint>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(serde_json::from_value(value).unwrap_or(None))
 }
 
 pub struct ScreenshotModule {
@@ -79,6 +96,25 @@ impl ScreenshotModule {
             return Ok(());
         }
 
+        // Gate 1 — locked / screensaver: checked *before* capturing. While locked or
+        // screensaving the user cannot be viewing real content, so skip the capture
+        // entirely (saving capture + classification cost) and emit a lightweight
+        // `ScreenshotSkipped` log so the feed records that monitoring was active. We
+        // advance the cadence clock so pacing continues and we re-check next interval
+        // (skip events fire at most once per screenshot interval); the last-uploaded
+        // fingerprint is left untouched. Fail-safe is `false` (fall back to the diff
+        // gate), never silently suppress.
+        if self.platform.is_locked_or_screensaver()? {
+            self.state.last_screenshot_at_ms = Some(now_ms);
+            let _ = emitter.send(Upload {
+                risk: 0.0,
+                kind: UploadKind::ScreenshotSkipped {
+                    reason: ScreenshotSkipReason::LockedOrScreensaver,
+                },
+            });
+            return Ok(());
+        }
+
         let screenshot = match self.platform.take_screenshot() {
             Ok(s) => s,
             Err(_) => {
@@ -86,13 +122,38 @@ impl ScreenshotModule {
                 return Ok(());
             }
         };
+        self.state.last_screenshot_at_ms = Some(now_ms);
+
+        // Gate 2 — screen-change diff vs the last *uploaded* frame. A failed fingerprint
+        // is `None`, which falls through to the upload path (fail-safe to upload). With no
+        // prior uploaded fingerprint we always upload the first frame.
+        let fingerprint = fingerprint::fingerprint(&screenshot.bytes).ok();
+        let static_frame = match (
+            self.state.last_uploaded_fingerprint.as_ref(),
+            fingerprint.as_ref(),
+        ) {
+            (Some(prev), Some(cur)) => !fingerprint::changed(prev, cur),
+            _ => false,
+        };
+        if static_frame {
+            // Redundant frame: suppress image upload + classification, keep the anchor
+            // fingerprint, but record a lightweight `ScreenshotSkipped` log so the feed
+            // shows the screen was static rather than leaving an unexplained gap.
+            let _ = emitter.send(Upload {
+                risk: 0.0,
+                kind: UploadKind::ScreenshotSkipped {
+                    reason: ScreenshotSkipReason::StaticScreen,
+                },
+            });
+            return Ok(());
+        }
+
         let risk = self
             .classifier
             .as_ref()
             .and_then(|c| c.classify(&screenshot.bytes).ok())
             .unwrap_or(0.0);
         let processed = image_pipeline::ImagePipeline.process(screenshot)?;
-        self.state.last_screenshot_at_ms = Some(now_ms);
         let _ = emitter.send(Upload {
             risk,
             kind: UploadKind::Screenshot {
@@ -100,6 +161,9 @@ impl ScreenshotModule {
                 content_type: processed.content_type,
             },
         });
+        if let Some(fingerprint) = fingerprint {
+            self.state.last_uploaded_fingerprint = Some(fingerprint);
+        }
         Ok(())
     }
 }
@@ -128,28 +192,10 @@ impl Observer for ScreenshotModule {
             _: Login => {
                 self.state.enabled = true;
                 self.state.last_screenshot_at_ms = None;
-                emitter.send(Upload {
-                    risk: 0.0,
-                    kind: UploadKind::Lifecycle { kind: LifecycleKind::ScreenshotResumed },
-                })?;
                 Ok(())
             },
             _: Logout => {
                 self.state.enabled = false;
-                self.state.last_screenshot_at_ms = None;
-                emitter.send(Upload {
-                    risk: 0.0,
-                    kind: UploadKind::Lifecycle { kind: LifecycleKind::ScreenshotPaused },
-                })?;
-                Ok(())
-            },
-            _: ScreenshotPaused => {
-                self.state.enabled = false;
-                self.state.last_screenshot_at_ms = None;
-                Ok(())
-            },
-            _: ScreenshotResumed => {
-                self.state.enabled = true;
                 self.state.last_screenshot_at_ms = None;
                 Ok(())
             },
@@ -170,7 +216,9 @@ impl Observer for ScreenshotModule {
 mod tests {
     use super::*;
     use crate::events::Ping;
-    use crate::model::{BatchRecipient, DeviceCredentials, DeviceSettings, UploadKind};
+    use crate::model::{
+        BatchRecipient, DeviceCredentials, DeviceSettings, ScreenshotSkipReason, UploadKind,
+    };
     use crate::module::auth::{Login, Logout};
     use crate::module::upload::Upload;
     use crate::testing::EventTester;
@@ -249,6 +297,134 @@ mod tests {
             ..
         }));
         assert_eq!(t.platform.take_call_count(), 1);
+    }
+
+    #[test]
+    fn static_frame_suppressed_after_first_upload() {
+        use crate::testing::fixtures::solid_png_screenshot;
+        let mut b = EventTester::builder();
+        b.platform()
+            .set_default_screenshot(solid_png_screenshot(100));
+        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        let mut t = b.build();
+        t.emit(1, test_login());
+        t.clear_captured();
+        // First ping uploads the baseline frame.
+        t.emit(1, Ping);
+        assert_eq!(t.captured::<Upload>().len(), 1);
+        t.clear_captured();
+        // Next interval: identical screen → captured but image upload suppressed; a
+        // `ScreenshotSkipped { StaticScreen }` log is emitted instead.
+        t.emit(61, Ping);
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::ScreenshotSkipped {
+                reason: ScreenshotSkipReason::StaticScreen
+            },
+            ..
+        }));
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Screenshot { .. },
+            ..
+        }));
+        assert_eq!(t.platform.take_call_count(), 2);
+    }
+
+    #[test]
+    fn changed_frame_uploads_again() {
+        use crate::testing::fixtures::solid_png_screenshot;
+        let mut b = EventTester::builder();
+        b.platform()
+            .set_default_screenshot(solid_png_screenshot(100));
+        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        let mut t = b.build();
+        t.emit(1, test_login());
+        t.emit(1, Ping); // baseline upload (solid 100)
+        t.clear_captured();
+        // A materially different frame on the next capture must re-upload.
+        t.platform.queue_screenshot(Ok(solid_png_screenshot(220)));
+        t.emit(61, Ping);
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::Screenshot { .. },
+            ..
+        }));
+    }
+
+    #[test]
+    fn locked_skips_capture_entirely() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        module.state.enabled = true;
+        b.add(module);
+        let mut t = b.build();
+        t.emit(1, Ping);
+        // No image captured, but a `ScreenshotSkipped { LockedOrScreensaver }` is logged.
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::ScreenshotSkipped {
+                reason: ScreenshotSkipReason::LockedOrScreensaver
+            },
+            ..
+        }));
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Screenshot { .. },
+            ..
+        }));
+        // No capture taken at all while locked.
+        assert_eq!(t.platform.take_call_count(), 0);
+        // Cadence still advances so we re-check next interval.
+        assert_eq!(
+            t.observer::<ScreenshotModule>().state.last_screenshot_at_ms,
+            Some(1000)
+        );
+    }
+
+    #[test]
+    fn unlock_resumes_capture() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        module.state.enabled = true;
+        b.add(module);
+        let mut t = b.build();
+        t.emit(1, Ping); // locked → skip (records ScreenshotSkipped, no Screenshot)
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Screenshot { .. },
+            ..
+        }));
+        t.clear_captured();
+        t.platform.set_locked_or_screensaver(false);
+        t.emit(61, Ping); // unlocked → capture + upload
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::Screenshot { .. },
+            ..
+        }));
+        assert_eq!(t.platform.take_call_count(), 1);
+    }
+
+    #[test]
+    fn legacy_fingerprint_format_does_not_break_state_load() {
+        // An older build persisted `last_uploaded_fingerprint` as a flat integer array;
+        // the current type is a struct. Loading such state must not fail — the fingerprint
+        // resets to None while the rest of the screenshot state is preserved (rather than
+        // erroring out of `init` and crash-looping the daemon).
+        let saved = serde_json::json!({
+            "screenshot": {
+                "enabled": true,
+                "last_screenshot_at_ms": 12_345,
+                "last_uploaded_fingerprint": [22, 17, 17, 19, 23]
+            }
+        });
+        let mut b = EventTester::builder();
+        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        b.with_state(saved);
+        let mut t = b.build();
+        let st = &t.observer::<ScreenshotModule>().state;
+        assert!(st.enabled, "enabled flag should survive the load");
+        assert_eq!(st.last_screenshot_at_ms, Some(12_345));
+        assert!(
+            st.last_uploaded_fingerprint.is_none(),
+            "incompatible legacy fingerprint should decode to None"
+        );
     }
 
     #[test]

--- a/client/core/src/module/screenshot/fingerprint.rs
+++ b/client/core/src/module/screenshot/fingerprint.rs
@@ -1,0 +1,216 @@
+//! Screen-change fingerprint used to dedup redundant screenshot uploads.
+//!
+//! A captured frame is downscaled to a small grayscale grid and two fingerprints are compared.
+//! A frame counts as *changed* if EITHER:
+//!   * the **mean** per-cell delta is high — a broad change, including low-contrast ones like a
+//!     terminal filling with text (this is the case a whole-frame approach misses); or
+//!   * a **number of cells** changed strongly — a concentrated change like a video window.
+//!
+//! The grid resolution is **derived from the image size** (each cell covers a roughly fixed
+//! `TARGET_CELL_PX`-sized source block) rather than a fixed 32×32. On a large/wide display a
+//! fixed grid makes each cell average thousands of source pixels, which dilutes real changes
+//! (e.g. text on a dark terminal) below any threshold — the bug this addresses. Sizing the grid
+//! to the image keeps per-cell dilution bounded and the metrics stable across resolutions.
+//!
+//! Two captures of the same screen produce identically-shaped grids and so are directly
+//! comparable; if the resolution changes the shapes differ and `changed` fails safe to `true`.
+//!
+//! Thresholds were calibrated against a real "minimum change that should be detected" sample
+//! (a terminal filling with text across one of two monitors on a 3840×1080 desktop). See the
+//! unit tests for the calibration table.
+
+use image::GenericImageView;
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+
+/// Approximate source pixels per grid cell on each axis. The grid is sized so a cell covers
+/// roughly this much screen, independent of resolution.
+const TARGET_CELL_PX: u32 = 32;
+/// Clamp for the per-axis cell count, so tiny screens still get a usable grid and huge ones
+/// don't produce an unbounded fingerprint.
+const GRID_MIN: u32 = 16;
+const GRID_MAX: u32 = 128;
+
+/// Mean per-cell absolute delta (0..=255) at or above which the frame is "changed". Catches
+/// broad changes, including low-contrast ones a single-cell rule would miss. Naturally
+/// size-normalized (it's an average), so it holds across grid resolutions.
+const MEAN_DELTA_THRESHOLD: f64 = 0.5;
+
+/// Per-cell absolute delta (0..=255) at or above which a cell is counted as "strongly changed".
+const STRONG_CELL_DELTA: u8 = 40;
+/// Number of strongly-changed cells at or above which the frame is "changed", regardless of the
+/// mean. A clock/cursor touches 1–2 cells; a video window touches many, so the *count* (not a
+/// single max) cleanly separates them and stays size-independent (cell source-size is fixed).
+const MIN_STRONG_CELLS: usize = 6;
+
+/// A grid fingerprint of a captured frame: the grid dimensions plus the row-major grayscale
+/// cells. Dimensions are stored so two fingerprints can only be compared when they describe the
+/// same-shaped grid (i.e. the same screen resolution).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Fingerprint {
+    pub width: u16,
+    pub height: u16,
+    pub cells: Vec<u8>,
+}
+
+/// Grid cell counts (width, height) for an image of the given pixel dimensions.
+pub(crate) fn grid_dims(width: u32, height: u32) -> (u32, u32) {
+    let axis =
+        |d: u32| ((d as f32 / TARGET_CELL_PX as f32).round() as u32).clamp(GRID_MIN, GRID_MAX);
+    (axis(width), axis(height))
+}
+
+/// Reduce an encoded image to a size-appropriate grayscale grid fingerprint.
+pub fn fingerprint(image_bytes: &[u8]) -> CoreResult<Fingerprint> {
+    let decoded = image::load_from_memory(image_bytes)?;
+    let (width, height) = decoded.dimensions();
+    let (grid_w, grid_h) = grid_dims(width, height);
+    let grid = decoded
+        .resize_exact(grid_w, grid_h, image::imageops::FilterType::Triangle)
+        .to_luma8();
+    Ok(Fingerprint {
+        width: grid_w as u16,
+        height: grid_h as u16,
+        cells: grid.into_raw(),
+    })
+}
+
+/// True if `cur` differs materially from `prev`.
+///
+/// Fails safe to `true` (treat as changed → upload) when the two fingerprints aren't directly
+/// comparable (different grid shape, e.g. a resolution change), so a mismatch can never silently
+/// suppress an upload.
+pub fn changed(prev: &Fingerprint, cur: &Fingerprint) -> bool {
+    if prev.width != cur.width
+        || prev.height != cur.height
+        || prev.cells.len() != cur.cells.len()
+        || cur.cells.is_empty()
+    {
+        return true;
+    }
+
+    let mut strong_cells = 0usize;
+    let mut total_delta = 0u64;
+    for (&a, &b) in prev.cells.iter().zip(cur.cells.iter()) {
+        let delta = a.abs_diff(b);
+        total_delta += delta as u64;
+        if delta >= STRONG_CELL_DELTA {
+            strong_cells += 1;
+        }
+    }
+
+    let mean_delta = total_delta as f64 / cur.cells.len() as f64;
+    mean_delta >= MEAN_DELTA_THRESHOLD || strong_cells >= MIN_STRONG_CELLS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp(width: u16, height: u16, cells: Vec<u8>) -> Fingerprint {
+        assert_eq!(cells.len(), width as usize * height as usize);
+        Fingerprint {
+            width,
+            height,
+            cells,
+        }
+    }
+
+    #[test]
+    fn grid_dims_scale_with_image_size() {
+        // 3840×1080 dual-monitor desktop: ~32px cells, aspect preserved (not squashed to square).
+        assert_eq!(grid_dims(3840, 1080), (120, 34));
+        // 1080p single monitor.
+        assert_eq!(grid_dims(1920, 1080), (60, 34));
+        // Small images clamp up to GRID_MIN so the grid stays usable.
+        assert_eq!(grid_dims(64, 64), (16, 16));
+        // Very large displays clamp down to GRID_MAX.
+        assert_eq!(grid_dims(8192, 4096), (128, 128));
+    }
+
+    #[test]
+    fn identical_grids_are_unchanged() {
+        let g = fp(60, 34, vec![120; 60 * 34]);
+        assert!(!changed(&g, &g));
+    }
+
+    #[test]
+    fn broad_low_contrast_change_is_detected() {
+        // The regression case: a terminal fills with text across part of a wide screen. No single
+        // cell moves dramatically, but a large area shifts a little — the mean rule must catch it.
+        // (On the real 3840×1080 sample this measured mean ≈ 1.9; here we model ~40% of cells
+        // nudging by 6, mean ≈ 2.4.)
+        let prev = fp(120, 34, vec![100; 120 * 34]);
+        let mut cur = prev.clone();
+        for c in cur.cells.iter_mut().take((120 * 34) * 4 / 10) {
+            *c += 6;
+        }
+        assert!(changed(&prev, &cur));
+    }
+
+    #[test]
+    fn clock_sized_one_cell_jitter_is_unchanged() {
+        // A clock/cursor moves one or two cells. Too few strong cells, negligible mean → unchanged.
+        let prev = fp(120, 34, vec![100; 120 * 34]);
+        let mut cur = prev.clone();
+        cur.cells[500] = 180; // one cell, +80
+        cur.cells[501] = 170;
+        assert!(!changed(&prev, &cur));
+    }
+
+    #[test]
+    fn a_few_strong_cells_are_unchanged() {
+        // Below MIN_STRONG_CELLS and tiny mean: e.g. a small status indicator updating.
+        let prev = fp(120, 34, vec![60; 120 * 34]);
+        let mut cur = prev.clone();
+        for i in 0..MIN_STRONG_CELLS - 1 {
+            cur.cells[i] = 160; // +100, strongly changed
+        }
+        assert!(!changed(&prev, &cur));
+    }
+
+    #[test]
+    fn concentrated_region_change_is_detected() {
+        // A small video window: a cluster of strongly-changed cells whose *mean* over the whole
+        // frame stays below threshold. The strong-cell-count rule (not the mean) must catch it —
+        // this is what keeps a small corner video from being diluted away.
+        let prev = fp(120, 34, vec![30; 120 * 34]);
+        let mut cur = prev.clone();
+        for i in 0..(MIN_STRONG_CELLS + 4) {
+            cur.cells[i] = 130; // +100
+        }
+        let total: u64 = prev
+            .cells
+            .iter()
+            .zip(&cur.cells)
+            .map(|(&a, &b)| a.abs_diff(b) as u64)
+            .sum();
+        let mean = total as f64 / cur.cells.len() as f64;
+        assert!(
+            mean < MEAN_DELTA_THRESHOLD,
+            "strong-cell rule, not mean, should fire"
+        );
+        assert!(changed(&prev, &cur));
+    }
+
+    #[test]
+    fn different_grid_shape_fails_safe_to_changed() {
+        // Resolution change → different grid shape → always upload.
+        assert!(changed(
+            &fp(60, 34, vec![10; 60 * 34]),
+            &fp(120, 34, vec![10; 120 * 34])
+        ));
+    }
+
+    #[test]
+    fn fingerprint_dims_match_grid_dims_and_are_stable() {
+        let png = crate::testing::fixtures::solid_png_bytes(120);
+        let a = fingerprint(&png).expect("fingerprint solid png");
+        let (gw, gh) = grid_dims(64, 64); // solid_png_bytes is 64×64
+        assert_eq!((a.width as u32, a.height as u32), (gw, gh));
+        assert_eq!(a.cells.len(), (gw * gh) as usize);
+        let b = fingerprint(&png).expect("fingerprint again");
+        assert!(!changed(&a, &b));
+    }
+}

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -240,6 +240,11 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         if !self.authenticated {
             return Ok(());
         }
+        // Battery: don't wake the network/radio while the screen is off/locked. Queued
+        // events persist and flush on the next ping once the screen is active.
+        if self.platform.is_locked_or_screensaver()? {
+            return Ok(());
+        }
         let now_ms = self.platform.get_time_utc_ms()?;
 
         if let Some(last) = self.state.last_batch_at_ms
@@ -269,13 +274,20 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             risk: Some(risk),
             event: kind,
         };
+        // Always enqueue, but only attempt network I/O while the screen is active
+        // (battery): a locked/off screen leaves events queued for the next ping flush.
+        let screen_active = !self.platform.is_locked_or_screensaver()?;
         if risk >= crate::module::lifecycle::EXTRA_HIGH_RISK {
             self.state.pending_immediate_events.push(entry);
-            self.retry_pending_immediates()?;
+            if screen_active {
+                self.retry_pending_immediates()?;
+            }
         } else {
             self.state.pending_hash_events.push(entry);
-            self.retry_pending_hashes()?;
-            self.maybe_upload_batch(now_ms, emitter)?;
+            if screen_active {
+                self.retry_pending_hashes()?;
+                self.maybe_upload_batch(now_ms, emitter)?;
+            }
         }
         Ok(())
     }
@@ -378,13 +390,25 @@ fn batch_recipients(settings: &DeviceSettings) -> CoreResult<Vec<BatchRecipient>
 
 #[cfg(test)]
 mod tests {
-    use super::{Upload, UploadModule};
+    use super::{FlushBatchNow, Upload, UploadModule};
+    use crate::events::Ping;
     use crate::model::{
-        BatchRecipient, DeviceCredentials, DeviceSettings, LogEntry, PartialStatus, UploadKind,
+        BatchRecipient, DeviceCredentials, DeviceSettings, LogEntry, PartialStatus,
+        ProcessStoppedReason, ScreenshotSkipReason, UploadKind,
     };
     use crate::module::auth::{Login, Logout};
+    use crate::module::lifecycle::ProcessStopped;
     use crate::module::status::StatusRequest;
     use crate::testing::{EventTester, MockApiClient};
+
+    fn skipped_upload() -> Upload {
+        Upload {
+            risk: 0.0,
+            kind: UploadKind::ScreenshotSkipped {
+                reason: ScreenshotSkipReason::StaticScreen,
+            },
+        }
+    }
 
     fn valid_credentials() -> DeviceCredentials {
         DeviceCredentials {
@@ -506,5 +530,80 @@ mod tests {
         t.assert_like::<PartialStatus>(crate::like!(PartialStatus::Upload {
             pending_request_count: 2,
         }));
+    }
+
+    #[test]
+    fn locked_screen_defers_uploads_until_active() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        // While locked, the event is queued but no network call fires on Upload or Ping.
+        t.emit(1, skipped_upload());
+        t.emit(2, Ping);
+        {
+            let s = t.api.state();
+            assert!(s.hash_uploads.is_empty(), "no hash upload while locked");
+            assert!(s.batch_uploads.is_empty(), "no batch upload while locked");
+            assert!(
+                s.log_uploads.is_empty(),
+                "no direct log upload while locked"
+            );
+        }
+        assert_eq!(
+            t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_hash_events
+                .len(),
+            1,
+            "event should remain queued while locked"
+        );
+
+        // Screen active again → next ping flushes the queue.
+        t.platform.set_locked_or_screensaver(false);
+        t.emit(3, Ping);
+        let s = t.api.state();
+        assert!(!s.hash_uploads.is_empty(), "hash flushes once active");
+        assert!(!s.batch_uploads.is_empty(), "batch flushes once active");
+    }
+
+    #[test]
+    fn flush_batch_now_uploads_while_locked() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
+        let mut t = b.build();
+        t.emit(1, login_event());
+        t.observer::<UploadModule<MockApiClient>>()
+            .state
+            .pending_batch_events
+            .push((500, vec![1, 2, 3]));
+
+        // A plain ping does not flush while locked.
+        t.emit(2, Ping);
+        assert!(t.api.state().batch_uploads.is_empty());
+
+        // FlushBatchNow is an explicit flush path → uploads regardless of lock.
+        t.emit(3, FlushBatchNow);
+        assert_eq!(t.api.state().batch_uploads.len(), 1);
+    }
+
+    #[test]
+    fn shutdown_flush_uploads_while_locked() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
+        let mut t = b.build();
+        t.emit(1, login_event());
+        t.observer::<UploadModule<MockApiClient>>()
+            .state
+            .pending_batch_events
+            .push((500, vec![1, 2, 3]));
+
+        // ProcessStopped(Shutdown) is a terminal flush path → uploads regardless of lock.
+        t.emit(2, ProcessStopped(ProcessStoppedReason::Shutdown));
+        assert_eq!(t.api.state().batch_uploads.len(), 1);
     }
 }

--- a/client/core/src/platform.rs
+++ b/client/core/src/platform.rs
@@ -18,6 +18,18 @@ pub trait ScreenshotHooks: Send + Sync + 'static {
 
     fn get_last_shutdown_time_utc_ms(&self) -> CoreResult<Option<i64>>;
     fn get_last_startup_time_utc_ms(&self) -> CoreResult<Option<i64>>;
+
+    /// True if the session is locked or a screensaver is active.
+    ///
+    /// While locked/screensaving the user cannot be viewing real content, so the
+    /// screenshot module suppresses capture unconditionally. `Ok(false)` is the
+    /// fail-safe default when the state can't be determined (unknown session) —
+    /// i.e. fall back to the diff gate, never silently suppress. The default
+    /// implementation returns `Ok(false)` for platforms without the concept
+    /// (e.g. mobile); desktop platforms override it.
+    fn is_locked_or_screensaver(&self) -> CoreResult<bool> {
+        Ok(false)
+    }
 }
 
 /// Marker trait for platform implementations. Kept as a supertrait of

--- a/client/core/src/testing/fixtures.rs
+++ b/client/core/src/testing/fixtures.rs
@@ -22,3 +22,26 @@ pub fn tiny_png_screenshot() -> Screenshot {
         content_type: "image/png".to_string(),
     }
 }
+
+/// Encode a 64×64 solid-gray PNG. Distinct `luma` values produce fingerprints that the
+/// screenshot dedup gate treats as materially different, so tests can simulate an
+/// unchanged vs. changed screen.
+pub fn solid_png_bytes(luma: u8) -> Vec<u8> {
+    let img = image::RgbImage::from_pixel(64, 64, image::Rgb([luma, luma, luma]));
+    let mut bytes = Vec::new();
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(
+            &mut std::io::Cursor::new(&mut bytes),
+            image::ImageFormat::Png,
+        )
+        .expect("encode solid test PNG");
+    bytes
+}
+
+pub fn solid_png_screenshot(luma: u8) -> Screenshot {
+    Screenshot {
+        captured_at_ms: 0,
+        bytes: solid_png_bytes(luma),
+        content_type: "image/png".to_string(),
+    }
+}

--- a/client/core/src/testing/platform.rs
+++ b/client/core/src/testing/platform.rs
@@ -19,6 +19,7 @@ struct TestPlatformInner {
     default_screenshot: Screenshot,
     last_shutdown_time_ms: Option<i64>,
     last_startup_time_ms: Option<i64>,
+    locked_or_screensaver: bool,
 }
 
 impl TestPlatformHooks {
@@ -35,6 +36,7 @@ impl TestPlatformHooks {
                 default_screenshot: tiny_png_screenshot(),
                 last_shutdown_time_ms: None,
                 last_startup_time_ms: None,
+                locked_or_screensaver: false,
             })),
         }
     }
@@ -57,6 +59,10 @@ impl TestPlatformHooks {
 
     pub fn set_last_startup_time(&self, ms: Option<i64>) {
         self.lock().last_startup_time_ms = ms;
+    }
+
+    pub fn set_locked_or_screensaver(&self, locked: bool) {
+        self.lock().locked_or_screensaver = locked;
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, TestPlatformInner> {
@@ -91,6 +97,10 @@ impl ScreenshotHooks for TestPlatformHooks {
 
     fn get_last_startup_time_utc_ms(&self) -> CoreResult<Option<i64>> {
         Ok(self.lock().last_startup_time_ms)
+    }
+
+    fn is_locked_or_screensaver(&self) -> CoreResult<bool> {
+        Ok(self.lock().locked_or_screensaver)
     }
 }
 

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -14,7 +14,7 @@ use virtue_core::{
     build_default_modules_reqwest, load_state, store_state, AuthState, Config, CoreError,
     CoreResult, DeviceSettings, EventBus, EventChannel, LoginRequested, LoginResult,
     LogoutRequested, Ping, PlatformHooks, ProcessStarted, ProcessStopped, ProcessStoppedReason,
-    Redacted, Screenshot, ScreenshotHooks, ScreenshotResumed, StatusRequest, StatusResponse,
+    Redacted, Screenshot, ScreenshotHooks, StatusRequest, StatusResponse,
     UserStopRequested,
 };
 
@@ -390,15 +390,11 @@ pub unsafe extern "C" fn virtue_ios_free_string(value: *mut c_char) {
 fn run_daemon_loop(core: &IosCore) -> Result<()> {
     let (mut bus, state_path) = build_bus(core, "ios-device")?;
     bus.send(ProcessStarted)?;
-    // Enable screenshot capture. The screenshot module only captures while it is
-    // "enabled", which the lifecycle module otherwise flips on via
-    // `UserSessionLogin` — a desktop-only OS event that never fires on iOS.
-    // The Safari extension only starts this daemon while monitoring is enabled
-    // (it sends `UserStopRequested`/stops the loop when the user pauses), so the
-    // loop running at all means capture should be on. Mirrors how the Android
-    // client drives `ScreenshotResumed` from its daemon loop rather than relying
-    // on a session-login event.
-    bus.send(ScreenshotResumed)?;
+    // The screenshot module's `enabled` flag is set on `Login` and persisted in
+    // `event_state.json`, so it survives across the separate login/daemon FFI calls
+    // and is already `true` here once the user has logged in. iOS has no lock/screen
+    // concept exposed to the daemon, so `is_locked_or_screensaver()` stays at the
+    // default `Ok(false)` and capture proceeds whenever the loop runs.
     let state = bus.iter()?;
     store_state(&state_path, &state)?;
 

--- a/client/linux/src/capture.rs
+++ b/client/linux/src/capture.rs
@@ -267,6 +267,130 @@ impl ScreenshotHooks for LinuxPlatformHooks {
             .map_err(|e| CoreError::CommandFailed(e.to_string()))?;
         Ok(parse_btime_ms(&stat))
     }
+
+    fn is_locked_or_screensaver(&self) -> CoreResult<bool> {
+        // Prefer logind's per-session `LockedHint`: the locker reports it across desktops
+        // (xss-lock, GNOME, KDE, …), so it covers minimal X11 setups like i3 + i3lock that
+        // expose no ScreenSaver D-Bus interface at all. Fall back to the freedesktop/GNOME
+        // ScreenSaver `GetActive` for environments that surface a screensaver but no
+        // LockedHint. Any error / missing service ⇒ false (fall back to the diff gate),
+        // never silently suppress.
+        if query_session_locked() == Some(true) {
+            return Ok(true);
+        }
+        Ok(query_screensaver_active().unwrap_or(false))
+    }
+}
+
+// Blocking logind proxies (system bus). `LockedHint` lives on the per-session object, so we
+// resolve the caller's primary graphical session via the user object's `Display` property
+// (the same path `loginctl` uses) and read the hint there.
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1",
+    gen_async = false,
+    gen_blocking = true
+)]
+trait Login1Manager {
+    fn get_user(&self, uid: u32) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.User",
+    default_service = "org.freedesktop.login1",
+    gen_async = false,
+    gen_blocking = true
+)]
+trait Login1User {
+    /// `(session_id, object_path)` of the user's primary graphical session.
+    #[zbus(property)]
+    fn display(&self) -> zbus::Result<(String, zbus::zvariant::OwnedObjectPath)>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.login1.Session",
+    default_service = "org.freedesktop.login1",
+    gen_async = false,
+    gen_blocking = true
+)]
+trait Login1Session {
+    #[zbus(property)]
+    fn locked_hint(&self) -> zbus::Result<bool>;
+}
+
+/// Real UID of this process, read from `/proc/self/status` (no libc dependency).
+fn current_uid() -> Option<u32> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status.lines().find_map(|line| {
+        line.strip_prefix("Uid:")
+            .and_then(|rest| rest.split_whitespace().next())
+            .and_then(|uid| uid.parse().ok())
+    })
+}
+
+/// `Some(true)`/`Some(false)` if logind reports the primary graphical session's lock state,
+/// `None` if logind is unavailable or the session can't be resolved (⇒ fall back to the
+/// screensaver query).
+fn query_session_locked() -> Option<bool> {
+    let connection = zbus::blocking::Connection::system().ok()?;
+    let manager = Login1ManagerProxy::new(&connection).ok()?;
+    let user_path = manager.get_user(current_uid()?).ok()?;
+    let user = Login1UserProxy::builder(&connection)
+        .path(user_path)
+        .ok()?
+        .build()
+        .ok()?;
+    let (_session_id, session_path) = user.display().ok()?;
+    let session = Login1SessionProxy::builder(&connection)
+        .path(session_path)
+        .ok()?
+        .build()
+        .ok()?;
+    session.locked_hint().ok()
+}
+
+// Blocking D-Bus proxies for the two common `GetActive()` providers. We use the
+// blocking flavour (gen_async = false) because `is_locked_or_screensaver` is a
+// synchronous hook called from the event bus.
+#[zbus::proxy(
+    interface = "org.freedesktop.ScreenSaver",
+    default_service = "org.freedesktop.ScreenSaver",
+    default_path = "/org/freedesktop/ScreenSaver",
+    gen_async = false,
+    gen_blocking = true
+)]
+trait FreedesktopScreenSaver {
+    fn get_active(&self) -> zbus::Result<bool>;
+}
+
+#[zbus::proxy(
+    interface = "org.gnome.ScreenSaver",
+    default_service = "org.gnome.ScreenSaver",
+    default_path = "/org/gnome/ScreenSaver",
+    gen_async = false,
+    gen_blocking = true
+)]
+trait GnomeScreenSaver {
+    fn get_active(&self) -> zbus::Result<bool>;
+}
+
+fn query_screensaver_active() -> Option<bool> {
+    let connection = zbus::blocking::Connection::session().ok()?;
+
+    if let Ok(proxy) = FreedesktopScreenSaverProxy::new(&connection)
+        && let Ok(active) = proxy.get_active()
+    {
+        return Some(active);
+    }
+
+    if let Ok(proxy) = GnomeScreenSaverProxy::new(&connection)
+        && let Ok(active) = proxy.get_active()
+    {
+        return Some(active);
+    }
+
+    None
 }
 
 impl PlatformHooks for LinuxPlatformHooks {}

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -13,7 +13,7 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 #[cfg(debug_assertions)]
-use virtue_core::{AlertReason, LifecycleKind};
+use virtue_core::{AlertReason, LifecycleKind, ScreenshotSkipReason};
 use virtue_core::{
     ClientController, EventBus, EventChannel, FlushBatchNow, Ping, ScreenshotHooks, ServiceStatus,
     StatusRequest, StatusResponse, Upload, UploadKind, build_default_modules_reqwest, load_state,
@@ -373,6 +373,12 @@ fn build_send_kind(args: &SendLogArgs) -> Result<UploadKind> {
                 .clone()
                 .unwrap_or_else(|| "Developer test alert".to_string()),
         }),
+        "screenshot_skipped" => {
+            let reason = args.reason.as_deref().unwrap_or("static_screen");
+            let reason: ScreenshotSkipReason = serde_json::from_value(parse_enum(reason)?)
+                .with_context(|| format!("unknown screenshot skip reason: {reason}"))?;
+            Ok(UploadKind::ScreenshotSkipped { reason })
+        }
         "capture_failed" => Ok(UploadKind::CaptureFailed),
         "dev" => Ok(UploadKind::Dev {
             title: args
@@ -382,7 +388,7 @@ fn build_send_kind(args: &SendLogArgs) -> Result<UploadKind> {
             details: args.details.clone(),
         }),
         other => anyhow::bail!(
-            "unsupported --type {other:?} (expected: lifecycle, lifecycle_alert, alert, capture_failed, dev, screenshot, or all)"
+            "unsupported --type {other:?} (expected: lifecycle, lifecycle_alert, screenshot_skipped, alert, capture_failed, dev, screenshot, or all)"
         ),
     }
 }
@@ -402,8 +408,6 @@ fn all_send_kinds() -> Vec<UploadKind> {
         ProcessStoppedUser,
         ProcessStoppedShutdown,
         ProcessStoppedOther,
-        ScreenshotPaused,
-        ScreenshotResumed,
     ]
     .into_iter()
     .map(|kind| UploadKind::Lifecycle { kind });
@@ -417,8 +421,15 @@ fn all_send_kinds() -> Vec<UploadKind> {
     ]
     .into_iter()
     .map(|reason| UploadKind::LifecycleAlert { reason });
+    let skips = [
+        ScreenshotSkipReason::StaticScreen,
+        ScreenshotSkipReason::LockedOrScreensaver,
+    ]
+    .into_iter()
+    .map(|reason| UploadKind::ScreenshotSkipped { reason });
     lifecycle
         .chain(alerts)
+        .chain(skips)
         .chain([
             UploadKind::Alert {
                 message: "Developer test alert".to_string(),

--- a/client/mac/Cargo.toml
+++ b/client/mac/Cargo.toml
@@ -20,6 +20,8 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSButtonCell", "NSColor", "NSControl", "NSEvent", "NSGraphics", "NSImage", "NSImageView", "NSMenu", "NSMenuItem", "NSResponder", "NSScrollView", "NSSecureTextField", "NSText", "NSTextField", "NSTextFieldCell", "NSTextView", "NSView", "NSVisualEffectView", "NSWindow", "NSWorkspace"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSDate", "NSNotification", "NSOperation", "NSRunLoop", "NSString", "block2"] }
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = ["std", "CFBase", "CFString", "CFDictionary", "CFNumber"] }
+objc2-core-graphics = { version = "0.3.2", default-features = false, features = ["std", "CGSession"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }

--- a/client/mac/src/capture.rs
+++ b/client/mac/src/capture.rs
@@ -180,6 +180,52 @@ impl ScreenshotHooks for MacPlatformHooks {
         let text = String::from_utf8_lossy(&output.stdout);
         Ok(parse_boottime_ms(&text))
     }
+
+    fn is_locked_or_screensaver(&self) -> CoreResult<bool> {
+        // Either the session being locked or an active screensaver means the user
+        // can't be viewing real content. Both checks fail safe to false.
+        Ok(screen_is_locked() || screensaver_process_running())
+    }
+}
+
+// Reads `CGSessionCopyCurrentDictionary()["CGSSessionScreenIsLocked"]`. Returns false
+// when the dictionary or key is absent (unknown session) — the fail-safe default.
+fn screen_is_locked() -> bool {
+    use std::ffi::c_void;
+
+    use objc2_core_foundation::{CFBoolean, CFString};
+    use objc2_core_graphics::CGSessionCopyCurrentDictionary;
+
+    let Some(dict) = CGSessionCopyCurrentDictionary() else {
+        return false;
+    };
+    let key = CFString::from_str("CGSSessionScreenIsLocked");
+    // SAFETY: `dict` is a valid CFDictionary; `key` outlives the lookup. The returned
+    // pointer (if non-null) is the dictionary's CFBoolean for that key.
+    let value = unsafe { dict.value(&*key as *const CFString as *const c_void) };
+    if value.is_null() {
+        return false;
+    }
+    // The screensaver/lock value is the shared kCFBooleanTrue singleton; pointer
+    // identity against it is the simplest correct read.
+    let true_ptr = CFBoolean::new(true) as *const CFBoolean as *const c_void;
+    std::ptr::eq(value, true_ptr)
+}
+
+// Detects the macOS screensaver host process. The engine name differs across releases.
+fn screensaver_process_running() -> bool {
+    ["ScreenSaverEngine", "legacyScreenSaver"]
+        .iter()
+        .any(|name| {
+            Command::new("pgrep")
+                .args(["-x", name])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|status| status.success())
+                .unwrap_or(false)
+        })
 }
 
 impl PlatformHooks for MacPlatformHooks {}

--- a/client/windows/Cargo.toml
+++ b/client/windows/Cargo.toml
@@ -39,6 +39,7 @@ features = [
   "Win32_Security",
   "Win32_Security_Authentication_Identity",
   "Win32_System_Registry",
+  "Win32_System_StationsAndDesktops",
   "Win32_System_Threading",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",

--- a/client/windows/src/capture.rs
+++ b/client/windows/src/capture.rs
@@ -231,6 +231,49 @@ pub fn read_last_shutdown_time_utc_ms() -> CoreResult<Option<i64>> {
     Ok(None)
 }
 
+// True if a screensaver is running or the session is locked. Both checks fail safe
+// to false (fall back to the diff gate) when the state can't be determined.
+#[cfg(target_os = "windows")]
+pub fn read_locked_or_screensaver() -> bool {
+    use windows::Win32::System::StationsAndDesktops::{
+        CloseDesktop, DESKTOP_CONTROL_FLAGS, DESKTOP_SWITCHDESKTOP, OpenInputDesktop,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        SPI_GETSCREENSAVERRUNNING, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
+    };
+    use windows::core::BOOL;
+
+    unsafe {
+        let mut running = BOOL(0);
+        let screensaver = SystemParametersInfoW(
+            SPI_GETSCREENSAVERRUNNING,
+            0,
+            Some(&mut running as *mut _ as *mut core::ffi::c_void),
+            SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
+        )
+        .is_ok()
+            && running.as_bool();
+        if screensaver {
+            return true;
+        }
+
+        // When the workstation is locked the input desktop becomes the secure
+        // (Winlogon) desktop, so a normal-privilege OpenInputDesktop fails.
+        match OpenInputDesktop(DESKTOP_CONTROL_FLAGS(0), false, DESKTOP_SWITCHDESKTOP) {
+            Ok(desktop) => {
+                let _ = CloseDesktop(desktop);
+                false
+            }
+            Err(_) => true,
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn read_locked_or_screensaver() -> bool {
+    false
+}
+
 #[derive(Clone)]
 pub struct WindowsPlatformHooks;
 
@@ -263,6 +306,10 @@ impl ScreenshotHooks for WindowsPlatformHooks {
 
     fn get_last_startup_time_utc_ms(&self) -> CoreResult<Option<i64>> {
         read_last_startup_time_utc_ms()
+    }
+
+    fn is_locked_or_screensaver(&self) -> CoreResult<bool> {
+        Ok(read_locked_or_screensaver())
     }
 }
 

--- a/landing/src/content/help/web/log-types.md
+++ b/landing/src/content/help/web/log-types.md
@@ -16,6 +16,12 @@ this page.
 A screenshot was captured on the device. This is the most common entry — the
 monitoring app captures the screen on a regular interval while it is running.
 
+## Screenshot Skipped
+
+Monitoring was active but no screenshot was uploaded — either the screen had
+not changed since the last capture, or the device was locked or asleep. This
+keeps the timeline continuous without storing redundant images.
+
 ## Computer Started
 
 The device was powered on or restarted.

--- a/web/src/pages/Logs/log-icons.test.tsx
+++ b/web/src/pages/Logs/log-icons.test.tsx
@@ -21,6 +21,7 @@ describe('getLogCategory — titles', () => {
       'Unexpected Gap',
     );
     expect(getLogCategory(log('capture_failed'))).toBe('Capture Failed');
+    expect(getLogCategory(log('screenshot_skipped'))).toBe('Screenshot Skipped');
   });
 });
 
@@ -33,6 +34,7 @@ describe('getLogHelpAnchor / getLogHelpUrl', () => {
       getLogHelpAnchor(log('lifecycle_alert', { reason: 'force_killed_before_shutdown' })),
     ).toBe('process-force-stopped');
     expect(getLogHelpAnchor(log('screenshot'))).toBe('screenshot');
+    expect(getLogHelpAnchor(log('screenshot_skipped'))).toBe('screenshot-skipped');
   });
 
   it('builds a full help URL with the anchor', () => {

--- a/web/src/pages/Logs/log-icons.tsx
+++ b/web/src/pages/Logs/log-icons.tsx
@@ -39,6 +39,17 @@ function CameraIcon() {
   );
 }
 
+function DocumentDuplicateIcon() {
+  return (
+    <Icon>
+      <path
+        {...cap}
+        d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75"
+      />
+    </Icon>
+  );
+}
+
 function ComputerDesktopIcon() {
   return (
     <Icon>
@@ -212,6 +223,8 @@ export function LogIcon({ log }: { log: DataLog }) {
   switch (log.type) {
     case 'screenshot':
       return <CameraIcon />;
+    case 'screenshot_skipped':
+      return <DocumentDuplicateIcon />;
     case 'lifecycle':
       if (kind === 'computer_booted') return <ComputerDesktopIcon />;
       if (kind === 'computer_suspended') return <MoonIcon />;

--- a/web/src/pages/Logs/shared.tsx
+++ b/web/src/pages/Logs/shared.tsx
@@ -25,6 +25,8 @@ export function getLogCategory(log: DataLog): string {
   switch (log.type) {
     case 'screenshot':
       return 'Screenshot';
+    case 'screenshot_skipped':
+      return 'Screenshot Skipped';
     case 'lifecycle':
       if (kind === 'computer_booted') return 'Computer Started';
       if (kind === 'computer_suspended') return 'Sleep';
@@ -107,6 +109,13 @@ export function getLogMessage(log: DataLog, deviceName: string): string {
     }
     case 'screenshot':
       return `Screenshot captured on ${deviceName}`;
+    case 'screenshot_skipped': {
+      const reason = d.reason as string | undefined;
+      if (reason === 'static_screen') return `Duplicate screenshot skipped on ${deviceName}`;
+      if (reason === 'locked_or_screensaver')
+        return `Screen locked, screenshot skipped on ${deviceName}`;
+      return `Screenshot skipped on ${deviceName}`;
+    }
     case 'alert': {
       const message = d.message as string | undefined;
       return message ?? `Alert on ${deviceName}`;
@@ -125,6 +134,7 @@ export function getLogMessage(log: DataLog, deviceName: string): string {
 
 export const LOG_TYPES = [
   'screenshot',
+  'screenshot_skipped',
   'lifecycle',
   'lifecycle_alert',
   'alert',


### PR DESCRIPTION
- Fixes #278 
- Fixes #279 
- Fixes #280 
- Fixes #281 

Adds a new platform hook for detecting if the screen is locked, and also adds a screenshot diff detection system (essentially if two screenshots are almost the same, it doesn't upload the second one). Instead when it is locked or the same it uploads a ScreenshotSkipped event.

- Tested that a static screen uploads skip screenshot (purely core)
- Tested uploads skip screenshot with locked_or_screensaver when locked on
  - [x] Linux
  - [x] Mac
  - [x] Windows
  - [x] iOS
  - [x] Android
