### PR TITLE
Fix #461: use staging API URL by default in dev/staging builds

### DIFF
--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -21,7 +21,7 @@ use virtue_core::{
 
 static CORE: OnceCell<AndroidCore> = OnceCell::new();
 
-const DEFAULT_BASE_API_URL: &str = "https://api.virtueinitiative.org";
+const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
 const ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(20);

--- a/client/core/build.rs
+++ b/client/core/build.rs
@@ -11,6 +11,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=VIRTUE_GIT_SHORT_HASH");
     println!("cargo:rerun-if-env-changed=VIRTUE_GIT_REF_NAME");
     println!("cargo:rerun-if-env-changed=VIRTUE_RELEASE_CHANNEL");
+    println!("cargo:rerun-if-env-changed=VIRTUE_DEFAULT_API_URL");
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
     println!("cargo:rerun-if-changed=../version.properties");
@@ -18,6 +19,9 @@ fn main() {
 
     let build_label = build_label();
     println!("cargo:rustc-env=VIRTUE_BUILD_LABEL={build_label}");
+
+    let default_api_url = default_api_base_url();
+    println!("cargo:rustc-env=VIRTUE_DEFAULT_API_URL={default_api_url}");
 }
 
 fn build_label() -> String {
@@ -25,6 +29,19 @@ fn build_label() -> String {
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| format!("{}-{}-{}", release_tag(), build_date(), git_short_hash()))
+}
+
+fn default_api_base_url() -> String {
+    env::var("VIRTUE_DEFAULT_API_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| {
+            if release_channel() == "stable" {
+                "https://api.virtueinitiative.org".to_string()
+            } else {
+                "https://staging.app.virtueinitiative.org/api".to_string()
+            }
+        })
 }
 
 fn release_tag() -> String {

--- a/client/core/src/config.rs
+++ b/client/core/src/config.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 
 use crate::error::{CoreError, CoreResult};
 
+pub const DEFAULT_API_BASE_URL: &str = env!("VIRTUE_DEFAULT_API_URL");
+
 const MIN_CAPTURE_INTERVAL_SECONDS: u64 = 15;
 const MIN_BATCH_INTERVAL_SECONDS: u64 = 1;
 

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod testing;
 
 pub use assembly::{build_default_modules, build_default_modules_reqwest};
 pub use build_info::{BUILD_LABEL, build_label};
-pub use config::Config;
+pub use config::{Config, DEFAULT_API_BASE_URL};
 pub use controller::ClientController;
 pub use error::{CoreError, CoreResult};
 pub use events::{

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -20,7 +20,7 @@ use virtue_core::{
 
 static CORE: OnceCell<IosCore> = OnceCell::new();
 
-const DEFAULT_BASE_API_URL: &str = "https://api.virtueinitiative.org";
+const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
 const ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(20);

--- a/client/linux/src/config.rs
+++ b/client/linux/src/config.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use virtue_core::Config;
 
-const DEFAULT_BASE_API_URL: &str = "https://api.virtueinitiative.org";
+const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
 

--- a/client/mac/src/config.rs
+++ b/client/mac/src/config.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use virtue_core::Config;
 
-const DEFAULT_BASE_API_URL: &str = "https://api.virtueinitiative.org";
+const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
 

--- a/client/windows/src/config.rs
+++ b/client/windows/src/config.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use virtue_core::Config;
 
-const DEFAULT_BASE_API_URL: &str = "https://api.virtueinitiative.org";
+const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
 


### PR DESCRIPTION
Fix #461: use staging API URL by default in dev/staging builds

## Type of change
- Bug fix

## Components changed
- Core
- Linux
- Mac
- Windows
- iOS
- Android

## Description

All Rust client binaries (Linux, Mac, Windows, Android, iOS) had `DEFAULT_BASE_API_URL = "https://api.virtueinitiative.org"` hardcoded unconditionally. Clients built from the staging branch or locally were silently hitting the production API instead of staging.

The fix:

- **`client/core/build.rs`**: Computes `VIRTUE_DEFAULT_API_URL` at build time using the same release-channel detection that already drives the build label. `main` branch → `"stable"` → `https://api.virtueinitiative.org`; anything else (staging, feature branches, local dev) → `"dev"` → `https://staging.app.virtueinitiative.org/api`. Accepts an explicit `VIRTUE_DEFAULT_API_URL` env var override for special cases.
- **`client/core/src/config.rs`**: Exposes `pub const DEFAULT_API_BASE_URL` backed by `env!("VIRTUE_DEFAULT_API_URL")`.
- **`client/core/src/lib.rs`**: Re-exports `DEFAULT_API_BASE_URL`.
- **All five platform crates**: Replace `"https://api.virtueinitiative.org"` literal with `virtue_core::DEFAULT_API_BASE_URL`.

The web app was already correct: `deploy:staging` runs `vite build --mode staging` which picks up `.env.staging` (`VITE_API_URL=https://staging.app.virtueinitiative.org/api`), and `deploy.yml` already selects the right script per branch.

## Testing

- `cargo build -p virtue-core` and `cargo build -p virtue-linux` both succeed on this branch.
- `cargo test -p virtue-core` — 108 tests pass.
- `cargo test -p virtue-linux` — 38 tests pass.
- Confirmed via `strings` on the built binary that `https://staging.app.virtueinitiative.org/api` is baked in (not the production URL) when building from this non-main branch.
- (Human) I read the code and it looks correct

## Impact

Staging and local dev builds of all Rust clients now connect to the staging API by default. Production builds (from `main`) are unchanged. The runtime config file override (`~/.config/virtue/config.json`) continues to work as before and takes precedence over the compiled-in default.

## Additional Information

The `VIRTUE_DEFAULT_API_URL` env var can be set explicitly to override the auto-detected URL (e.g. for builds targeting a local API). This mirrors the existing `VIRTUE_RELEASE_CHANNEL` override pattern.