### PR TITLE
Added async image processing and ping gap budget

### DIFF
--- a/client/android/.gitignore
+++ b/client/android/.gitignore
@@ -4,3 +4,4 @@ local.properties
 app/src/main/jniLibs/
 rust/target/
 captures/
+scripts/cli/env.local.sh

--- a/client/android/scripts/cli/README.md
+++ b/client/android/scripts/cli/README.md
@@ -1,0 +1,51 @@
+# `va` — Virtue Android dev CLI
+
+A friendly wrapper around Gradle + the Android emulator for day-to-day work on
+the Android client.
+
+```bash
+client/android/scripts/cli/va <command>
+```
+
+Tip: add it to your PATH for the session — `export PATH="$PWD/client/android/scripts/cli:$PATH"` — then just `va install`.
+
+## Commands
+
+| Command         | What it does                                          |
+| --------------- | ----------------------------------------------------- |
+| `va install`    | Build, install, and launch the app on the emulator    |
+| `va build`      | Build the APK (+ Rust JNI core) only                  |
+| `va start`      | Start the emulator and wait for boot                  |
+| `va stop`       | Kill the running emulator                             |
+| `va lock`       | Lock the device screen                                |
+| `va force-idle` | Force the device into Doze (test background survival) |
+
+### Flags
+
+- `--release` — use the release build variant (`install` / `build`)
+- `--headless` — run the emulator with no window (`start`)
+- `-h`, `--help` — full usage
+
+### Typical loop
+
+```bash
+va start            # boot the emulator (--headless for no window)
+va install          # build + install + launch
+va force-idle       # exercise Doze / background survival
+va stop             # tear down
+```
+
+## Configuration — `env.sh`
+
+`env.sh` is committed and only sets defaults. Resolution order (later wins):
+
+1. Defaults in `env.sh`
+2. `scripts/cli/env.local.sh` (untracked — your machine paths; see `env.local.sh.example`)
+3. Variables already exported in your shell
+
+For machine-specific paths (e.g. a storage-redirected SDK), copy
+`env.local.sh.example` to `env.local.sh` — it's git-ignored.
+
+Key vars: `ANDROID_SDK_ROOT`, `ANDROID_NDK_ROOT`, `VIRTUE_AVD`,
+`VIRTUE_PACKAGE`, `VIRTUE_ACTIVITY`. To point at a different emulator for one
+run: `VIRTUE_AVD=my_avd va start`.

--- a/client/android/scripts/cli/env.local.sh.example
+++ b/client/android/scripts/cli/env.local.sh.example
@@ -1,0 +1,17 @@
+# Machine-local Android CLI overrides (untracked).
+#
+# Copy to env.local.sh and adjust. Sourced by env.sh *before* the defaults,
+# so anything set here wins. Use it for machine-specific paths you don't want
+# committed.
+
+# Point at your SDK (default is ~/Android/Sdk):
+# export ANDROID_SDK_ROOT="$HOME/Android/Sdk"
+
+# Use a full JDK if your default java is JRE-only:
+# export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+
+# A different emulator for this machine:
+# export VIRTUE_AVD="my_avd"
+
+# Or source an existing SDK env script that sets all of the above:
+# [ -f "$HOME/storage/android-sdk/env.sh" ] && . "$HOME/storage/android-sdk/env.sh"

--- a/client/android/scripts/cli/env.sh
+++ b/client/android/scripts/cli/env.sh
@@ -1,0 +1,49 @@
+# Shared environment for the Virtue Android CLI (scripts/cli/va).
+#
+# This file is committed and path-parametrized: it only sets sensible
+# *defaults*. Anything machine-specific belongs in the override layers below,
+# in priority order (later wins):
+#
+#   1. Defaults in this file.
+#   2. scripts/cli/env.local.sh            (untracked, your machine overrides —
+#                                            e.g. a storage-redirected SDK setup)
+#   3. Variables already exported in your shell.
+#
+# Nothing here is destructive — every assignment respects a value that is
+# already set in the environment.
+
+# ---------------------------------------------------------------------------
+# 2. Untracked machine-local overrides, sourced first so the values they set
+#    (ANDROID_SDK_ROOT, JAVA_HOME, redirected caches, …) win over the defaults
+#    below via the ${VAR:-default} guards.
+# ---------------------------------------------------------------------------
+if [ -f "${VIRTUE_ANDROID_CLI_DIR:-$(dirname "${BASH_SOURCE[0]:-$0}")}/env.local.sh" ]; then
+  # shellcheck disable=SC1091
+  . "${VIRTUE_ANDROID_CLI_DIR:-$(dirname "${BASH_SOURCE[0]:-$0}")}/env.local.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Defaults (only applied if still unset after the override above).
+# ---------------------------------------------------------------------------
+export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
+export ANDROID_HOME="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-$ANDROID_SDK_ROOT/ndk/26.1.10909125}"
+export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-$ANDROID_NDK_ROOT}"
+
+# Make sure the SDK tools are reachable.
+for _dir in \
+  "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" \
+  "$ANDROID_SDK_ROOT/platform-tools" \
+  "$ANDROID_SDK_ROOT/emulator"; do
+  case ":$PATH:" in
+    *":$_dir:"*) ;;
+    *) [ -d "$_dir" ] && PATH="$_dir:$PATH" ;;
+  esac
+done
+unset _dir
+export PATH
+
+# App + emulator coordinates this project uses.
+export VIRTUE_AVD="${VIRTUE_AVD:-virtue_api35}"
+export VIRTUE_PACKAGE="${VIRTUE_PACKAGE:-org.virtueinitiative.virtue}"
+export VIRTUE_ACTIVITY="${VIRTUE_ACTIVITY:-$VIRTUE_PACKAGE/.MainActivity}"

