### PR TITLE
Add Heartbeat log type to Rust core (#299)

### DIFF
--- a/client/core/src/assembly.rs
+++ b/client/core/src/assembly.rs
@@ -7,6 +7,7 @@ use crate::events::bus::Observer;
 use crate::module::auth::AuthModule;
 use crate::module::capture_availability::CaptureAvailabilityModule;
 use crate::module::config::ConfigModule;
+use crate::module::heartbeat::HeartbeatModule;
 use crate::module::lifecycle::LifecycleModule;
 use crate::module::screenshot::ScreenshotModule;
 use crate::module::status::StatusModule;
@@ -50,7 +51,8 @@ where
             api.clone(),
             batch_interval_ms,
         )),
-        Box::new(CaptureAvailabilityModule::new(Box::new(platform))),
+        Box::new(CaptureAvailabilityModule::new(Box::new(platform.clone()))),
+        Box::new(HeartbeatModule::new(Box::new(platform))),
         Box::new(AuthModule::new(api, device_name, platform_name)),
         Box::new(StatusModule::new(STATUS_PARTIAL_COUNT)),
         Box::new(ConfigModule::new(config)),

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -99,6 +99,7 @@ pub enum UploadKind {
         title: String,
         details: Option<String>,
     },
+    Heartbeat,
 }
 
 /// A single piece of `ServiceStatus` reported by one module in response to a

