### PR TITLE
Add skin/nsfw raw scores to screenshot logs and fix risk=0 on all platforms

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/client-linux.yml
+++ b/.github/workflows/client-linux.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/client-macos.yml
+++ b/.github/workflows/client-macos.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/client-windows.yml
+++ b/.github/workflows/client-windows.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This project uses [Bun](https://bun.sh) as its package manager and runtime.
 
 ### First-time setup
 
+The NSFW screenshot model (`client/core/models/*.onnx`) is stored with
+[Git LFS](https://git-lfs.com). Install and pull it before building any client,
+or the risk classifier silently reports `0` for every screenshot (the client
+build now fails loudly if the model is still an unresolved LFS pointer):
+
+```
+git lfs install
+git lfs pull
+```
+
 Run the setup script from the repo root. It installs all dependencies, copies
 example config files, runs local database migrations, and installs/configures
 [Caddy](https://caddyserver.com) for HTTPS reverse-proxying:

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -7,7 +7,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use jni::objects::{JByteArray, JClass, JString, JValue};
+use jni::objects::{GlobalRef, JByteArray, JClass, JString, JValue};
 use jni::sys::{jboolean, jstring};
 use jni::{JNIEnv, JavaVM};
 use once_cell::sync::OnceCell;
@@ -36,6 +36,8 @@ struct AndroidCore {
     state_dir: PathBuf,
     runtime_config_file: PathBuf,
     java_vm: Arc<JavaVM>,
+    // Cached at init time (main thread) so background threads can use the app class loader.
+    screenshot_service_class: Arc<GlobalRef>,
     stop: Arc<AtomicBool>,
     user_stop: Arc<AtomicBool>,
     daemon_running: Mutex<bool>,
@@ -44,6 +46,7 @@ struct AndroidCore {
 #[derive(Clone)]
 struct AndroidPlatformHooks {
     java_vm: Arc<JavaVM>,
+    screenshot_service_class: Arc<GlobalRef>,
 }
 
 impl AndroidPlatformHooks {
@@ -53,7 +56,7 @@ impl AndroidPlatformHooks {
         })?;
 
         env.call_static_method(
-            SCREENSHOT_SERVICE_CLASS,
+            &*self.screenshot_service_class,
             "captureStatusForDaemon",
             "()I",
             &[],
@@ -71,7 +74,12 @@ impl AndroidPlatformHooks {
         })?;
 
         let value = env
-            .call_static_method(SCREENSHOT_SERVICE_CLASS, "capturePngForDaemon", "()[B", &[])
+            .call_static_method(
+                &*self.screenshot_service_class,
+                "capturePngForDaemon",
+                "()[B",
+                &[],
+            )
             .map_err(|err| {
                 CoreError::CommandFailed(format!("capturePngForDaemon failed: {err}"))
             })?;
@@ -194,10 +202,20 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeInit(
 
         if CORE.get().is_none() {
             let java_vm = Arc::new(env.get_java_vm().context("failed to get JavaVM")?);
+            // Cache the ScreenshotService class here (main thread → app class loader).
+            // Background threads use the system class loader and cannot resolve app classes.
+            let class = env
+                .find_class(SCREENSHOT_SERVICE_CLASS)
+                .context("failed to find ScreenshotService class")?;
+            let screenshot_service_class = Arc::new(
+                env.new_global_ref(class)
+                    .context("failed to create GlobalRef for ScreenshotService")?,
+            );
             CORE.set(AndroidCore {
                 state_dir: PathBuf::from(data_dir),
                 runtime_config_file,
                 java_vm,
+                screenshot_service_class,
                 stop: Arc::new(AtomicBool::new(false)),
                 user_stop: Arc::new(AtomicBool::new(false)),
                 daemon_running: Mutex::new(false),
@@ -442,6 +460,7 @@ fn build_bus(core: &AndroidCore) -> Result<(EventBus, PathBuf)> {
         cfg,
         AndroidPlatformHooks {
             java_vm: core.java_vm.clone(),
+            screenshot_service_class: core.screenshot_service_class.clone(),
         },
     )?;
     let state_path = core.state_dir.join("event_state.json");

--- a/client/core/build.rs
+++ b/client/core/build.rs
@@ -16,8 +16,47 @@ fn main() {
     println!("cargo:rerun-if-changed=../version.properties");
     println!("cargo:rerun-if-changed=../../.git/HEAD");
 
+    assert_model_resolved();
+
     let build_label = build_label();
     println!("cargo:rustc-env=VIRTUE_BUILD_LABEL={build_label}");
+}
+
+/// The NSFW model is tracked by Git LFS and embedded into the binary via `include_bytes!`
+/// (`src/module/screenshot.rs`). If LFS objects aren't materialized at build time, the file on
+/// disk is a ~130-byte text *pointer*, which gets baked into the binary instead of the model.
+/// The classifier then fails to load and every screenshot risk is silently 0. Catch that here at
+/// build time — loudly — instead of shipping a broken detector.
+fn assert_model_resolved() {
+    const LFS_POINTER_MAGIC: &[u8] = b"version https://git-lfs.github.com/spec/v1";
+    // The real ONNX model is ~17 MB; any LFS pointer is well under 1 KiB. Anything below this is
+    // certainly not a usable model.
+    const MIN_MODEL_BYTES: u64 = 4096;
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let model_path = manifest_dir.join("models/nsfw_small_v1.onnx");
+    println!("cargo:rerun-if-changed=models/nsfw_small_v1.onnx");
+
+    let metadata = fs::metadata(&model_path).unwrap_or_else(|err| {
+        panic!(
+            "NSFW model {} is missing ({err}). Run `git lfs install && git lfs pull` before building.",
+            model_path.display()
+        )
+    });
+
+    let is_pointer = fs::read(&model_path)
+        .map(|bytes| bytes.starts_with(LFS_POINTER_MAGIC))
+        .unwrap_or(false);
+
+    if is_pointer || metadata.len() < MIN_MODEL_BYTES {
+        panic!(
+            "NSFW model {} is an unresolved Git LFS pointer ({} bytes), not the real ONNX. \
+             Run `git lfs install && git lfs pull` (and ensure CI checks out with `lfs: true`) \
+             before building, or the screenshot risk classifier will silently report 0.",
+            model_path.display(),
+            metadata.len()
+        );
+    }
 }
 
 fn build_label() -> String {

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -81,6 +81,15 @@ pub enum UploadKind {
     Screenshot {
         image: Vec<u8>,
         content_type: String,
+        /// Raw skin-tone heuristic score ∈ [0.0, 1.0] from the risk classifier (dev metadata).
+        /// `None` on older logs or when no classifier was available.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        skin_detection: Option<f32>,
+        /// Raw NSFW model probability ∈ [0.0, 1.0] from the risk classifier (dev metadata).
+        /// `None` when the skin gate skipped the model, on older logs, or when no classifier
+        /// was available.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        nsfw_detection: Option<f32>,
     },
     Lifecycle {
         kind: LifecycleKind,

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -83,7 +83,19 @@ pub struct ScreenshotModule {
 impl ScreenshotModule {
     pub fn new(platform: Arc<dyn ScreenshotHooks>, screenshot_interval_ms: i64) -> Self {
         #[cfg(not(test))]
-        let classifier = RiskClassifier::new(MODEL_BYTES).ok().map(Arc::new);
+        let classifier = match RiskClassifier::new(MODEL_BYTES) {
+            Ok(classifier) => Some(Arc::new(classifier)),
+            Err(err) => {
+                // The model is embedded via `include_bytes!` at build time; the usual cause of
+                // a load failure is an unresolved Git LFS pointer baked in instead of the real
+                // ONNX (see build.rs guard). Without a classifier every screenshot risk is 0,
+                // so make that loud rather than silent.
+                eprintln!(
+                    "[screenshot] NSFW classifier disabled, all screenshot risk will be 0: {err}"
+                );
+                None
+            }
+        };
         #[cfg(test)]
         let classifier: Option<Arc<RiskClassifier>> = None;
         Self {
@@ -218,9 +230,20 @@ fn run_capture(
         return Ok(());
     }
 
-    let risk = classifier
-        .and_then(|c| c.classify(&screenshot.bytes).ok())
-        .unwrap_or(0.0);
+    // Classify before the (consuming) image pipeline. A `None` classifier (model failed to
+    // load) or a classify error fails safe to risk 0 with no raw scores, but — unlike the old
+    // silent `.ok()` — we log the error so an always-0 misconfiguration is diagnosable.
+    let scores = classifier.and_then(|c| match c.classify(&screenshot.bytes) {
+        Ok(scores) => Some(scores),
+        Err(err) => {
+            eprintln!("[screenshot] classify failed, recording risk 0: {err}");
+            None
+        }
+    });
+    let (risk, skin_detection, nsfw_detection) = match scores {
+        Some(scores) => (scores.risk, Some(scores.skin), scores.nsfw),
+        None => (0.0, None, None),
+    };
     let processed = match image_pipeline::ImagePipeline.process(screenshot) {
         Ok(p) => p,
         Err(err) => {
@@ -237,6 +260,8 @@ fn run_capture(
         kind: UploadKind::Screenshot {
             image: processed.bytes,
             content_type: processed.content_type,
+            skin_detection,
+            nsfw_detection,
         },
     });
     let _ = emitter.send(ScreenshotCaptured {

--- a/client/core/src/module/screenshot/risk_classifier.rs
+++ b/client/core/src/module/screenshot/risk_classifier.rs
@@ -14,6 +14,22 @@ const SKIN_GATE: f32 = 0.05; // below this contribution (~1.5% skin) skip the mo
 
 type NsfwModel = SimplePlan<TypedFact, Box<dyn TypedOp>, Graph<TypedFact, Box<dyn TypedOp>>>;
 
+/// Raw, unweighted outputs of the two-stage NSFW cascade plus the blended risk.
+///
+/// `risk` is what drives severity/alerting; `skin` and `nsfw` are the raw stage scores
+/// recorded on the log as low-level dev metadata so a reviewer can see *why* a frame scored
+/// the way it did.
+pub struct RiskScores {
+    /// Blended risk ∈ [0.0, 1.0] = `skin * SKIN_WEIGHT + nsfw * MODEL_WEIGHT` (or just the
+    /// skin contribution when the gate skips the model).
+    pub risk: f32,
+    /// Raw skin-tone heuristic score ∈ [0.0, 1.0], before weighting.
+    pub skin: f32,
+    /// Raw NSFW model probability ∈ [0.0, 1.0]. `None` when the skin gate skipped the model
+    /// (i.e. negligible skin), so it's distinguishable from "model ran and returned 0".
+    pub nsfw: Option<f32>,
+}
+
 pub struct RiskClassifier {
     model: NsfwModel,
 }
@@ -34,25 +50,34 @@ impl RiskClassifier {
         Ok(Self { model })
     }
 
-    /// Returns a risk score ∈ [0.0, 1.0] using a two-stage cascade:
+    /// Returns the [`RiskScores`] for an image using a two-stage cascade:
     ///
     /// 1. A cheap YCbCr skin-tone heuristic (~1ms, no model) contributes up to 30%.
     /// 2. Only when meaningful skin is present do we pay for the MobileNet NSFW model,
     ///    which contributes up to 70%.
     ///
     /// Most screenshots (terminals, code, docs) have negligible skin and return early
-    /// without any ONNX inference, keeping the daemon loop fast enough to avoid
-    /// `PingGapWhileRunning` false alerts.
-    pub fn classify(&self, image_bytes: &[u8]) -> CoreResult<f32> {
+    /// without any ONNX inference (`nsfw = None`), keeping the daemon loop fast enough to
+    /// avoid `PingGapWhileRunning` false alerts.
+    pub fn classify(&self, image_bytes: &[u8]) -> CoreResult<RiskScores> {
         let img = image::load_from_memory(image_bytes)?;
 
-        let contribution = skin_score(&img) * SKIN_WEIGHT;
+        let skin = skin_score(&img);
+        let contribution = skin * SKIN_WEIGHT;
         if contribution <= SKIN_GATE {
-            return Ok(contribution);
+            return Ok(RiskScores {
+                risk: contribution,
+                skin,
+                nsfw: None,
+            });
         }
 
         let model_score = self.run_inference(&img)?;
-        Ok(contribution + model_score * MODEL_WEIGHT)
+        Ok(RiskScores {
+            risk: contribution + model_score * MODEL_WEIGHT,
+            skin,
+            nsfw: Some(model_score),
+        })
     }
 
     /// Returns P(nsfw) ∈ [0.0, 1.0] from the MobileNetV2 model for the full image.

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -492,6 +492,8 @@ fn dev_send(paths: ClientPaths, args: SendLogArgs) -> Result<()> {
         vec![UploadKind::Screenshot {
             image: shot.bytes,
             content_type: shot.content_type,
+            skin_detection: None,
+            nsfw_detection: None,
         }]
     } else {
         vec![build_send_kind(&args)?]
@@ -578,6 +580,8 @@ fn dev_add_screenshot(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()
         kind: UploadKind::Screenshot {
             image: screenshot.bytes,
             content_type: screenshot.content_type,
+            skin_detection: None,
+            nsfw_detection: None,
         },
     })?;
     bus.send(Ping)?;


### PR DESCRIPTION
Add skin/nsfw raw scores to screenshot logs and fix risk=0 on all platforms hopefully? At least tested on ios and mac, it works now. Needed to update build to ensure lfs was pulled for the model.


iOS:

<img width="868" height="581" alt="image" src="https://github.com/user-attachments/assets/fa2478eb-bd3d-44ea-a3aa-6385e74744be" />

## Type of change
- Bug fix
- New feature

## Components changed
- Core
- Mac
- Linux
- iOS
- Android
- Windows

## Description
The NSFW classifier was silently disabled on every platform. The ONNX model is tracked by Git LFS, but `include_bytes!` baked in the 133-byte LFS pointer instead of the real model whenever LFS objects weren't materialized at build time. Neither the classifier load failure nor per-frame errors were surfaced, so risk always reported 0 with no indication of why.

- Fixes #458 
- Fixes #460 
- Fixes #459?

**Fix for risk=0:**
- `client/core/build.rs`: compile-time guard panics with a clear message if the model file is missing or still an LFS pointer
- `client/core/src/module/screenshot.rs`: replace silent `.ok()` with `eprintln!` warnings when the classifier fails to load or `classify()` errors
- All five client CI workflows: add `lfs: true` to `actions/checkout@v4`
- `README.md`: document `git lfs install && git lfs pull` as a prerequisite for client builds

**Raw stage scores in logs:**
- `risk_classifier.rs`: `classify()` now returns `RiskScores { risk, skin, nsfw: Option<f32> }` — `nsfw` is `None` when the skin gate skips the model (skin contribution ≤ 0.05)
- `model.rs`: `UploadKind::Screenshot` gains `skin_detection` and `nsfw_detection` (`Option<f32>`, omitted when `None` for backward compat with old logs)
- `screenshot.rs`: `run_capture` populates both fields from classifier output
- Web: no changes needed — `getLogMetadata` already renders all `data` keys by raw name (same as `content_type`)

## Testing
- `cargo build -p virtue-core` fails with a clear LFS message when model is replaced with a pointer stub; passes with real model
- `cargo test -p virtue-core` — 108 tests pass
- Mac client tested locally: screenshot logs show `skin_detection` and `nsfw_detection` in the web metadata section and non-zero `risk` for skin-tone content
- iOS client tested on device (iPhone 16 Pro)

## Impact
- Screenshots from old clients continue to work — the two new fields are optional and backward-compatible
- Every client build now fails loudly (at compile time) if the LFS model is not materialized, preventing silent regression
- CI bandwidth increases slightly due to LFS object download on each client build

## Additional Information
The root cause affected all platforms equally — Android CI builds also embedded the LFS pointer, but appeared to work if the model happened to be present locally when the binary was built outside CI.