### PR TITLE
Fix typos and grammar in security article

### DIFF
--- a/landing/src/content/blog/how-our-security-works.md
+++ b/landing/src/content/blog/how-our-security-works.md
@@ -1,16 +1,16 @@
 ---
 title: How our security works
-description: A high level overview of how our security works for a non-technical person
+description: A high-level overview of how our security works for a non-technical person
 pubDate: 2026-05-16
 author: The Virtue Initiative team
 ---
 
 In this article, we will be covering the high-level details of our security -
-how it works and what it does. In one sentence, we use end to end encryption to
+how it works and what it does. In one sentence, we use end-to-end encryption to
 send screenshots and other data from your computer to your partners, which
 means only you and your partner can ever see the screenshots. Our server
 cannot (i.e. it doesn't have the key to) access it. The details of how this
-works follows.
+works follow.
 
 ## Foundations
 
@@ -25,13 +25,13 @@ meet due to distance.
 Let's say you invented a special paint that only you knew the chemical required
 to dissolve it and sent it to your friend. Your friend writes their message and
 then puts a coating of your special paint over it. Now no one can read the
-message unless they know how to dissolve the paint, which means its safe from
+message unless they know how to dissolve the paint, which means it's safe from
 the mailman, but you can still read it since you know how to dissolve the
 paint.
 
 Public and private keys are a similar system where (using some math) one person
 can create something like a digital "coating" (called the public key) which can
-only be disolved with the "special chemical" (called the private key). (In
+only be dissolved with the "special chemical" (called the private key). (In
 reality, these are just huge special numbers that we do some fancy math with.)
 
 So in the digital world, when you want someone to send a secret message to you,
@@ -67,21 +67,21 @@ password you sent them to login to get your private ("dissolving") key.
 
 The server could **if** we actually sent your password to the server, but we
 **don't** and here's how. Imagine you have a secret recipe for an amazing
-chocolate cake. Let's say you got it from your great great grandma. Now let's
-say you find a long lost distant relative that also claims to have the secret
-recipe from your great grandma. You're skeptical but neither of you are willing
+chocolate cake. Let's say you got it from your great-great-grandma. Now, let's
+say you find a long-lost distant relative who also claims to have the secret
+recipe from your great-grandma. You're skeptical, but neither of you is willing
 to compare recipes since that would be giving away the secret. What's the
-solution? Have your long lost relative bake a cake with the recipe, if it
-matches your cake, you know you both have the same recipe even though neither
+solution? Have your long-lost relative bake a cake with the recipe. If it
+matches your cake, you know you both have the same recipe, even though neither
 of you ever saw each other's recipes.
 
 We use a similar concept for handling passwords. Imagine your password is a
 recipe for a cake. When you sign up, instead of sending the password itself, we
 send the server the "cake" you made with your password recipe. The server then
-remembers this "cake". Now when you log into your account, you make another
+remembers this "cake". Now, when you log into your account, you make another
 "cake" with the same recipe and send it to the server. The server checks if
 both "cakes" match and then lets you log in. Importantly, the server only ever
-sees the **"cake"** not the password itself, so we can still use the password
+sees the **"cake"**, not the password itself, so we can still use the password
 for your public and private keys.
 
 ## The end

--- a/landing/src/content/blog/how-our-security-works.md
+++ b/landing/src/content/blog/how-our-security-works.md
@@ -67,7 +67,7 @@ password you sent them to login to get your private ("dissolving") key.
 
 The server could **if** we actually sent your password to the server, but we
 **don't** and here's how. Imagine you have a secret recipe for an amazing
-chocolate cake. Let's say you got it from your great-great-grandma. Now, let's
+chocolate cake. Let's say you got it from your great-grandma. Now, let's
 say you find a long-lost distant relative who also claims to have the secret
 recipe from your great-grandma. You're skeptical, but neither of you is willing
 to compare recipes since that would be giving away the secret. What's the


### PR DESCRIPTION
Fixed a bunch of typos in the security blog.

## Type of change
Documentation update

## Components changed
Landing

## Description
Ran Grammarly on the document and fixed all the errors.

## Testing
None

## Impact
We look more professional
- Fixes #398 