--- a/client/core/src/module/heartbeat.rs
+++ b/client/core/src/module/heartbeat.rs
@@ -1,0 +1,244 @@
+use std::any::Any;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreResult;
+use crate::events::Ping;
+use crate::events::bus::{Emitter, EventBus, Observer, StateType};
+use crate::model::UploadKind;
+use crate::module::auth::{Login, Logout};
+use crate::module::upload::Upload;
+use crate::platform::ScreenshotHooks;
+
+pub(crate) const HEARTBEAT_INTERVAL_MS: i64 = 24 * 60 * 60 * 1_000;
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct HeartbeatObserverState {
+    pub last_heartbeat_ms: i64,
+}
+
+pub struct HeartbeatModule {
+    pub state: HeartbeatObserverState,
+    platform: Box<dyn ScreenshotHooks>,
+    authenticated: bool,
+}
+
+impl HeartbeatModule {
+    pub fn new(platform: Box<dyn ScreenshotHooks>) -> Self {
+        Self {
+            state: HeartbeatObserverState::default(),
+            platform,
+            authenticated: false,
+        }
+    }
+}
+
+impl Observer for HeartbeatModule {
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "heartbeat"
+    }
+
+    fn init(&mut self, _bus: &mut EventBus, state: StateType) -> CoreResult<()> {
+        if !state.is_null() {
+            self.state = serde_json::from_value(state)?;
+        }
+        Ok(())
+    }
+
+    fn on_event(&mut self, event: &dyn Any, emitter: &Emitter) -> CoreResult<()> {
+        crate::dispatch_event!(event, {
+            _: Login => {
+                self.authenticated = true;
+                Ok(())
+            },
+            _: Logout => {
+                self.authenticated = false;
+                Ok(())
+            },
+            _: Ping => {
+                if !self.authenticated {
+                    return Ok(());
+                }
+                let now_ms = self.platform.get_time_utc_ms()?;
+                if now_ms - self.state.last_heartbeat_ms >= HEARTBEAT_INTERVAL_MS {
+                    self.state.last_heartbeat_ms = now_ms;
+                    let _ = emitter.send(Upload {
+                        risk: 0.0,
+                        kind: UploadKind::Heartbeat,
+                    });
+                }
+                Ok(())
+            },
+        })
+    }
+
+    fn save(&self) -> CoreResult<StateType> {
+        Ok(serde_json::to_value(&self.state)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HEARTBEAT_INTERVAL_MS, HeartbeatModule};
+    use crate::events::Ping;
+    use crate::model::UploadKind;
+    use crate::model::{BatchRecipient, DeviceCredentials, DeviceSettings};
+    use crate::module::auth::{Login, Logout};
+    use crate::module::upload::Upload;
+    use crate::testing::EventTester;
+
+    fn login_event() -> Login {
+        Login {
+            credentials: DeviceCredentials {
+                device_id: "test-device".into(),
+                access_token: "test-access".into(),
+                refresh_token: "test-refresh".into(),
+            },
+            settings: DeviceSettings {
+                device_id: "test-device".into(),
+                name: "test device".into(),
+                platform: "test".into(),
+                owner: Some(BatchRecipient {
+                    user_id: "test-user".into(),
+                    pub_key_base64: "CQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
+                }),
+                partners: Vec::new(),
+                hash_base_url: None,
+            },
+        }
+    }
+
+    #[test]
+    fn heartbeat_not_emitted_when_unauthenticated() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        // Ping without login: no heartbeat
+        t.emit(1, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    // The mock clock starts near 0, so a 24h interval (86_400_000 ms) is never
+    // reached from small test timestamps. Use a start time of 1 day + 1 second
+    // so `now_ms - 0 >= HEARTBEAT_INTERVAL_MS` on the very first ping.
+    const DAY_SECS: f64 = (HEARTBEAT_INTERVAL_MS / 1_000 + 1) as f64;
+
+    #[test]
+    fn first_ping_after_login_emits_heartbeat() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        // `last_heartbeat_ms` defaults to 0, so any now_ms >= 24h from epoch triggers.
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping);
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    #[test]
+    fn second_ping_within_24h_does_not_emit_heartbeat() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping); // fires first heartbeat (last_heartbeat_ms was 0)
+        t.clear_captured();
+        // 1 hour later — still within 24h window since the last heartbeat
+        t.emit(DAY_SECS + 3600.0, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    #[test]
+    fn ping_after_24h_emits_next_heartbeat() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping); // first heartbeat
+        t.clear_captured();
+
+        t.emit(DAY_SECS + DAY_SECS, Ping);
+        t.assert_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    #[test]
+    fn logout_stops_heartbeats() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping); // first heartbeat
+        t.emit(DAY_SECS + 1.0, Logout);
+        t.clear_captured();
+
+        t.emit(DAY_SECS + DAY_SECS, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    #[test]
+    fn heartbeat_timer_persists_across_restarts() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping); // heartbeat fires
+        t.clear_captured();
+
+        let saved = t.bus.save().unwrap();
+
+        // Simulate daemon restart: restore state
+        let mut b2 = EventTester::builder();
+        b2.add(HeartbeatModule::new(Box::new(b2.platform())));
+        b2.with_state(saved);
+        let mut t2 = b2.build();
+
+        // Only a few seconds after the last heartbeat: should NOT fire again
+        t2.emit(DAY_SECS + 10.0, login_event());
+        t2.emit(DAY_SECS + 20.0, Ping);
+        t2.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+
+        // After another 24h: should fire
+        t2.clear_captured();
+        t2.emit(DAY_SECS + DAY_SECS + 20.0, Ping);
+        t2.assert_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    #[test]
+    fn heartbeat_upload_has_zero_risk() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping);
+        let uploads = t.captured::<Upload>();
+        let hb = uploads
+            .iter()
+            .find(|u| matches!(u.kind, UploadKind::Heartbeat))
+            .expect("heartbeat upload not found");
+        assert_eq!(hb.risk, 0.0, "heartbeat should have zero risk");
+    }
+}

--- a/client/core/src/module/mod.rs
+++ b/client/core/src/module/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod capture_availability;
 pub mod config;
+pub mod heartbeat;
 pub mod lifecycle;
 pub mod screenshot;
 pub mod status;

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -269,6 +269,9 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             return Ok(());
         }
         let now_ms = self.platform.get_time_utc_ms()?;