--- a/client/android/scripts/cli/va
+++ b/client/android/scripts/cli/va
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+#
+# va — friendly CLI for building, installing, and driving the Virtue Android app
+#      against a local emulator.
+#
+# Run `va --help` for usage.
+
+set -euo pipefail
+
+# --- locate ourselves & load env -------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANDROID_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"  # client/android
+GRADLEW="$ANDROID_DIR/gradlew"
+
+export VIRTUE_ANDROID_CLI_DIR="$SCRIPT_DIR"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/env.sh"
+
+# --- pretty output ---------------------------------------------------------
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'; C_BLUE=$'\033[34m'
+  C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_RED=$'\033[31m'; C_DIM=$'\033[2m'
+else
+  C_RESET=; C_BOLD=; C_BLUE=; C_GREEN=; C_YELLOW=; C_RED=; C_DIM=
+fi
+step() { printf '%s==>%s %s%s%s\n' "$C_BLUE$C_BOLD" "$C_RESET" "$C_BOLD" "$*" "$C_RESET"; }
+info() { printf '%s  - %s%s\n' "$C_DIM" "$*" "$C_RESET"; }
+ok()   { printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn() { printf '%s!%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+die()  { printf '%s✗%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "missing tool: $1 (check $SCRIPT_DIR/env.sh / ANDROID_SDK_ROOT)"; }
+
+gradle() { ( cd "$ANDROID_DIR" && "$GRADLEW" "$@" ); }
+
+# Variant helpers: map our --release flag onto Gradle task names.
+variant_suffix() { [ "${RELEASE:-0}" = 1 ] && echo "Release" || echo "Debug"; }
+
+# --- emulator helpers ------------------------------------------------------
+emulator_running() { adb devices | grep -q '^emulator-.*device$'; }
+
+wait_for_boot() {
+  step "Waiting for device to boot"
+  adb wait-for-device
+  until [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+    sleep 1
+  done
+  adb shell input keyevent 82 >/dev/null 2>&1 || true  # dismiss keyguard
+  ok "device booted"
+}
+
+# --- commands --------------------------------------------------------------
+cmd_build() {
+  need "$GRADLEW" 2>/dev/null || true
+  [ -x "$GRADLEW" ] || die "gradlew not found at $GRADLEW"
+  local v; v="$(variant_suffix)"
+  step "Building app ($v) + Rust JNI core"
+  gradle ":app:assemble${v}"
+  ok "build complete"
+  info "APK: $ANDROID_DIR/app/build/outputs/apk/$(echo "$v" | tr '[:upper:]' '[:lower:]')/app-$(echo "$v" | tr '[:upper:]' '[:lower:]').apk"
+}
+
+cmd_install() {
+  [ -x "$GRADLEW" ] || die "gradlew not found at $GRADLEW"
+  need adb
+  emulator_running || warn "no emulator detected — 'va start' first if install fails"
+  local v; v="$(variant_suffix)"
+  step "Building + installing app ($v)"
+  gradle ":app:install${v}"
+  ok "installed $VIRTUE_PACKAGE"
+  step "Launching app"
+  adb shell am start -n "$VIRTUE_ACTIVITY" >/dev/null
+  ok "launched $VIRTUE_ACTIVITY"
+  info "logs: adb logcat --pid \"\$(adb shell pidof -s $VIRTUE_PACKAGE)\""
+}
+
+cmd_start() {
+  need emulator; need adb
+  if emulator_running; then
+    ok "emulator already running"
+    wait_for_boot
+    return
+  fi
+  emulator -list-avds | grep -qx "$VIRTUE_AVD" \
+    || die "AVD '$VIRTUE_AVD' not found. Create it (see README) or set VIRTUE_AVD."
+  local extra=()
+  [ "${HEADLESS:-0}" = 1 ] && extra+=(-no-window -no-audio) && info "headless mode"
+  step "Starting emulator '$VIRTUE_AVD'"
+  # Detached so it survives this script; logs to a temp file.
+  local log="${TMPDIR:-/tmp}/virtue-emulator.log"
+  nohup emulator -avd "$VIRTUE_AVD" -no-snapshot "${extra[@]}" >"$log" 2>&1 &
+  info "emulator pid $! (log: $log)"
+  wait_for_boot
+}
+
+cmd_stop() {
+  need adb
+  if ! emulator_running; then
+    ok "no emulator running"
+    return
+  fi
+  step "Stopping emulator"
+  adb emu kill >/dev/null 2>&1 || die "failed to stop emulator"
+  ok "emulator stopped"
+}
+
+cmd_lock() {
+  need adb
+  emulator_running || die "no emulator running"
+  step "Locking screen"
+  adb shell input keyevent KEYCODE_SLEEP >/dev/null  # screen off -> keyguard
+  ok "screen locked (use KEYCODE_WAKEUP / 'va start' state to wake)"
+}
+
+cmd_force_idle() {
+  need adb
+  emulator_running || die "no emulator running"
+  step "Forcing Doze (deep idle)"
+  adb shell dumpsys battery unplug >/dev/null
+  adb shell dumpsys deviceidle enable >/dev/null
+  adb shell dumpsys deviceidle force-idle >/dev/null
+  ok "device forced into Doze"
+  info "restore with: adb shell dumpsys deviceidle unforce && adb shell dumpsys battery reset"
+}
+
+usage() {
+  cat <<EOF
+${C_BOLD}va${C_RESET} — Virtue Android dev CLI
+
+${C_BOLD}Usage:${C_RESET} va <command> [options]
+
+${C_BOLD}Commands:${C_RESET}
+  ${C_GREEN}install${C_RESET} [--release]   Build, install, and launch the app on the emulator
+  ${C_GREEN}build${C_RESET}   [--release]   Build the APK (+ Rust JNI core) only
+  ${C_GREEN}start${C_RESET}   [--headless]  Start the emulator and wait for boot
+  ${C_GREEN}stop${C_RESET}                  Kill the running emulator
+  ${C_GREEN}lock${C_RESET}                  Lock the device screen
+  ${C_GREEN}force-idle${C_RESET}            Force the device into Doze (test background survival)
+
+${C_BOLD}Options:${C_RESET}
+  --release             Use the release build variant (build/install)
+  --headless            Run the emulator without a window (start)
+  -h, --help            Show this help
+
+${C_BOLD}Environment${C_RESET} (see scripts/cli/env.sh):
+  VIRTUE_AVD=$VIRTUE_AVD
+  VIRTUE_PACKAGE=$VIRTUE_PACKAGE
+  ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT
+
+${C_BOLD}Examples:${C_RESET}
+  va start --headless     # boot a windowless emulator
+  va install              # build debug, install, launch
+  va build --release      # produce a release APK
+  va force-idle           # push the app into Doze
+EOF
+}
+
+# --- arg parsing -----------------------------------------------------------
+RELEASE=0
+HEADLESS=0
+CMD=""
+for arg in "$@"; do
+  case "$arg" in
+    --release)  RELEASE=1 ;;
+    --headless) HEADLESS=1 ;;
+    -h|--help)  usage; exit 0 ;;
+    -*)         die "unknown option: $arg (try 'va --help')" ;;
+    *)          [ -z "$CMD" ] && CMD="$arg" || die "unexpected argument: $arg" ;;
+  esac
+done
+
+case "$CMD" in
+  install)    cmd_install ;;
+  build)      cmd_build ;;
+  start)      cmd_start ;;
+  stop)       cmd_stop ;;
+  lock)       cmd_lock ;;
+  force-idle) cmd_force_idle ;;
+  "")         usage; exit 1 ;;
+  *)          die "unknown command: $CMD (try 'va --help')" ;;
+esac

--- a/client/core/src/assembly.rs
+++ b/client/core/src/assembly.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::api::{ApiTransport, ReqwestApiClient};
 use crate::config::Config;
 use crate::error::CoreResult;
