### PR TITLE
Fix #456: Style info button as ghost button matching close button

### DIFF
--- a/web/src/pages/Logs/layout.css
+++ b/web/src/pages/Logs/layout.css
@@ -198,12 +198,31 @@ button.logs-fullscreen-btn {
 }
 
 .logs-detail-help-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  background: transparent;
   color: var(--text-muted);
-}
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
 
-.logs-detail-help-link svg {
-  width: 1.25rem;
-  height: 1.25rem;
+  & svg {
+    width: 1.1rem;
+    height: 1.1rem;
+  }
+
+  &:hover {
+    color: var(--text);
+    background: var(--bg-subtle);
+  }
 }
 
 .logs-detail-learn-more {

--- a/web/src/pages/Logs/shared.tsx
+++ b/web/src/pages/Logs/shared.tsx
@@ -283,7 +283,7 @@ export function LogDetailDialog({
               <span class="logs-verify-badge logs-verify-badge--failed">⚠ Unverified</span>
             )}
             <a
-              class="vi-icon-btn logs-detail-help-link"
+              class="logs-detail-help-link"
               href={getLogHelpUrl(item)}
               target="_blank"
               rel="noreferrer"


### PR DESCRIPTION
Style the log detail dialog info button as a ghost button, matching the existing close button appearance.

## Type of change
- Bug fix
- UI/UX improvement

## Components changed
- Web

## Description
Fixes #456. The info button (link to the help article for a log event) in the log detail dialog was rendered with `vi-icon-btn`, which includes a visible border — making it look like an outlined icon button while the adjacent close button is borderless (ghost style). This mismatch was visible with the two buttons sitting side by side in the dialog header.

Changes:
- Removed `vi-icon-btn` class from the info button anchor in `shared.tsx`
- Rewrote `.logs-detail-help-link` in `layout.css` to exactly mirror `.vi-dialog-close`: no border, `2rem × 2rem` size, transparent background, same hover state (`var(--bg-subtle)` / `var(--text)`), and matching `1.1rem` SVG size

<img width="320" height="201" alt="image" src="https://github.com/user-attachments/assets/3b9a6ad3-74c2-4e22-8f41-201588a9e296" />

## Testing
Visually confirmed the two buttons in the log detail dialog header now share the same ghost appearance.

## Impact
Visual-only change scoped to the log detail dialog header. No behaviour, API, or data-layer changes.

## Additional Information
No new dependencies introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H68hcd6W1gMie5qE5rHPuX