+        // Heartbeats bypass the screen-lock gate: the whole point is to prove the
+        // device is alive when idle, so we upload even if the screen is locked.
+        let is_heartbeat = matches!(kind, UploadKind::Heartbeat);
         let entry = LogEntry {
             ts: now_ms,
             risk: Some(risk),
@@ -284,9 +287,14 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             }
         } else {
             self.state.pending_hash_events.push(entry);
-            if screen_active {
+            if screen_active || is_heartbeat {
                 self.retry_pending_hashes()?;
-                self.maybe_upload_batch(now_ms, emitter)?;
+                if is_heartbeat {
+                    // Force an immediate batch flush — don't wait for the interval timer.
+                    self.try_upload_batch(now_ms, emitter)?;
+                } else {
+                    self.maybe_upload_batch(now_ms, emitter)?;
+                }
             }
         }
         Ok(())
@@ -588,6 +596,36 @@ mod tests {
         // FlushBatchNow is an explicit flush path → uploads regardless of lock.
         t.emit(3, FlushBatchNow);
         assert_eq!(t.api.state().batch_uploads.len(), 1);
+    }
+
+    #[test]
+    fn heartbeat_upload_bypasses_lock_and_forces_batch_flush() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        // With a locked screen a normal Upload is queued but not flushed.
+        t.emit(2, skipped_upload());
+        t.emit(3, Ping);
+        assert!(
+            t.api.state().batch_uploads.is_empty(),
+            "no batch while locked"
+        );
+
+        // A Heartbeat Upload bypasses the lock gate and forces the batch out.
+        t.emit(
+            4,
+            Upload {
+                risk: 0.0,
+                kind: UploadKind::Heartbeat,
+            },
+        );
+        assert!(
+            !t.api.state().batch_uploads.is_empty(),
+            "heartbeat should flush batch even while locked"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a `Heartbeat` log event that keeps idle devices syncing even when no screen activity occurs.

## Type of change
- New feature

## Components changed
- Core

## Description

Closes #299.

Devices that are powered on but not actively used never trigger a screenshot upload (the screen-change dedup gate and the screensaver/lock gate both suppress captures). This means they can go days with no synced data, making it impossible to distinguish "device idle" from "device offline or tampered with."

This PR adds a `Heartbeat` upload kind that fires once per 24 hours on every authenticated device, regardless of screen activity:

- **`UploadKind::Heartbeat`** — new variant in `model.rs`, serialises as `"heartbeat"` (snake_case tag).
- **`HeartbeatModule`** — new 8th observer that tracks `last_heartbeat_ms` (persisted in `event_state.json` so the timer survives daemon restarts). On every `Ping` while authenticated, if 24 h have elapsed since the last heartbeat, it emits `Upload { kind: Heartbeat, risk: 0.0 }`. The default `last_heartbeat_ms` is 0, so the first ping after authentication always sends a heartbeat.
- **`UploadModule` bypass** — `handle_upload` detects `UploadKind::Heartbeat` and skips two gates that would otherwise block the upload on idle devices:
  1. The `is_locked_or_screensaver` screen-lock gate (so heartbeats upload even when the screen is off).
  2. The `batch_interval_ms` timer check — `try_upload_batch` is called directly instead of `maybe_upload_batch`, so the batch flushes immediately rather than waiting for the next interval.

## Testing

- 7 unit tests in `module/heartbeat.rs`: no-auth guard, first-ping trigger, 24 h cooldown, next-day re-fire, logout stop, state persistence across restart, zero-risk assertion.
- 1 new unit test in `module/upload.rs`: `heartbeat_upload_bypasses_lock_and_forces_batch_flush` — confirms a Heartbeat upload flushes the batch even when `is_locked_or_screensaver` is true.
- All 108 existing tests continue to pass.

## Impact

- Adds one new observer (`HeartbeatModule`) to the default 7-module set; `STATUS_PARTIAL_COUNT` is unchanged (heartbeat does not emit `PartialStatus`).
- The `Heartbeat` variant is a new `UploadKind` value; the TypeScript web app will need a corresponding display handler to render these events (not included in this PR — no crash risk, unknown variants are ignored at decode time).
- Battery/network impact is minimal: one upload per 24 h per device, triggered only when authenticated.

## Additional Information

The heartbeat interval is a `pub(crate) const HEARTBEAT_INTERVAL_MS` in `heartbeat.rs`. Making it configurable via `Config`/`ConfigChanged` is a natural follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bfzKXpejoTNtoVQWTSZdq