@@ -40,7 +42,7 @@ where
     let observers: Vec<Box<dyn Observer>> = vec![
         Box::new(LifecycleModule::new(Box::new(platform.clone()))),
         Box::new(ScreenshotModule::new(
-            Box::new(platform.clone()),
+            Arc::new(platform.clone()),
             screenshot_interval_ms,
         )),
         Box::new(UploadModule::new(

--- a/client/core/src/events/bus.rs
+++ b/client/core/src/events/bus.rs
@@ -1,7 +1,10 @@
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    sync::mpsc::{self, Receiver, Sender},
+    sync::{
+        Arc,
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -108,6 +111,26 @@ pub trait Observer: 'static {
 /// registered under, so the inner downcast always succeeds.
 type Handler = Box<dyn Fn(&dyn Any) + Send + Sync>;
 
+/// Runs a detached background job on behalf of [`Emitter::spawn`].
+///
+/// Production uses [`ThreadSpawner`] (a real OS thread). Tests can substitute an
+/// inline spawner that runs the job immediately, so events the job emits cascade
+/// within the **same** `iter()` and stay deterministic.
+pub trait Spawner: Send + Sync + 'static {
+    fn spawn(&self, job: Box<dyn FnOnce() + Send + 'static>);
+}
+
+/// Production [`Spawner`]: runs each job on a detached `std::thread`. Core's
+/// `tokio` only enables the `time` feature (no runtime), so we use a real OS
+/// thread rather than `tokio::spawn`.
+pub struct ThreadSpawner;
+
+impl Spawner for ThreadSpawner {
+    fn spawn(&self, job: Box<dyn FnOnce() + Send + 'static>) {
+        std::thread::spawn(job);
+    }
+}
+
 /// A cheap, cloneable handle for publishing events.
 ///
 /// Handlers must be `'static`, so they cannot borrow the [`EventBus`]. Instead
@@ -116,6 +139,7 @@ type Handler = Box<dyn Fn(&dyn Any) + Send + Sync>;
 #[derive(Clone)]
 pub struct Emitter {
     tx: Sender<AnyEvent>,
+    spawner: Arc<dyn Spawner>,
 }
 
 impl Emitter {
@@ -125,6 +149,27 @@ impl Emitter {
             .send(Box::new(event))
             .map_err(|_| CoreError::InvalidState("event bus channel closed"))
     }
+
+    /// Hand heavy work to a background job that emits a follow-up event when it
+    /// finishes — letting a sync handler offload a slow capture/upload without
+    /// stalling the single-threaded event loop. The task receives its own
+    /// `Emitter` clone; events it sends land on the queue and drain on the next
+    /// `iter()` (≤1s, next `Ping`). If the task returns `Err`, an [`Error`] event
+    /// is emitted in its place so the failure still propagates.
+    pub fn spawn<F>(&self, task: F)
+    where
+        F: FnOnce(&Emitter) -> CoreResult<()> + Send + 'static,
+    {
+        let em = self.clone();
+        self.spawner.spawn(Box::new(move || {
+            if let Err(err) = task(&em) {
+                let _ = em.send(Error {
+                    source: "spawn".into(),
+                    message: err.to_string(),
+                });
+            }
+        }));
+    }
 }
 
 pub struct EventBus {
@@ -132,6 +177,7 @@ pub struct EventBus {
     handlers: HashMap<TypeId, Vec<Handler>>,
     tx: Sender<AnyEvent>,
     rx: Receiver<AnyEvent>,
+    spawner: Arc<dyn Spawner>,
 }
 
 impl EventBus {
@@ -144,12 +190,23 @@ impl EventBus {
     ///
     /// [`save`]: EventBus::save
     pub fn new(observers: Vec<Box<dyn Observer>>, state: StateType) -> CoreResult<Self> {
+        Self::with_spawner(observers, state, Arc::new(ThreadSpawner))
+    }
+
+    /// Like [`EventBus::new`] but with an explicit [`Spawner`]. Tests pass an
+    /// inline spawner so background jobs run synchronously and deterministically.
+    pub fn with_spawner(
+        observers: Vec<Box<dyn Observer>>,
+        state: StateType,
+        spawner: Arc<dyn Spawner>,
+    ) -> CoreResult<Self> {
         let (tx, rx) = mpsc::channel();
         let mut bus = Self {
             observers: Vec::with_capacity(observers.len()),
             handlers: HashMap::new(),
             tx,
             rx,
+            spawner,
         };
 
         for mut observer in observers {
@@ -201,6 +258,7 @@ impl EventBus {
     pub fn emitter(&self) -> Emitter {
         Emitter {
             tx: self.tx.clone(),
+            spawner: Arc::clone(&self.spawner),
         }
     }
 
@@ -572,5 +630,193 @@ mod tests {
             seen, 1,
             "cascade must complete despite the failing observer"
         );
+    }
+
+    /// Observer that, for every `Tick`, spawns a background job that emits a `Tock`.
+    struct SpawnObserver;
+    impl Observer for SpawnObserver {
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+        fn init(&mut self, _bus: &mut EventBus, _state: StateType) -> CoreResult<()> {
+            Ok(())
+        }
+        fn on_event(&mut self, event: &dyn Any, emitter: &Emitter) -> CoreResult<()> {
+            crate::dispatch_event!(event, {
+                tick: Tick => {
+                    let n = tick.n;
+                    emitter.spawn(move |em| em.send(Tock { n }));
+                    Ok(())
+                },
+            })
+        }
+        fn save(&self) -> CoreResult<StateType> {
+            Ok(StateType::Null)
+        }
+        fn name(&self) -> &'static str {
+            "spawn_observer"
+        }
+    }
+
+    /// Counts only `Tock` events (and, unlike `Counter`, emits nothing on `Tick`) so
+    /// the spawn tests observe exactly the `Tock`s produced by spawned jobs.
+    struct TockCounter {
+        seen: u32,
+    }
+    impl Observer for TockCounter {
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+        fn init(&mut self, _bus: &mut EventBus, _state: StateType) -> CoreResult<()> {
+            Ok(())
+        }
+        fn on_event(&mut self, event: &dyn Any, _emitter: &Emitter) -> CoreResult<()> {
+            if event.is::<Tock>() {
+                self.seen += 1;
+            }
+            Ok(())
+        }
+        fn save(&self) -> CoreResult<StateType> {
+            Ok(StateType::Null)
+        }
+        fn name(&self) -> &'static str {
+            "tock_counter"
+        }
+    }
+
+    fn tocks_seen(bus: &mut EventBus) -> u32 {
+        bus.observer_mut("tock_counter")
+            .unwrap()
+            .as_any_mut()
+            .downcast_mut::<TockCounter>()
+            .unwrap()
+            .seen
+    }
+
+    #[test]
+    fn inline_spawner_cascades_within_single_iter() {
+        // With the inline spawner the job runs synchronously, so the `Tock` it emits
+        // cascades within the same `iter()` and the counter sees it.
+        let mut bus = EventBus::with_spawner(
+            vec![Box::new(SpawnObserver), Box::new(TockCounter { seen: 0 })],
+            StateType::Null,
+            Arc::new(crate::testing::InlineSpawner),
+        )
+        .unwrap();
+
+        bus.send(Tick { n: 1 }).unwrap();
+        bus.iter().unwrap();
+
+        assert_eq!(tocks_seen(&mut bus), 1);
+    }
+
+    #[test]
+    fn thread_spawner_delivers_on_a_later_iter() {
+        use std::time::Duration;
+
+        // The default `new()` uses `ThreadSpawner`: the job runs on a background thread,
+        // so its `Tock` is not visible in the same `iter()` — it arrives on a later one.
+        let mut bus = EventBus::new(
+            vec![Box::new(SpawnObserver), Box::new(TockCounter { seen: 0 })],
+            StateType::Null,
+        )
+        .unwrap();
+
+        bus.send(Tick { n: 1 }).unwrap();
+        bus.iter().unwrap();
+
+        // Poll subsequent iters until the background job's event lands.
+        let mut seen = tocks_seen(&mut bus);
+        for _ in 0..200 {
+            if seen == 1 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+            bus.iter().unwrap();
+            seen = tocks_seen(&mut bus);
+        }
+        assert_eq!(
+            seen, 1,
+            "background job's event must arrive on a later iter"
+        );
+    }
+
+    #[test]
+    fn spawn_job_error_emits_error_event() {
+        // A spawned task that returns `Err` must surface as an `Error` event (sourced
+        // from "spawn"). Inline spawner keeps it deterministic within one `iter()`.
+        struct SpawnFail;
+        impl Observer for SpawnFail {
+            fn as_any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+            fn init(&mut self, _bus: &mut EventBus, _state: StateType) -> CoreResult<()> {
+                Ok(())
+            }
+            fn on_event(&mut self, event: &dyn Any, emitter: &Emitter) -> CoreResult<()> {
+                crate::dispatch_event!(event, {
+                    _: Tick => {
+                        emitter.spawn(|_em| Err(CoreError::InvalidState("boom")));
+                        Ok(())
+                    },
+                })
+            }
+            fn save(&self) -> CoreResult<StateType> {
+                Ok(StateType::Null)
+            }
+            fn name(&self) -> &'static str {
+                "spawn_fail"
+            }
+        }
+
+        struct Capture {
+            errors: Vec<Error>,
+        }
+        impl Observer for Capture {
+            fn as_any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+            fn init(&mut self, _bus: &mut EventBus, _state: StateType) -> CoreResult<()> {
+                Ok(())
+            }
+            fn on_event(&mut self, event: &dyn Any, _emitter: &Emitter) -> CoreResult<()> {
+                crate::dispatch_event!(event, {
+                    err: Error => {
+                        self.errors.push(err.clone());
+                        Ok(())
+                    },
+                })
+            }
+            fn save(&self) -> CoreResult<StateType> {
+                Ok(StateType::Null)
+            }
+            fn name(&self) -> &'static str {
+                "capture"
+            }
+        }
+
+        let mut bus = EventBus::with_spawner(
+            vec![
+                Box::new(SpawnFail),
+                Box::new(Capture { errors: Vec::new() }),
+            ],
+            StateType::Null,
+            Arc::new(crate::testing::InlineSpawner),
+        )
+        .unwrap();
+
+        bus.send(Tick { n: 1 }).unwrap();
+        bus.iter().unwrap();
+
+        let errors = &bus
+            .observer_mut("capture")
+            .unwrap()
+            .as_any_mut()
+            .downcast_mut::<Capture>()
+            .unwrap()
+            .errors;
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].source.contains("spawn"));
+        assert!(errors[0].message.contains("boom"));
     }
 }

--- a/client/core/src/module/lifecycle.rs
+++ b/client/core/src/module/lifecycle.rs
@@ -36,6 +36,12 @@ pub struct UserStopRequested {
 use crate::platform::ScreenshotHooks;
 
 pub(crate) const EXTRA_HIGH_RISK: f32 = 0.9;
+/// High-risk lifecycle alerts that are still noteworthy but don't warrant an
+/// immediate notification. The upload module routes `risk >= EXTRA_HIGH_RISK`
+/// through the immediate (emailed) path; keeping these just below that threshold
+/// flags them as high for review/sorting while letting them ride the normal
+/// batch — so common, non-urgent alerts (e.g. a ping gap) don't send an email.
+pub(crate) const HIGH_RISK_LIFECYCLE_ALERT: f32 = 0.8;
 pub(crate) const MEDIUM_RISK_LIFECYCLE_ALERT: f32 = 0.6;
 
 // Sliding-window ping-gap detection. A single slow loop iteration (e.g. a heavy
@@ -206,7 +212,7 @@ impl LifecycleModule {
             };
             if ping_gap > 10000 && (now_ms - boot_ms) > 120000 {
                 let _ = emitter.send(Upload {
-                    risk: EXTRA_HIGH_RISK,
+                    risk: HIGH_RISK_LIFECYCLE_ALERT,
                     kind: UploadKind::LifecycleAlert {
                         reason: AlertReason::UnexpectedProcessStart,
                     },
@@ -311,8 +317,10 @@ impl LifecycleModule {
                 self.state.last_ping_gap_alert = now_ms;
                 // Note: `ping_gaps` is intentionally NOT cleared — chronic stalls keep
                 // re-alerting each cooldown, while one-off bursts age out of the window.
+                // High risk but below the immediate-upload threshold: a ping gap is
+                // batched (no email), not sent immediately.
                 let _ = emitter.send(Upload {
-                    risk: EXTRA_HIGH_RISK,
+                    risk: HIGH_RISK_LIFECYCLE_ALERT,
                     kind: UploadKind::LifecycleAlert {
                         reason: AlertReason::PingGapWhileRunning,
                     },
@@ -439,7 +447,7 @@ mod tests {
         ComputerResumed, ComputerSuspended, ProcessStarted, ProcessStopped, UserSessionLogin,
         UserSessionLogout,
     };
-    use super::{LifecycleModule, LifecycleStatus};
+    use super::{EXTRA_HIGH_RISK, HIGH_RISK_LIFECYCLE_ALERT, LifecycleModule, LifecycleStatus};
     use crate::events::Ping;
     use crate::model::PartialStatus;
     use crate::model::{AlertReason, LifecycleKind, ProcessStoppedReason, UploadKind};
@@ -704,7 +712,13 @@ mod tests {
                 )
             })
             .unwrap();
-        assert!(alert.risk >= 0.9, "ping gap alert should be high risk");
+        // High risk for review, but below the immediate-upload threshold so it batches
+        // (no email) rather than firing an immediate alert.
+        assert!(
+            alert.risk >= HIGH_RISK_LIFECYCLE_ALERT && alert.risk < EXTRA_HIGH_RISK,
+            "ping gap alert should be high but not immediate, got {}",
+            alert.risk
+        );
     }
 
     #[test]

--- a/client/core/src/module/lifecycle.rs
+++ b/client/core/src/module/lifecycle.rs
@@ -38,6 +38,16 @@ use crate::platform::ScreenshotHooks;
 pub(crate) const EXTRA_HIGH_RISK: f32 = 0.9;
 pub(crate) const MEDIUM_RISK_LIFECYCLE_ALERT: f32 = 0.6;
 
+// Sliding-window ping-gap detection. A single slow loop iteration (e.g. a heavy
+// capture/classify) can briefly stall pings; alerting on one blip is twitchy, so
+// we sum the time lost to over-threshold gaps inside a sliding window and only
+// alert when that sustained gap budget is exceeded. (These may move to config later.)
+const PING_GAP_PER_GAP_THRESHOLD_MS: i64 = 10_000; // a gap must exceed 10s to count
+const PING_GAP_WINDOW_MS: i64 = 10 * 60 * 1_000; // 10-min sliding window
+const PING_GAP_BUDGET_MS: i64 = 60_000; // alert when counted gap time ≥ 60s in window
+const PING_GAP_ALERT_COOLDOWN_MS: i64 = 5 * 60 * 1_000; // ≤ one alert per 5 min
+const LIFECYCLE_LOGIN_GRACE_MS: i64 = 120_000; // grace after login before gap alerts
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub enum LifecycleStatus {
     #[default]
@@ -68,6 +78,14 @@ pub struct LifecycleObserverState {
 
     // User stop tracking
     pub user_stop_requested: bool,
+
+    // Sliding-window ping-gap detection. `ping_gaps` holds `(ts_ms, gap_ms)` for
+    // each gap that exceeded the per-gap threshold; entries age out of the window.
+    // `last_ping_gap_alert` is the cooldown anchor (0 = never alerted).
+    #[serde(default)]
+    pub ping_gaps: Vec<(i64, i64)>,
+    #[serde(default)]
+    pub last_ping_gap_alert: i64,
 }
 
 pub struct LifecycleModule {
@@ -266,10 +284,33 @@ impl LifecycleModule {
         self.maybe_backfill_missed_events(last_shutdown, startup_time_ms, emitter)?;
         self.state.last_ping = now_ms;
 
-        if now_ms - old.last_login > 120000 {
+        if now_ms - old.last_login > LIFECYCLE_LOGIN_GRACE_MS {
             let ping_gap = now_ms - old.last_ping;
             let start_gap = now_ms - old.last_running_started;
-            if old.last_ping > 0 && ping_gap > 10000 && start_gap > 10000 {
+
+            // Record this gap if it's a real over-threshold stall (and not the first
+            // ping after start, where `last_ping` is 0 or the process just began).
+            if old.last_ping > 0
+                && ping_gap > PING_GAP_PER_GAP_THRESHOLD_MS
+                && start_gap > PING_GAP_PER_GAP_THRESHOLD_MS
+            {
+                self.state.ping_gaps.push((now_ms, ping_gap));
+            }
+
+            // Prune to the sliding window, then sum the gap time that remains.
+            let window_start = now_ms - PING_GAP_WINDOW_MS;
+            self.state.ping_gaps.retain(|(ts, _)| *ts >= window_start);
+            let total_gap: i64 = self.state.ping_gaps.iter().map(|(_, gap)| *gap).sum();
+
+            // The `== 0` short-circuit keeps the very first alert from being suppressed
+            // by the cooldown (which is anchored at 0 = "never alerted").
+            let cooldown_ok = self.state.last_ping_gap_alert == 0
+                || now_ms - self.state.last_ping_gap_alert >= PING_GAP_ALERT_COOLDOWN_MS;
+
+            if total_gap >= PING_GAP_BUDGET_MS && cooldown_ok {
+                self.state.last_ping_gap_alert = now_ms;
+                // Note: `ping_gaps` is intentionally NOT cleared — chronic stalls keep
+                // re-alerting each cooldown, while one-off bursts age out of the window.
                 let _ = emitter.send(Upload {
                     risk: EXTRA_HIGH_RISK,
                     kind: UploadKind::LifecycleAlert {
@@ -686,6 +727,118 @@ mod tests {
     }
 
     #[test]
+    fn sub_budget_ping_gap_does_not_alert() {
+        let mut b = EventTester::builder();
+        b.add(LifecycleModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        // Seed a running process whose last ping is already past the login grace
+        // window (last_login stays 0).
+        {
+            let s = &mut t.observer::<LifecycleModule>().state;
+            s.last_running_started = 1_000;
+            s.last_ping = 130_000;
+        }
+        // A single 30s gap: over the 10s per-gap threshold (so it's recorded) but
+        // under the 60s sliding-window budget, so no alert fires.
+        t.emit(160, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+        assert_eq!(t.observer::<LifecycleModule>().state.ping_gaps.len(), 1);
+    }
+
+    #[test]
+    fn accumulated_ping_gaps_cross_budget_and_alert() {
+        let mut b = EventTester::builder();
+        b.add(LifecycleModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        {
+            let s = &mut t.observer::<LifecycleModule>().state;
+            s.last_running_started = 1_000;
+            s.last_ping = 130_000;
+        }
+        // Three 25s gaps: 25 → 50 (both under the 60s budget), then 75 ≥ 60 alerts.
+        t.emit(155, Ping);
+        t.emit(180, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+        t.clear_captured();
+        t.emit(205, Ping);
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+    }
+
+    #[test]
+    fn aged_out_ping_gaps_are_pruned_and_do_not_alert() {
+        let mut b = EventTester::builder();
+        b.add(LifecycleModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        // An old 50s gap recorded ~700s before "now"; it sits outside the 10-min
+        // window once the new ping lands and must be pruned before summing.
+        {
+            let s = &mut t.observer::<LifecycleModule>().state;
+            s.last_running_started = 1_000;
+            s.last_ping = 750_000;
+            s.ping_gaps = vec![(100_000, 50_000)];
+        }
+        // New 50s gap. Without pruning, 50 + 50 = 100 ≥ 60 would alert; with pruning
+        // the aged entry drops and only the fresh 50s remains (< 60s budget).
+        t.emit(800, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+        // Old entry pruned, new entry kept.
+        assert_eq!(t.observer::<LifecycleModule>().state.ping_gaps.len(), 1);
+    }
+
+    #[test]
+    fn cooldown_suppresses_repeat_ping_gap_alert() {
+        let mut b = EventTester::builder();
+        b.add(LifecycleModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        // Seed a state that already alerted recently with enough banked gap time to
+        // cross the budget again.
+        {
+            let s = &mut t.observer::<LifecycleModule>().state;
+            s.last_running_started = 1_000;
+            s.last_ping = 200_000;
+            s.last_ping_gap_alert = 190_000;
+            s.ping_gaps = vec![(199_000, 70_000)];
+        }
+        // 40s after the last alert (< 5-min cooldown): budget exceeded but suppressed.
+        t.emit(230, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+        // Well past the cooldown: the chronic stall re-alerts.
+        t.clear_captured();
+        t.emit(600, Ping);
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+    }
+
+    #[test]
     fn process_killed_before_shutdown_emits_alert() {
         let mut b = EventTester::builder();
         b.add(LifecycleModule::new(Box::new(b.platform())));
@@ -810,6 +963,13 @@ mod tests {
         t.emit(99, Ping); // pings_while_suspended = 1
         t.emit(99, Ping); // pings_while_suspended = 2
 
+        // Seed sliding-window ping-gap state so the round-trip covers it too.
+        {
+            let s = &mut t.observer::<LifecycleModule>().state;
+            s.ping_gaps = vec![(80_000, 15_000), (95_000, 20_000)];
+            s.last_ping_gap_alert = 95_000;
+        }
+
         {
             let s = &t.observer::<LifecycleModule>().state;
             assert_eq!(s.last_login, 30_000);
@@ -832,5 +992,7 @@ mod tests {
         assert_eq!(s2.last_ping, 99_000);
         assert_eq!(s2.pings_while_suspended, 2);
         assert!(matches!(s2.status, LifecycleStatus::Suspended));
+        assert_eq!(s2.ping_gaps, vec![(80_000, 15_000), (95_000, 20_000)]);
+        assert_eq!(s2.last_ping_gap_alert, 95_000);
     }
 }

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -3,6 +3,7 @@ pub mod image_pipeline;
 pub mod risk_classifier;
 
 use std::any::Any;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +22,17 @@ const MODEL_BYTES: &[u8] = include_bytes!("../../models/nsfw_small_v1.onnx");
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CaptureFailed;
+
+/// In-process event emitted by the background capture job when it finishes (on
+/// **every** branch, including failure) so the module can clear its in-flight
+/// guard. Never serialized to the network — it only travels the local bus.
+///
+/// `update_fingerprint` is `Some` only when a frame was actually uploaded and
+/// its fingerprint computed; the module then advances its dedup anchor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreenshotCaptured {
+    pub update_fingerprint: Option<fingerprint::Fingerprint>,
+}
 
 #[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(default)]
@@ -54,22 +66,32 @@ where
 
 pub struct ScreenshotModule {
     pub state: ScreenshotObserverState,
-    platform: Box<dyn ScreenshotHooks>,
+    /// Shared so a background capture job can hold its own handle (`Arc`, no
+    /// `Mutex` — `ScreenshotHooks` is `Send + Sync`).
+    platform: Arc<dyn ScreenshotHooks>,
     pub screenshot_interval_ms: i64,
-    classifier: Option<RiskClassifier>,
+    /// Shared with the background capture job. `RiskClassifier` is `Send + Sync`
+    /// (tract op types are), so an `Arc` crosses threads without a `Mutex`.
+    classifier: Option<Arc<RiskClassifier>>,
+    /// True while a background capture is running. A **module field**, never
+    /// persisted to `event_state.json`, so a crash/restart can't leave it stuck
+    /// true. Guards against launching overlapping captures when one runs longer
+    /// than the screenshot interval.
+    capture_in_flight: bool,
 }
 
 impl ScreenshotModule {
-    pub fn new(platform: Box<dyn ScreenshotHooks>, screenshot_interval_ms: i64) -> Self {
+    pub fn new(platform: Arc<dyn ScreenshotHooks>, screenshot_interval_ms: i64) -> Self {
         #[cfg(not(test))]
-        let classifier = RiskClassifier::new(MODEL_BYTES).ok();
+        let classifier = RiskClassifier::new(MODEL_BYTES).ok().map(Arc::new);
         #[cfg(test)]
-        let classifier: Option<RiskClassifier> = None;
+        let classifier: Option<Arc<RiskClassifier>> = None;
         Self {
             state: ScreenshotObserverState::default(),
             platform,
             screenshot_interval_ms,
             classifier,
+            capture_in_flight: false,
         }
     }
 
@@ -96,14 +118,14 @@ impl ScreenshotModule {
             return Ok(());
         }
 
-        // Gate 1 — locked / screensaver: checked *before* capturing. While locked or
-        // screensaving the user cannot be viewing real content, so skip the capture
-        // entirely (saving capture + classification cost) and emit a lightweight
-        // `ScreenshotSkipped` log so the feed records that monitoring was active. We
-        // advance the cadence clock so pacing continues and we re-check next interval
-        // (skip events fire at most once per screenshot interval); the last-uploaded
-        // fingerprint is left untouched. Fail-safe is `false` (fall back to the diff
-        // gate), never silently suppress.
+        // Gate 1 — locked / screensaver: checked *before* capturing (inline, cheap).
+        // While locked or screensaving the user cannot be viewing real content, so skip
+        // the capture entirely (saving capture + classification cost) and emit a
+        // lightweight `ScreenshotSkipped` log so the feed records that monitoring was
+        // active. We advance the cadence clock so pacing continues and we re-check next
+        // interval (skip events fire at most once per screenshot interval); the
+        // last-uploaded fingerprint is left untouched. No background work is spawned.
+        // Fail-safe is `false` (fall back to the diff gate), never silently suppress.
         if self.platform.is_locked_or_screensaver()? {
             self.state.last_screenshot_at_ms = Some(now_ms);
             let _ = emitter.send(Upload {
@@ -115,57 +137,112 @@ impl ScreenshotModule {
             return Ok(());
         }
 
-        let screenshot = match self.platform.take_screenshot() {
-            Ok(s) => s,
-            Err(_) => {
-                let _ = emitter.send(CaptureFailed);
-                return Ok(());
-            }
-        };
-        self.state.last_screenshot_at_ms = Some(now_ms);
-
-        // Gate 2 — screen-change diff vs the last *uploaded* frame. A failed fingerprint
-        // is `None`, which falls through to the upload path (fail-safe to upload). With no
-        // prior uploaded fingerprint we always upload the first frame.
-        let fingerprint = fingerprint::fingerprint(&screenshot.bytes).ok();
-        let static_frame = match (
-            self.state.last_uploaded_fingerprint.as_ref(),
-            fingerprint.as_ref(),
-        ) {
-            (Some(prev), Some(cur)) => !fingerprint::changed(prev, cur),
-            _ => false,
-        };
-        if static_frame {
-            // Redundant frame: suppress image upload + classification, keep the anchor
-            // fingerprint, but record a lightweight `ScreenshotSkipped` log so the feed
-            // shows the screen was static rather than leaving an unexplained gap.
-            let _ = emitter.send(Upload {
-                risk: 0.0,
-                kind: UploadKind::ScreenshotSkipped {
-                    reason: ScreenshotSkipReason::StaticScreen,
-                },
-            });
+        // Overlap guard: a previous capture is still running on a background thread.
+        // Skip this interval rather than stacking captures (covers captures slower than
+        // the screenshot interval).
+        if self.capture_in_flight {
             return Ok(());
         }
 
-        let risk = self
-            .classifier
-            .as_ref()
-            .and_then(|c| c.classify(&screenshot.bytes).ok())
-            .unwrap_or(0.0);
-        let processed = image_pipeline::ImagePipeline.process(screenshot)?;
-        let _ = emitter.send(Upload {
-            risk,
-            kind: UploadKind::Screenshot {
-                image: processed.bytes,
-                content_type: processed.content_type,
-            },
+        // Hand the heavy work (capture → fingerprint → classify → image-process) to a
+        // background thread so a slow capture can't stall the daemon's event loop and
+        // trip a false `PingGapWhileRunning`. Advance the cadence clock and set the
+        // in-flight guard *before* spawning so pacing continues while it runs; the guard
+        // is cleared when the terminal `ScreenshotCaptured` event arrives.
+        self.capture_in_flight = true;
+        self.state.last_screenshot_at_ms = Some(now_ms);
+
+        let platform = Arc::clone(&self.platform);
+        let classifier = self.classifier.clone();
+        let anchor = self.state.last_uploaded_fingerprint.clone();
+        emitter.spawn(move |em| {
+            run_capture(
+                platform.as_ref(),
+                classifier.as_deref(),
+                anchor.as_ref(),
+                em,
+            )
         });
-        if let Some(fingerprint) = fingerprint {
-            self.state.last_uploaded_fingerprint = Some(fingerprint);
-        }
+
         Ok(())
     }
+}
+
+/// Heavy screenshot pipeline run off the event loop (capture → fingerprint diff →
+/// classify → image process). Thread-free and unit-testable on its own.
+///
+/// Emits **exactly one** [`ScreenshotCaptured`] on every branch so the module's
+/// in-flight guard always clears, plus the appropriate payload:
+/// - capture error → [`CaptureFailed`] + `ScreenshotCaptured { None }`,
+/// - static vs anchor → `Upload { ScreenshotSkipped { StaticScreen } }` + `{ None }`,
+/// - else → `Upload { Screenshot { .. } }` + `ScreenshotCaptured { Some(fp) }` (`Some`
+///   only when the fingerprint computed, matching the prior dedup behavior).
+fn run_capture(
+    platform: &dyn ScreenshotHooks,
+    classifier: Option<&RiskClassifier>,
+    anchor: Option<&fingerprint::Fingerprint>,
+    emitter: &Emitter,
+) -> CoreResult<()> {
+    let screenshot = match platform.take_screenshot() {
+        Ok(s) => s,
+        Err(_) => {
+            let _ = emitter.send(CaptureFailed);
+            let _ = emitter.send(ScreenshotCaptured {
+                update_fingerprint: None,
+            });
+            return Ok(());
+        }
+    };
+
+    // Gate 2 — screen-change diff vs the last *uploaded* frame. A failed fingerprint
+    // is `None`, which falls through to the upload path (fail-safe to upload). With no
+    // prior uploaded fingerprint we always upload the first frame.
+    let fingerprint = fingerprint::fingerprint(&screenshot.bytes).ok();
+    let static_frame = match (anchor, fingerprint.as_ref()) {
+        (Some(prev), Some(cur)) => !fingerprint::changed(prev, cur),
+        _ => false,
+    };
+    if static_frame {
+        // Redundant frame: suppress image upload + classification, keep the anchor
+        // fingerprint, but record a lightweight `ScreenshotSkipped` log so the feed
+        // shows the screen was static rather than leaving an unexplained gap.
+        let _ = emitter.send(Upload {
+            risk: 0.0,
+            kind: UploadKind::ScreenshotSkipped {
+                reason: ScreenshotSkipReason::StaticScreen,
+            },
+        });
+        let _ = emitter.send(ScreenshotCaptured {
+            update_fingerprint: None,
+        });
+        return Ok(());
+    }
+
+    let risk = classifier
+        .and_then(|c| c.classify(&screenshot.bytes).ok())
+        .unwrap_or(0.0);
+    let processed = match image_pipeline::ImagePipeline.process(screenshot) {
+        Ok(p) => p,
+        Err(err) => {
+            // Clear the in-flight guard even when image processing fails, then let the
+            // error propagate (the bus turns it into an `Error` event).
+            let _ = emitter.send(ScreenshotCaptured {
+                update_fingerprint: None,
+            });
+            return Err(err);
+        }
+    };
+    let _ = emitter.send(Upload {
+        risk,
+        kind: UploadKind::Screenshot {
+            image: processed.bytes,
+            content_type: processed.content_type,
+        },
+    });
+    let _ = emitter.send(ScreenshotCaptured {
+        update_fingerprint: fingerprint,
+    });
+    Ok(())
 }
 
 impl Observer for ScreenshotModule {
@@ -200,6 +277,13 @@ impl Observer for ScreenshotModule {
                 Ok(())
             },
             _: Ping => self.handle_ping(emitter),
+            ev: ScreenshotCaptured => {
+                self.capture_in_flight = false;
+                if let Some(fp) = &ev.update_fingerprint {
+                    self.state.last_uploaded_fingerprint = Some(fp.clone());
+                }
+                Ok(())
+            },
             ev: ConfigChanged => {
                 self.screenshot_interval_ms = ev.screenshot_interval_ms as i64;
                 Ok(())
@@ -247,7 +331,7 @@ mod tests {
     #[test]
     fn ping_when_logged_out_does_nothing() {
         let mut b = EventTester::builder();
-        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
         let mut t = b.build();
         t.emit(1, Ping);
         assert!(t.captured::<Upload>().is_empty());
@@ -257,7 +341,7 @@ mod tests {
     #[test]
     fn login_then_ping_takes_screenshot() {
         let mut b = EventTester::builder();
-        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
         let mut t = b.build();
         t.emit(1, test_login());
         t.clear_captured();
@@ -273,7 +357,7 @@ mod tests {
     fn screenshot_not_retaken_before_interval() {
         let mut b = EventTester::builder();
         b.clock.set(30_000);
-        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        let mut module = ScreenshotModule::new(Arc::new(b.platform()), 60_000);
         module.state.enabled = true;
         module.state.last_screenshot_at_ms = Some(0);
         b.add(module);
@@ -286,7 +370,7 @@ mod tests {
     fn screenshot_retaken_after_interval() {
         let mut b = EventTester::builder();
         b.clock.set(61_000);
-        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        let mut module = ScreenshotModule::new(Arc::new(b.platform()), 60_000);
         module.state.enabled = true;
         module.state.last_screenshot_at_ms = Some(0);
         b.add(module);
@@ -305,7 +389,7 @@ mod tests {
         let mut b = EventTester::builder();
         b.platform()
             .set_default_screenshot(solid_png_screenshot(100));
-        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
         let mut t = b.build();
         t.emit(1, test_login());
         t.clear_captured();
@@ -335,7 +419,7 @@ mod tests {
         let mut b = EventTester::builder();
         b.platform()
             .set_default_screenshot(solid_png_screenshot(100));
-        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
         let mut t = b.build();
         t.emit(1, test_login());
         t.emit(1, Ping); // baseline upload (solid 100)
@@ -353,7 +437,7 @@ mod tests {
     fn locked_skips_capture_entirely() {
         let mut b = EventTester::builder();
         b.platform().set_locked_or_screensaver(true);
-        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        let mut module = ScreenshotModule::new(Arc::new(b.platform()), 60_000);
         module.state.enabled = true;
         b.add(module);
         let mut t = b.build();
@@ -382,7 +466,7 @@ mod tests {
     fn unlock_resumes_capture() {
         let mut b = EventTester::builder();
         b.platform().set_locked_or_screensaver(true);
-        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        let mut module = ScreenshotModule::new(Arc::new(b.platform()), 60_000);
         module.state.enabled = true;
         b.add(module);
         let mut t = b.build();
@@ -415,7 +499,7 @@ mod tests {
             }
         });
         let mut b = EventTester::builder();
-        b.add(ScreenshotModule::new(Box::new(b.platform()), 60_000));
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
         b.with_state(saved);
         let mut t = b.build();
         let st = &t.observer::<ScreenshotModule>().state;
@@ -430,7 +514,7 @@ mod tests {
     #[test]
     fn logout_disables_and_resets_schedule() {
         let mut b = EventTester::builder();
-        let mut module = ScreenshotModule::new(Box::new(b.platform()), 60_000);
+        let mut module = ScreenshotModule::new(Arc::new(b.platform()), 60_000);
         module.state.enabled = true;
         module.state.last_screenshot_at_ms = Some(500);
         b.add(module);
@@ -441,5 +525,118 @@ mod tests {
             t.observer::<ScreenshotModule>().state.last_screenshot_at_ms,
             None
         );
+    }
+
+    #[test]
+    fn capture_completion_updates_fingerprint_and_clears_flag() {
+        use crate::testing::fixtures::solid_png_screenshot;
+        let mut b = EventTester::builder();
+        b.platform()
+            .set_default_screenshot(solid_png_screenshot(100));
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
+        let mut t = b.build();
+        t.emit(1, test_login());
+        t.emit(1, Ping);
+        // The inline spawner runs the whole capture pipeline synchronously, so by now
+        // the terminal `ScreenshotCaptured` has updated the dedup anchor and cleared
+        // the in-flight guard.
+        let m = t.observer::<ScreenshotModule>();
+        assert!(
+            m.state.last_uploaded_fingerprint.is_some(),
+            "anchor fingerprint should be set after a successful upload"
+        );
+        assert!(!m.capture_in_flight, "in-flight guard should be cleared");
+    }
+
+    #[test]
+    fn capture_failure_emits_capture_failed_and_clears_flag() {
+        let mut b = EventTester::builder();
+        b.add(ScreenshotModule::new(Arc::new(b.platform()), 60_000));
+        b.capture::<CaptureFailed>();
+        let mut t = b.build();
+        t.emit(1, test_login());
+        t.clear_captured();
+        // Next capture fails; the failure path must still emit `CaptureFailed` and clear
+        // the in-flight guard so future pings aren't permanently blocked.
+        t.platform
+            .queue_screenshot(Err(crate::error::CoreError::CommandFailed("boom".into())));
+        t.emit(1, Ping);
+        assert_eq!(t.captured::<CaptureFailed>().len(), 1);
+        assert!(
+            !t.observer::<ScreenshotModule>().capture_in_flight,
+            "in-flight guard should clear even when capture fails"
+        );
+    }
+
+    #[test]
+    fn in_flight_guard_prevents_overlapping_captures() {
+        use std::sync::{Arc, Mutex};
+
+        use crate::events::Ping;
+        use crate::events::bus::{EventBus, Spawner, StateType};
+        use crate::testing::TestPlatformHooks;
+
+        type Job = Box<dyn FnOnce() + Send + 'static>;
+
+        // Spawner that holds jobs until explicitly run, so we can observe the module
+        // while a capture is mid-flight.
+        #[derive(Clone, Default)]
+        struct DeferringSpawner {
+            jobs: Arc<Mutex<Vec<Job>>>,
+        }
+        impl DeferringSpawner {
+            fn pending(&self) -> usize {
+                self.jobs.lock().unwrap().len()
+            }
+            fn run_all(&self) {
+                let jobs: Vec<_> = std::mem::take(&mut *self.jobs.lock().unwrap());
+                for job in jobs {
+                    job();
+                }
+            }
+        }
+        impl Spawner for DeferringSpawner {
+            fn spawn(&self, job: Job) {
+                self.jobs.lock().unwrap().push(job);
+            }
+        }
+
+        let spawner = DeferringSpawner::default();
+        let platform = TestPlatformHooks::new();
+        let mut module = ScreenshotModule::new(Arc::new(platform.clone()), 60_000);
+        module.state.enabled = true;
+        let mut bus = EventBus::with_spawner(
+            vec![Box::new(module)],
+            StateType::Null,
+            Arc::new(spawner.clone()),
+        )
+        .unwrap();
+
+        // First ping: schedules a capture job (deferred — capture hasn't run yet).
+        platform.clock.set(0);
+        bus.send(Ping).unwrap();
+        bus.iter().unwrap();
+        assert_eq!(spawner.pending(), 1);
+        assert_eq!(
+            platform.take_call_count(),
+            0,
+            "capture runs inside the deferred job, not on the event loop"
+        );
+
+        // Second ping a full interval later, while the first capture is still in flight:
+        // the overlap guard must skip it — no second job scheduled.
+        platform.clock.set(60_000);
+        bus.send(Ping).unwrap();
+        bus.iter().unwrap();
+        assert_eq!(
+            spawner.pending(),
+            1,
+            "overlap guard must prevent a second concurrent capture"
+        );
+
+        // Run the deferred capture and drain its completion event: exactly one capture.
+        spawner.run_all();
+        bus.iter().unwrap();
+        assert_eq!(platform.take_call_count(), 1);
     }
 }

--- a/client/core/src/testing/event_tester.rs
+++ b/client/core/src/testing/event_tester.rs
@@ -92,8 +92,11 @@ impl EventTesterBuilder {
     }
 
     pub fn build(self) -> EventTester {
+        // Inline spawner: background jobs run synchronously, so events they emit
+        // cascade within the same `iter()` and the tester stays deterministic.
         let mut bus =
-            EventBus::new(self.observers, self.state).expect("EventBus construction failed");
+            EventBus::with_spawner(self.observers, self.state, Arc::new(super::InlineSpawner))
+                .expect("EventBus construction failed");
         let mut captures = CaptureStore::new();
         let mut clearers = CaptureClearers::new();
 

--- a/client/core/src/testing/mod.rs
+++ b/client/core/src/testing/mod.rs
@@ -4,6 +4,7 @@ pub mod event_tester;
 pub mod fixtures;
 pub mod platform;
 pub mod scenario;
+pub mod spawner;
 
 pub use api::{BatchCall, HashCall, LogCall, MockApiClient, MockApiState, RegisterDeviceCall};
 pub use clock::MockClock;
@@ -11,6 +12,7 @@ pub use event_tester::{EventTester, EventTesterBuilder};
 pub use fixtures::{tiny_png_bytes, tiny_png_screenshot};
 pub use platform::TestPlatformHooks;
 pub use scenario::Scenario;
+pub use spawner::InlineSpawner;
 
 #[cfg(test)]
 mod tests {

--- a/client/core/src/testing/scenario.rs
+++ b/client/core/src/testing/scenario.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -20,6 +21,7 @@ use crate::state::load_state;
 use crate::testing::api::MockApiClient;
 use crate::testing::clock::MockClock;
 use crate::testing::platform::TestPlatformHooks;
+use crate::testing::spawner::InlineSpawner;
 
 static SCENARIO_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -102,7 +104,7 @@ impl Scenario {
         let observers: Vec<Box<dyn Observer>> = vec![
             Box::new(LifecycleModule::new(Box::new(platform.clone()))),
             Box::new(ScreenshotModule::new(
-                Box::new(platform.clone()),
+                Arc::new(platform.clone()),
                 screenshot_interval_ms,
             )),
             Box::new(UploadModule::new(
@@ -118,7 +120,10 @@ impl Scenario {
 
         let state_path = state_dir.join("event_state.json");
         let saved_state = load_state(&state_path).unwrap_or(StateType::Null);
-        let mut bus = EventBus::new(observers, saved_state).expect("scenario bus must construct");
+        // Inline spawner so offloaded screenshot captures run synchronously and
+        // scenarios stay deterministic.
+        let mut bus = EventBus::with_spawner(observers, saved_state, Arc::new(InlineSpawner))
+            .expect("scenario bus must construct");
 
         // Pre-set device settings in upload module if provided
         if let Some(s) = settings {
@@ -358,7 +363,7 @@ impl Scenario {
         let observers: Vec<Box<dyn Observer>> = vec![
             Box::new(LifecycleModule::new(Box::new(platform.clone()))),
             Box::new(ScreenshotModule::new(
-                Box::new(platform.clone()),
+                Arc::new(platform.clone()),
                 screenshot_interval_ms,
             )),
             Box::new(UploadModule::new(
@@ -374,7 +379,8 @@ impl Scenario {
 
         let state_path = state_dir.join("event_state.json");
         let saved_state = load_state(&state_path).unwrap_or(StateType::Null);
-        let mut bus = EventBus::new(observers, saved_state).expect("scenario bus must construct");
+        let mut bus = EventBus::with_spawner(observers, saved_state, Arc::new(InlineSpawner))
+            .expect("scenario bus must construct");
         bus.iter().expect("initial bus iter must succeed");
 
         Self {

--- a/client/core/src/testing/spawner.rs
+++ b/client/core/src/testing/spawner.rs
@@ -1,0 +1,14 @@
+use crate::events::bus::Spawner;
+
+/// Test [`Spawner`] that runs each job immediately, inline, on the calling
+/// thread. Because the job (and any events it emits) execute before `spawn`
+/// returns, an `emitter.spawn(...)` from within a handler cascades its follow-up
+/// events into the **same** `iter()` — keeping [`EventTester`](super::EventTester)
+/// deterministic with no threads or timing involved.
+pub struct InlineSpawner;
+
+impl Spawner for InlineSpawner {
+    fn spawn(&self, job: Box<dyn FnOnce() + Send + 'static>) {
+        job();
+    }
+}

--- a/client/core/tests/scenarios.rs
+++ b/client/core/tests/scenarios.rs
@@ -120,8 +120,11 @@ fn user_stopped_process_emits_high_risk_upload() {
 #[test]
 fn ping_gap_while_running_emits_alert() {
     let mut scenario = Scenario::authenticated();
+    // First ping past the login grace window establishes a baseline last_ping.
     scenario.at_t(121_000).loop_iteration();
-    scenario.at_t(132_000).loop_iteration();
+    // A single 61s gap exceeds the sliding-window budget (60s) in one shot, so the
+    // PingGapWhileRunning alert fires.
+    scenario.at_t(182_000).loop_iteration();
     assert!(
         !scenario.api.state().log_uploads.is_empty(),
         "expected a PingGapWhileRunning log upload"

--- a/client/core/tests/scenarios.rs
+++ b/client/core/tests/scenarios.rs
@@ -118,16 +118,24 @@ fn user_stopped_process_emits_high_risk_upload() {
 }
 
 #[test]
-fn ping_gap_while_running_emits_alert() {
+fn ping_gap_while_running_batches_alert_without_email() {
     let mut scenario = Scenario::authenticated();
     // First ping past the login grace window establishes a baseline last_ping.
     scenario.at_t(121_000).loop_iteration();
+    // Suppress a second screenshot so the only new upload traffic is the alert itself.
+    scenario.set_last_screenshot_at_ms(Some(150_000));
+    let hashes_before = scenario.api.state().hash_uploads.len();
     // A single 61s gap exceeds the sliding-window budget (60s) in one shot, so the
-    // PingGapWhileRunning alert fires.
+    // PingGapWhileRunning alert fires — but it's high-risk, not immediate.
     scenario.at_t(182_000).loop_iteration();
+    let state = scenario.api.state();
     assert!(
-        !scenario.api.state().log_uploads.is_empty(),
-        "expected a PingGapWhileRunning log upload"
+        state.log_uploads.is_empty(),
+        "ping gap must not trigger an immediate (emailed) log upload"
+    );
+    assert!(
+        state.hash_uploads.len() > hashes_before,
+        "ping gap alert should still be recorded via the batched hash path"
     );
 }
 
@@ -286,9 +294,15 @@ fn unexpected_process_start_after_long_ping_gap_emits_alert() {
     });
     scenario.queue(ProcessStarted);
     scenario.at_t(130_000).loop_iteration();
+    // UnexpectedProcessStart is high-risk but batched (no immediate email).
+    let state = scenario.api.state();
     assert!(
-        !scenario.api.state().log_uploads.is_empty(),
-        "expected an UnexpectedProcessStart log upload"
+        state.log_uploads.is_empty(),
+        "unexpected process start must not trigger an immediate (emailed) log upload"
+    );
+    assert!(
+        !state.hash_uploads.is_empty() || !state.batch_uploads.is_empty(),
+        "unexpected process start alert should still be recorded via the batched path"
     );
 }
 


### PR DESCRIPTION
Adds async image processing (spawns a new thread) and a ping gap budget

## Type of change
Bug fix

## Components changed
Core

## Description
- It adds a `spawn(task)` method to the event emitter, which spawns a new thread and handles errors from the thread.
- It moves screenshot capture and processing off of the main thread. It communicates back using a `ScreenshotCaptured` event.
- Ping gap detection is now done using a rolling window strategy. If a gap is detected, it's added to a rolling list and if the total number of gap times gets too high, it alerts.
- Reduced Ping gap and unexpected process starts from immediate email alerts (90%) to just high alerts (80%)
- Also added an Android CLI that I hadn't committed yet

## Testing
- Web UI still gets uploaded screenshots
- Pause for 80 seconds, uploads ping gap detected
- Pause < 10 seconds, no gap added to the rolling window
- Pause > 10 seconds, gap is added to the rolling window
- Once more than 60 seconds of gap time is accumulated in the last 10 minutes, it alerts.

## Impact
False positives are reduced.

## Additional Notes
It currently uses a 5 minute cooldown, but this does mean that a large gap (like 60 seconds) will alert twice since it alerts once and then one more time right after the cooldown (it doesn't alert a third time cause it drops off the batch window). Another option here would be to clear the rolling window when an event is emitted. I'm not sure which is better.