### PR TITLE
Fix #470: noindex meta tag on staging pages

### DIFF
--- a/landing/src/components/NoindexMeta.astro
+++ b/landing/src/components/NoindexMeta.astro
@@ -1,0 +1,8 @@
+---
+// Keep non-production deployments (staging, feature branches) out of search
+// engines. The staging build runs `astro build --mode staging`, so any mode
+// other than `production` should not be indexed.
+const noindex = import.meta.env.MODE !== 'production';
+---
+
+{noindex && <meta name="robots" content="noindex, nofollow" />}

--- a/landing/src/layouts/HelpLayout.astro
+++ b/landing/src/layouts/HelpLayout.astro
@@ -2,6 +2,7 @@
 import HelpSidebarNav from '../components/HelpSidebarNav.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
+import NoindexMeta from '../components/NoindexMeta.astro';
 import { helpSidebar } from '../help/navigation';
 import '../styles/global.css';
 
@@ -20,6 +21,7 @@ const rootLinks = [{ label: 'Help', href: '/help' }, ...helpSidebar];
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <NoindexMeta />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/landing/src/layouts/SiteLayout.astro
+++ b/landing/src/layouts/SiteLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
+import NoindexMeta from '../components/NoindexMeta.astro';
 import '../styles/global.css';
 
 interface Props {
@@ -17,6 +18,7 @@ const title = pageTitle ? `${pageTitle} - The Virtue Initiative` : 'The Virtue I
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <NoindexMeta />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,6 +19,17 @@ export default defineConfig(({ mode }) => {
           }
         : undefined,
     plugins: [
+      // Keep non-production deployments (staging, feature branches) out of search
+      // engines by injecting a robots meta tag into the prerendered <head>.
+      mode !== 'production' && {
+        name: 'inject-noindex-meta',
+        transformIndexHtml(html: string) {
+          return html.replace(
+            '</head>',
+            '    <meta name="robots" content="noindex, nofollow" />\n  </head>',
+          );
+        },
+      },
       preact({
         prerender: {
           enabled: true,


### PR DESCRIPTION
Add `<meta name="robots" content="noindex, nofollow">` to non-production pages so search engines don't index staging (and other non-production) deployments. Fixes #470.

## Type of change
- Bug fix

## Components changed
- Web
- Landing

## Description
Staging pages were indexable by search engines. This injects a `noindex, nofollow` robots meta tag into the `<head>` of every non-production page.

Detection is based on the build mode, which cleanly distinguishes the two deployment targets already in use:
- Production builds run in the default `production` mode (`web`: `vite build`, `landing`: `astro build`).
- Staging builds run with `--mode staging` (`web`: `vite build --mode staging`, `landing`: `astro build --mode staging`).

Any mode other than `production` (staging, dev, feature-branch builds) is treated as non-indexable, so production is the only environment that stays indexable.

Implementation:
- **web** (`web/vite.config.ts`): a small `transformIndexHtml` Vite plugin, active whenever `mode !== 'production'`, injects the tag into the prerendered `index.html` head. Because prerendering derives every route's head from that template, all prerendered routes (including `/404`) get the tag.
- **landing** (`landing/src/components/NoindexMeta.astro`): a shared component that conditionally renders the tag based on `import.meta.env.MODE`, added to the head of both `SiteLayout.astro` and `HelpLayout.astro`. Every page in `src/pages/` uses one of those two layouts.

## Testing
- `web`: `vite build --mode staging` → tag present in `dist/index.html` and prerendered `dist/404/index.html`; `vite build` (prod) → tag absent.
- `landing`: `astro build --mode staging` → tag present in all 33 generated HTML pages; `astro build` (prod) → tag absent.
- `web`: `tsc -p tsconfig.lint.json --noEmit` and `prettier --check` pass.
- `landing`: `astro check` (0 errors) and `prettier --check` pass.

## Impact
No runtime dependencies added and no effect on production, which continues to serve pages without the tag. Only the HTML `<head>` of non-production builds changes.

## Additional Information
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7JSxhkMDso5C5anKgUo16