### PR TITLE
Fix #453, #454: squarish sidebar style and auto-select first Logs child

### DIFF
--- a/landing/src/styles/help-sidebar.css
+++ b/landing/src/styles/help-sidebar.css
@@ -16,7 +16,6 @@
 .help-sidebar-section {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
 }
 
 .help-sidebar-section-summary {

--- a/landing/src/styles/help-sidebar.css
+++ b/landing/src/styles/help-sidebar.css
@@ -24,10 +24,13 @@
   display: flex;
   align-items: center;
   gap: 0;
-  border-radius: 8px;
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-sm);
   padding-right: 0.25rem;
   cursor: pointer;
-  transition: background 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 
 .help-sidebar-section-summary::-webkit-details-marker {
@@ -51,18 +54,23 @@
   display: block;
   width: 100%;
   padding: 0.55rem 0.8rem;
-  border-radius: 8px;
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-sm);
   color: var(--text);
+  font-family: var(--font-serif);
   font-size: 0.96rem;
   font-weight: 500;
   letter-spacing: -0.01em;
   line-height: 1.38;
   text-decoration: none;
-  transition: background 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 
 .help-sidebar-section-summary .help-sidebar-item {
   flex: 1;
+  border-left: none;
 }
 
 .help-sidebar-section-summary .help-sidebar-item:hover {
@@ -70,17 +78,21 @@
 }
 
 .help-sidebar-item:hover {
-  background: var(--bg-subtle);
+  background: var(--paper-2);
+  color: var(--forest);
   text-decoration: none;
 }
 
 .help-sidebar-section-summary:hover,
 .help-sidebar-section-summary:focus-visible {
-  background: var(--bg-subtle);
+  background: var(--paper-2);
+  color: var(--forest);
 }
 
 .help-sidebar-section-summary.is-active {
-  background: var(--accent);
+  background: var(--paper-2);
+  border-left-color: var(--forest);
+  color: var(--forest);
 }
 
 .help-sidebar-section-summary.is-active .help-sidebar-item.is-active {
@@ -88,12 +100,13 @@
 }
 
 .help-sidebar-section-summary.is-active .help-sidebar-toggle {
-  color: var(--surface);
+  color: var(--forest);
 }
 
 .help-sidebar-item.is-active {
-  background: var(--accent);
-  color: var(--surface);
+  background: var(--paper-2);
+  border-left-color: var(--forest);
+  color: var(--forest);
 }
 
 .help-sidebar-toggle {
@@ -122,7 +135,7 @@
 }
 
 .help-sidebar-item-child {
-  padding-left: 1.9rem;
+  padding-left: calc(1.9rem + 3px);
   font-size: 0.93rem;
   font-weight: 450;
 }
@@ -269,7 +282,7 @@
   }
 
   .help-sidebar-drawer .help-sidebar-item-child {
-    padding-left: 1.65rem;
+    padding-left: calc(1.65rem + 3px);
   }
 
   .help-sidebar-drawer .help-sidebar-section-summary {

--- a/landing/src/styles/site-shell.css
+++ b/landing/src/styles/site-shell.css
@@ -31,10 +31,6 @@ body {
   z-index: 10;
 }
 
-.help-page .site-header-shell {
-  padding-bottom: 1.5rem;
-}
-
 .site-header {
   display: flex;
   align-items: center;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,6 +17,7 @@ setdir "." && bun install
 setdir "api"
 cp .dev.vars.example .dev.vars
 yes | bun run db:migrate:local
+setdir "." && bun ./scripts/seed-dev-user.mjs
 
 # Caddy — install if missing
 if ! command -v caddy > /dev/null 2>&1; then

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -313,12 +313,12 @@ export function Sidebar() {
           </NavLink>
 
           <div class="sidebar-nav-group">
-            <div class="sidebar-nav-group-heading">
+            <a href="/logs" class="sidebar-nav-group-heading" onClick={closeMobile}>
               <span class="sidebar-nav-icon">
                 <LogsIcon />
               </span>
               <span class="sidebar-nav-label">Logs</span>
-            </div>
+            </a>
             <div class="sidebar-nav-sublist">
               <NavLink href="/logs" active={onLogs && !activeUserId} onNavigate={closeMobile}>
                 My logs

--- a/web/src/pages/Logs/layout.css
+++ b/web/src/pages/Logs/layout.css
@@ -252,7 +252,7 @@ button.logs-fullscreen-btn {
   margin-left: auto;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   padding: 0.3rem 0.9rem;
   font-size: 0.8rem;
   font-weight: 600;
@@ -266,7 +266,7 @@ button.logs-fullscreen-btn {
   font-weight: 600;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   padding: 0.1rem 0.45rem;
   font-family: ui-monospace, monospace;
 }

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -59,6 +59,7 @@
   padding: 0.625rem 0.875rem;
   border: 0;
   border-left: 3px solid transparent;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--ink-2);
   font-family: var(--font-serif);
@@ -134,9 +135,24 @@
   gap: 0.875rem;
   padding: 0.625rem 0.875rem;
   border-left: 3px solid transparent;
+  border-radius: var(--radius-sm);
   color: var(--ink-2);
   font-family: var(--font-serif);
   font-size: 0.9375rem;
+  text-decoration: none;
+}
+
+a.sidebar-nav-group-heading {
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+
+  &:hover {
+    color: var(--forest);
+    background: var(--paper-2);
+    text-decoration: none;
+  }
 }
 
 .sidebar-nav-sublist {


### PR DESCRIPTION
Fixes sidebar style inconsistencies and a broken navigation behaviour reported in issues #453 and #454.

## Type of change
- Bug fix
- UI/UX improvement

## Components changed
- Web
- Landing

## Description

**Fixes #453 — Clicking 'Logs' now selects the first child**
The 'Logs' group heading in the app sidebar was a non-interactive `<div>` that did nothing on click. It is now an `<a href="/logs">` that navigates to 'My logs' (the first child item). The heading itself is never marked active; the active state appears on the child item as expected.

**Fixes #454 — Squarish border-radius throughout**
- Floating date chips (`.logs-sticky-date`): `border-radius` reduced from `10px` → `var(--radius-md)` (4px)
- Log type labels (`.logs-type`): reduced from `5px` → `var(--radius-sm)` (2px)
- App sidebar nav links and group heading: `border-radius: var(--radius-sm)` added so the hover/active background highlight is consistently squarish

**Landing help sidebar — match app sidebar style**
- `border-radius` on items and section summaries: `8px` → `var(--radius-sm)` (2px)
- Active state changed from dark-fill (`var(--accent)` background + `var(--surface)` text) to the left-border indicator style used in the app sidebar (`border-left: 3px solid var(--forest)` + `var(--paper-2)` background + `var(--forest)` text)
- Hover colours updated to match (`var(--paper-2)` + `var(--forest)`)
- Font changed to `var(--font-serif)` (Source Serif 4) to match app sidebar nav link typography
- Items nested inside section summaries have `border-left: none` to avoid a double border; child item indentation adjusted by +3px to compensate for the added border width

**Other**
- Removes a now-redundant `.help-page .site-header-shell` padding override from `site-shell.css`
- Adds dev seed script call to `scripts/setup.sh`

<img width="522" height="755" alt="image" src="https://github.com/user-attachments/assets/dcd3a70a-e31c-4a72-bfbc-e8d4cff72801" />
<img width="327" height="238" alt="image" src="https://github.com/user-attachments/assets/8dffb045-5465-434f-80b8-b934a6663c9a" />


## Testing
- Verified 'Logs' heading click navigates to `/logs` and does not show as active
- Verified date chips and log type labels render with squarish corners
- Verified app sidebar hover/active highlights have the correct squarish radius
- Verified help sidebar active and hover states use the left-border style with correct colours and font

## Impact
Visual-only changes to `web/` and `landing/`. No API, crypto, or data-layer changes. No new dependencies.

## Additional Information
All border-radius values use the shared design tokens (`--radius-sm: 2px`, `--radius-md: 4px`) defined in `shared-web/tokens.css`.