### PR TITLE
Fix #467: replace direct-log endpoint with encrypted batch + notify pipeline

### DIFF
--- a/api/API.md
+++ b/api/API.md
@@ -591,30 +591,24 @@ Response `200`:
 ```js
 {
   "batches": [BatchData],
-  "logs": [
-    {
-      "id": UUID,
-      "device_id": UUID,
-      "ts": DateTime,
-      "type": "system_event",
-      "data": {},
-      "created_at": DateTime,
-      "risk": 0.7 | undefined
-    }
-  ]
+  "logs": []
 }
 ```
 
 `batches` only include rows where the requester has a matching `encrypted_key` envelope.
-Returns every batch and log with `created_at > since`, ordered oldest-to-newest. Callers
+Returns every batch with `created_at > since`, ordered oldest-to-newest. Callers
 should pass the largest `created_at` they've seen as `since` on subsequent syncs.
+
+`logs` is always an empty array. Direct device logs were removed in #467 — high-risk
+events now live inside the encrypted batches above. The field is retained only for
+API stability; existing clients that read it will keep working.
 
 ## Device API
 
 The following routes use device auth:
 
 - `POST /d/device` uses the authenticated web session cookie
-- `POST /d/token`, `GET /d/device`, `POST /d/batch`, and `POST /d/log` use a `DeviceRefreshToken`
+- `POST /d/token`, `GET /d/device`, `POST /d/batch`, and `POST /d/notify` use a `DeviceRefreshToken`
 - `POST /hash`, `GET /hash`, and `DELETE /hash` use a `HashServerToken` or `ServerToken` as applicable
 
 ### `POST /d/device`
@@ -681,7 +675,14 @@ Multipart form request:
 - `start_time`: integer
 - `end_time`: integer
 - `access_keys`: JSON string
+- `high_risk_count`: non-negative integer, optional, default `0`
+- `medium_risk_count`: non-negative integer, optional, default `0`
 - `file`: encrypted batch blob
+
+`high_risk_count`/`medium_risk_count` are risk-band tallies computed client-side from the
+per-event `risk` values in this batch (thresholds mirror `shared-web/risk.ts`). Since
+event bodies are end-to-end encrypted, these counts are the only server-visible signal
+used to summarize tamper activity in partner digest emails.
 
 `access_keys` JSON shape:
 
@@ -708,7 +709,12 @@ Response `201`:
 }
 ```
 
-### `POST /d/log`
+### `POST /d/notify`
+
+Sends the alert email for a high-risk event. The event body itself is uploaded separately
+via the encrypted `POST /d/batch` pipeline; this endpoint only carries the metadata needed
+to render the notification email and persists nothing server-side. Replaces the removed
+`POST /d/log` endpoint.
 
 Request:
 
@@ -716,21 +722,20 @@ Request:
 {
   "ts": DateTime,
   "type": "system_event",
-  "risk": 0.7 | undefined,
-  "data": {}
+  "risk": 0.7,
+  "title": "Device reported system event." | undefined,
+  "details": "..." | undefined
 }
 ```
 
-Response `201` echoes the stored log.
-Response `201`:
+`risk` is required (`0`-`1`). `title`/`details` are optional; when omitted, a default title
+is derived from `type` and no details are included.
+
+Response `202`:
 
 ```js
 {
-  "id": UUID,
-  "ts": DateTime,
-  "type": "system_event",
-  "risk": 0.7 | undefined,
-  "data": {}
+  "ok": true
 }
 ```
 

--- a/api/API.md
+++ b/api/API.md
@@ -590,18 +590,13 @@ Response `200`:
 
 ```js
 {
-  "batches": [BatchData],
-  "logs": []
+  "batches": [BatchData]
 }
 ```
 
 `batches` only include rows where the requester has a matching `encrypted_key` envelope.
 Returns every batch with `created_at > since`, ordered oldest-to-newest. Callers
 should pass the largest `created_at` they've seen as `since` on subsequent syncs.
-
-`logs` is always an empty array. Direct device logs were removed in #467 — high-risk
-events now live inside the encrypted batches above. The field is retained only for
-API stability; existing clients that read it will keep working.
 
 ## Device API
 

--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -406,7 +406,6 @@ export async function listBatchUrlsForUser(db: D1Database, userId: string) {
 
 export async function deleteDeviceById(db: D1Database, deviceId: string) {
   const deviceIdBytes = uuidToBytes(deviceId);
-  await db.prepare('DELETE FROM device_logs WHERE device_id = ?').bind(deviceIdBytes).run();
   await db.prepare('DELETE FROM batches WHERE device_id = ?').bind(deviceIdBytes).run();
   await db.prepare('DELETE FROM hash_states WHERE device_id = ?').bind(deviceIdBytes).run();
   return db.prepare('DELETE FROM devices WHERE id = ?').bind(deviceIdBytes).run();
@@ -542,14 +541,17 @@ export async function createBatch(
     end_time: number;
     end_hash: string;
     access_keys: string;
+    high_risk_count?: number;
+    medium_risk_count?: number;
     created_at: number;
   },
 ) {
   return db
     .prepare(
       `INSERT INTO batches (
-         id, user_id, device_id, url, start_time, end_time, end_hash, access_keys, created_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         id, user_id, device_id, url, start_time, end_time, end_hash, access_keys,
+         high_risk_count, medium_risk_count, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .bind(
       uuidToBytes(input.id),
@@ -560,37 +562,8 @@ export async function createBatch(
       input.end_time,
       input.end_hash,
       input.access_keys,
-      input.created_at,
-    )
-    .run();
-}
-
-export async function createDeviceLog(
-  db: D1Database,
-  input: {
-    id: string;
-    user_id: string;
-    device_id: string;
-    ts: number;
-    type: string;
-    data: string;
-    risk?: number | null;
-    created_at: number;
-  },
-) {
-  return db
-    .prepare(
-      `INSERT INTO device_logs (id, user_id, device_id, ts, type, data, risk, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .bind(
-      uuidToBytes(input.id),
-      uuidToBytes(input.user_id),
-      uuidToBytes(input.device_id),
-      input.ts,
-      input.type,
-      input.data,
-      input.risk ?? null,
+      input.high_risk_count ?? 0,
+      input.medium_risk_count ?? 0,
       input.created_at,
     )
     .run();
@@ -641,143 +614,23 @@ export async function listBatchWindowsForUser(
   windowStart: number,
   windowEnd: number,
 ) {
-  return allWithUuidFields<{ id: string; device_id: string; start_time: number; end_time: number }>(
+  return allWithUuidFields<{
+    id: string;
+    device_id: string;
+    start_time: number;
+    end_time: number;
+    high_risk_count: number;
+    medium_risk_count: number;
+  }>(
     db
       .prepare(
-        `SELECT id, device_id, start_time, end_time
+        `SELECT id, device_id, start_time, end_time, high_risk_count, medium_risk_count
          FROM batches
          WHERE user_id = ? AND end_time > ? AND start_time < ?
          ORDER BY start_time ASC`,
       )
       .bind(uuidToBytes(userId), windowStart, windowEnd),
     ['id', 'device_id'],
-  );
-}
-
-export async function listDeviceLogs(
-  db: D1Database,
-  ownerIds: string[],
-  filters: { deviceId?: string; since?: number },
-) {
-  if (ownerIds.length === 0) {
-    return [];
-  }
-
-  const params: SqlValue[] = ownerIds.map(uuidToBytes);
-  let query = `SELECT id, user_id, device_id, ts, type, data, risk, created_at
-               FROM device_logs
-               WHERE user_id IN (${placeholders(ownerIds.length)})`;
-
-  if (filters.deviceId) {
-    query += ' AND device_id = ?';
-    params.push(uuidToBytes(filters.deviceId));
-  }
-
-  if (filters.since !== undefined) {
-    query += ' AND created_at > ?';
-    params.push(filters.since);
-  }
-
-  query += ' ORDER BY created_at ASC';
-
-  return allWithUuidFields<{
-    id: string;
-    user_id: string;
-    device_id: string;
-    ts: number;
-    type: string;
-    data: string;
-    risk: number | null;
-    created_at: number;
-  }>(db.prepare(query).bind(...params), ['id', 'user_id', 'device_id']);
-}
-
-export async function findDeviceLogByKindWithinWindow(
-  db: D1Database,
-  input: { userId: string; deviceId: string; type: string; windowStart: number; windowEnd: number },
-) {
-  return firstWithUuidFields<{
-    id: string;
-    user_id: string;
-    device_id: string;
-    ts: number;
-    type: string;
-    data: string;
-    risk: number | null;
-    created_at: number;
-  }>(
-    db
-      .prepare(
-        `SELECT id, user_id, device_id, ts, type, data, risk, created_at
-         FROM device_logs
-         WHERE user_id = ? AND device_id = ? AND type = ? AND ts >= ? AND ts < ?
-         ORDER BY ts DESC
-         LIMIT 1`,
-      )
-      .bind(
-        uuidToBytes(input.userId),
-        uuidToBytes(input.deviceId),
-        input.type,
-        input.windowStart,
-        input.windowEnd,
-      ),
-    ['id', 'user_id', 'device_id'],
-  );
-}
-
-export async function listRiskDeviceLogsForUser(
-  db: D1Database,
-  userId: string,
-  windowStart: number,
-  windowEnd: number,
-) {
-  return allWithUuidFields<{
-    id: string;
-    user_id: string;
-    device_id: string;
-    ts: number;
-    type: string;
-    data: string;
-    risk: number | null;
-    created_at: number;
-  }>(
-    db
-      .prepare(
-        `SELECT id, user_id, device_id, ts, type, data, risk, created_at
-         FROM device_logs
-         WHERE user_id = ? AND risk IS NOT NULL AND ts >= ? AND ts < ?
-         ORDER BY ts DESC`,
-      )
-      .bind(uuidToBytes(userId), windowStart, windowEnd),
-    ['id', 'user_id', 'device_id'],
-  );
-}
-
-export async function listDeviceLogsForUser(
-  db: D1Database,
-  userId: string,
-  windowStart: number,
-  windowEnd: number,
-) {
-  return allWithUuidFields<{
-    id: string;
-    user_id: string;
-    device_id: string;
-    ts: number;
-    type: string;
-    data: string;
-    risk: number | null;
-    created_at: number;
-  }>(
-    db
-      .prepare(
-        `SELECT id, user_id, device_id, ts, type, data, risk, created_at
-         FROM device_logs
-         WHERE user_id = ? AND ts >= ? AND ts < ?
-         ORDER BY ts DESC`,
-      )
-      .bind(uuidToBytes(userId), windowStart, windowEnd),
-    ['id', 'user_id', 'device_id'],
   );
 }
 

--- a/api/src/lib/email-domain.ts
+++ b/api/src/lib/email-domain.ts
@@ -32,14 +32,3 @@ export const PASSWORD_RESET_TTL_MS = 1000 * 60 * 60;
 export const PARTNER_INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
 
 export const DEFAULT_EMAIL_FREQUENCY: EmailFrequency = 'daily';
-export const DEFAULT_IMMEDIATE_TAMPER_SEVERITY: TamperSeverity = 'critical';
-
-const severityRankings: Record<TamperSeverity, number> = {
-  info: 0,
-  warning: 1,
-  critical: 2,
-};
-
-export function severityAtLeast(value: TamperSeverity, minimum: TamperSeverity) {
-  return severityRankings[value] >= severityRankings[minimum];
-}

--- a/api/src/lib/scheduler.ts
+++ b/api/src/lib/scheduler.ts
@@ -1,15 +1,8 @@
 import { DigestFrequency, TamperSeverity } from './email-domain';
 import { formatUtcDate, getDigestWindowForRun } from './digest-schedule';
-import {
-  listBatchWindowsForUser,
-  listDevicesForUser,
-  listDeviceLogsForUser,
-  listDigestEligiblePartnerships,
-  listRiskDeviceLogsForUser,
-} from './db';
+import { listBatchWindowsForUser, listDevicesForUser, listDigestEligiblePartnerships } from './db';
 import { sendEmail } from './email';
 import { renderPartnerDigestTemplate } from './email/templates';
-import { riskToSeverity } from './tamper';
 import { Env } from '../types/bindings';
 
 const DEFAULT_CAPTURE_INTERVAL_MS = 300 * 1000;
@@ -32,13 +25,17 @@ function countApproximateScreenshots(
   }, 0);
 }
 
-function summarizeTamperCounts(events: Array<{ risk: number | null }>) {
+// High-risk events now live inside end-to-end encrypted batches, so the server can
+// no longer read individual event risks. Each batch instead reports how many of its
+// events fell in the high (>= 0.7) and medium (0.4–0.7) risk bands; those map to the
+// `critical` and `warning` tamper severities respectively.
+function summarizeTamperCounts(
+  batches: Array<{ high_risk_count: number; medium_risk_count: number }>,
+) {
   const counts: Record<TamperSeverity, number> = { info: 0, warning: 0, critical: 0 };
-  for (const event of events) {
-    const severity = riskToSeverity(event.risk);
-    if (severity) {
-      counts[severity] += 1;
-    }
+  for (const batch of batches) {
+    counts.critical += batch.high_risk_count;
+    counts.warning += batch.medium_risk_count;
   }
   return counts;
 }
@@ -51,24 +48,14 @@ function batchOverlapsWindow(
   return batch.end_time > windowStart && batch.start_time < windowEnd;
 }
 
-function logFallsWithinWindow(log: { ts: number }, windowStart: number, windowEnd: number) {
-  return log.ts >= windowStart && log.ts < windowEnd;
-}
-
 function hasActivityInWindow(
   deviceId: string,
   batches: Array<{ device_id: string; start_time: number; end_time: number }>,
-  logs: Array<{ device_id: string; ts: number }>,
   windowStart: number,
   windowEnd: number,
 ) {
-  return (
-    batches.some(
-      (batch) => batch.device_id === deviceId && batchOverlapsWindow(batch, windowStart, windowEnd),
-    ) ||
-    logs.some(
-      (log) => log.device_id === deviceId && logFallsWithinWindow(log, windowStart, windowEnd),
-    )
+  return batches.some(
+    (batch) => batch.device_id === deviceId && batchOverlapsWindow(batch, windowStart, windowEnd),
   );
 }
 
@@ -76,7 +63,6 @@ function collectMissingLogPeriods(
   cadence: DigestFrequency,
   devices: Array<{ id: string; name: string; created_at: number }>,
   batches: Array<{ device_id: string; start_time: number; end_time: number }>,
-  logs: Array<{ device_id: string; ts: number }>,
   windowStart: number,
   windowEnd: number,
 ) {
@@ -89,7 +75,7 @@ function collectMissingLogPeriods(
     }
 
     if (cadence === 'daily') {
-      if (!hasActivityInWindow(device.id, batches, logs, firstRelevantTime, windowEnd)) {
+      if (!hasActivityInWindow(device.id, batches, firstRelevantTime, windowEnd)) {
         missing.push(`${device.name}: no logs in the last 24 hours`);
       }
       continue;
@@ -97,7 +83,7 @@ function collectMissingLogPeriods(
 
     for (let bucketStart = firstRelevantTime; bucketStart < windowEnd; bucketStart += DAY_MS) {
       const bucketEnd = Math.min(bucketStart + DAY_MS, windowEnd);
-      if (!hasActivityInWindow(device.id, batches, logs, bucketStart, bucketEnd)) {
+      if (!hasActivityInWindow(device.id, batches, bucketStart, bucketEnd)) {
         missing.push(`${device.name}: no logs on ${formatUtcDate(bucketStart)}`);
       }
     }
@@ -145,15 +131,8 @@ export async function runNotificationSchedule(env: Env, now = Date.now()) {
           ),
         )
         .map(async (partnership) => {
-          const [batches, riskLogs, deviceLogs, devices] = await Promise.all([
+          const [batches, devices] = await Promise.all([
             listBatchWindowsForUser(env.DB, partnership.watching_user_id, window.start, window.end),
-            listRiskDeviceLogsForUser(
-              env.DB,
-              partnership.watching_user_id,
-              window.start,
-              window.end,
-            ),
-            listDeviceLogsForUser(env.DB, partnership.watching_user_id, window.start, window.end),
             listDevicesForUser(env.DB, partnership.watching_user_id),
           ]);
 
@@ -166,12 +145,11 @@ export async function runNotificationSchedule(env: Env, now = Date.now()) {
               DEFAULT_CAPTURE_INTERVAL_MS,
               window,
             ),
-            tamperCounts: summarizeTamperCounts(riskLogs),
+            tamperCounts: summarizeTamperCounts(batches),
             missingLogDays: collectMissingLogPeriods(
               emailFrequency,
               devices,
               batches,
-              deviceLogs,
               window.start,
               window.end,
             ),

--- a/api/src/lib/tamper.ts
+++ b/api/src/lib/tamper.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_IMMEDIATE_TAMPER_SEVERITY, TamperSeverity, severityAtLeast } from './email-domain';
+import { TamperSeverity } from './email-domain';
 import { findUserById, listAcceptedNotificationTargetsForUser } from './db';
 import { sendEmail } from './email';
 import { renderTamperAlertTemplate } from './email/templates';
@@ -39,10 +39,6 @@ export async function notifyPartnersAboutRiskLog(
   const targets = await listAcceptedNotificationTargetsForUser(db, input.userId);
   for (const target of targets) {
     if (target.settings.email_frequency === 'none') {
-      continue;
-    }
-
-    if (!severityAtLeast(input.severity, DEFAULT_IMMEDIATE_TAMPER_SEVERITY)) {
       continue;
     }
 

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -58,9 +58,6 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
         };
       })
       .filter((item) => item !== null),
-    // Direct device logs were removed in #467: high-risk events now live inside the
-    // encrypted batches above. The field is retained (always empty) for API stability.
-    logs: [],
   });
 });
 

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { authenticateWebSession } from '../middleware/auth';
-import { canViewUserData, listBatches, listDeviceLogs } from '../lib/db';
+import { canViewUserData, listBatches } from '../lib/db';
 import { validateZ } from '../middleware/validation';
 import { Env, Variables } from '../types/bindings';
 
@@ -36,10 +36,7 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
     return c.json({ error: 'Forbidden' }, 403);
   }
 
-  const [batches, logs] = await Promise.all([
-    listBatches(c.env.DB, [targetUserId], { deviceId: device_id, since }),
-    listDeviceLogs(c.env.DB, [targetUserId], { deviceId: device_id, since }),
-  ]);
+  const batches = await listBatches(c.env.DB, [targetUserId], { deviceId: device_id, since });
 
   return c.json({
     batches: batches
@@ -61,15 +58,9 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
         };
       })
       .filter((item) => item !== null),
-    logs: logs.map((log) => ({
-      id: log.id,
-      device_id: log.device_id,
-      ts: log.ts,
-      type: log.type,
-      data: JSON.parse(log.data) as Record<string, unknown>,
-      created_at: log.created_at,
-      ...(log.risk !== null ? { risk: log.risk } : {}),
-    })),
+    // Direct device logs were removed in #467: high-risk events now live inside the
+    // encrypted batches above. The field is retained (always empty) for API stability.
+    logs: [],
   });
 });
 

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -6,7 +6,6 @@ import { validateZ } from '../middleware/validation';
 import {
   createBatch,
   createDevice,
-  createDeviceLog,
   createSessionRecord,
   getHashState,
   findDeviceById,
@@ -38,6 +37,8 @@ const uploadBatchSchema = z.object({
   start_time: z.coerce.number().int().nonnegative(),
   end_time: z.coerce.number().int().nonnegative(),
   access_keys: z.string().min(1),
+  high_risk_count: z.coerce.number().int().nonnegative().optional().default(0),
+  medium_risk_count: z.coerce.number().int().nonnegative().optional().default(0),
   file: z
     .instanceof(File)
     .refine((file) => file.size > 0, { message: 'File is empty' })
@@ -53,11 +54,12 @@ const accessKeysSchema = z.object({
   keys: z.array(accessKeyEntrySchema).min(1),
 });
 
-const deviceLogSchema = z.object({
+const notifySchema = z.object({
   ts: z.number().int().nonnegative(),
   type: z.string().min(1),
-  risk: z.number().min(0).max(1).optional(),
-  data: z.record(z.string(), z.unknown()).optional().default({}),
+  risk: z.number().min(0).max(1),
+  title: z.string().optional(),
+  details: z.string().optional(),
 });
 
 function parseAccessKeysPayload(raw: string) {
@@ -191,7 +193,8 @@ deviceOnly.post(
       return c.json({ error: 'Not found' }, 404);
     }
 
-    const { start_time, end_time, access_keys, file } = c.req.valid('form');
+    const { start_time, end_time, access_keys, high_risk_count, medium_risk_count, file } =
+      c.req.valid('form');
 
     const hashState = await readHashState(c, device.id);
     const endHash = encodeHex(hashState);
@@ -223,6 +226,8 @@ deviceOnly.post(
       end_time,
       end_hash: endHash,
       access_keys: JSON.stringify(parsedAccessKeys),
+      high_risk_count,
+      medium_risk_count,
       created_at: createdAt,
     });
     await resetHashState(c, device);
@@ -232,12 +237,16 @@ deviceOnly.post(
 );
 
 /**
- * POST /d/log - Submit a single non-batched log item.
+ * POST /d/notify - Send an alert email for a high-risk event.
+ *
+ * The event itself is uploaded (end-to-end encrypted) via POST /d/batch; this
+ * endpoint only carries the minimal metadata needed to render the notification
+ * email and is not persisted. Replaces the removed POST /d/log endpoint.
  */
 deviceOnly.post(
-  '/log',
+  '/notify',
   authenticateDeviceSession(),
-  validateZ('json', deviceLogSchema),
+  validateZ('json', notifySchema),
   async (c) => {
     const device = await findDeviceById(c.env.DB, c.get('sub'));
 
@@ -245,49 +254,29 @@ deviceOnly.post(
       return c.json({ error: 'Not found' }, 404);
     }
 
-    const log = c.req.valid('json');
-    const providedTitle = typeof log.data.title === 'string' ? log.data.title : undefined;
-    const providedDetails = typeof log.data.details === 'string' ? log.data.details : undefined;
-    const computedRisk = log.risk ?? null;
-    const computedSeverity = riskToSeverity(computedRisk);
-    const logId = uuidv4();
+    const notification = c.req.valid('json');
+    const severity = riskToSeverity(notification.risk);
 
-    await createDeviceLog(c.env.DB, {
-      id: logId,
-      user_id: device.owner,
-      device_id: device.id,
-      ts: log.ts,
-      type: log.type,
-      data: JSON.stringify(log.data),
-      risk: computedRisk,
-      created_at: Date.now(),
-    });
-
-    if (computedSeverity && computedRisk != null) {
+    if (severity) {
+      const providedTitle = notification.title?.trim();
+      const providedDetails = notification.details?.trim();
       await notifyPartnersAboutRiskLog(c.env.DB, c.env, {
-        logId,
+        logId: uuidv4(),
         appUrl: getAppUrl(c),
         userId: device.owner,
         deviceName: device.name,
-        severity: computedSeverity,
-        risk: computedRisk,
+        severity,
+        risk: notification.risk,
         title:
-          providedTitle && providedTitle.trim().length > 0
+          providedTitle && providedTitle.length > 0
             ? providedTitle
-            : `Device reported ${log.type.replaceAll('_', ' ')}.`,
-        details: providedDetails && providedDetails.trim().length > 0 ? providedDetails : null,
-        happenedAt: log.ts,
+            : `Device reported ${notification.type.replaceAll('_', ' ')}.`,
+        details: providedDetails && providedDetails.length > 0 ? providedDetails : null,
+        happenedAt: notification.ts,
       });
     }
 
-    return c.json(
-      {
-        id: logId,
-        ...log,
-        ...(computedRisk != null ? { risk: computedRisk } : {}),
-      },
-      201,
-    );
+    return c.json({ ok: true }, 202);
   },
 );
 

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -255,26 +255,22 @@ deviceOnly.post(
     }
 
     const notification = c.req.valid('json');
-    const severity = riskToSeverity(notification.risk);
-
-    if (severity) {
-      const providedTitle = notification.title?.trim();
-      const providedDetails = notification.details?.trim();
-      await notifyPartnersAboutRiskLog(c.env.DB, c.env, {
-        logId: uuidv4(),
-        appUrl: getAppUrl(c),
-        userId: device.owner,
-        deviceName: device.name,
-        severity,
-        risk: notification.risk,
-        title:
-          providedTitle && providedTitle.length > 0
-            ? providedTitle
-            : `Device reported ${notification.type.replaceAll('_', ' ')}.`,
-        details: providedDetails && providedDetails.length > 0 ? providedDetails : null,
-        happenedAt: notification.ts,
-      });
-    }
+    const providedTitle = notification.title?.trim();
+    const providedDetails = notification.details?.trim();
+    await notifyPartnersAboutRiskLog(c.env.DB, c.env, {
+      logId: uuidv4(),
+      appUrl: getAppUrl(c),
+      userId: device.owner,
+      deviceName: device.name,
+      severity: riskToSeverity(notification.risk) ?? 'info',
+      risk: notification.risk,
+      title:
+        providedTitle && providedTitle.length > 0
+          ? providedTitle
+          : `Device reported ${notification.type.replaceAll('_', ' ')}.`,
+      details: providedDetails && providedDetails.length > 0 ? providedDetails : null,
+      happenedAt: notification.ts,
+    });
 
     return c.json({ ok: true }, 202);
   },

--- a/api/src/schema/migrations/0008_notify_endpoint.sql
+++ b/api/src/schema/migrations/0008_notify_endpoint.sql
@@ -1,0 +1,13 @@
+-- #467: Replace the direct-log endpoint with a notification-only endpoint.
+--
+-- High-risk events now flow through the end-to-end encrypted batch pipeline
+-- instead of being stored unencrypted via POST /d/log. Batches carry a count of
+-- the high- and medium-risk events they contain so digest emails can still
+-- summarize tamper activity without reading the encrypted payload.
+
+ALTER TABLE batches ADD COLUMN high_risk_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE batches ADD COLUMN medium_risk_count INTEGER NOT NULL DEFAULT 0;
+
+-- The device_logs table stored unencrypted event bodies; it is no longer written
+-- to or read from now that high-risk events live in encrypted batches.
+DROP TABLE IF EXISTS device_logs;

--- a/api/test/auth-routes.test.ts
+++ b/api/test/auth-routes.test.ts
@@ -378,20 +378,6 @@ describe('Auth routes', () => {
     });
     expect(hashUploadRes.status).toBe(200);
 
-    const logRes = await SELF.fetch(`${BASE}/d/log`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({
-        ts: 1710000000000,
-        type: 'system_event',
-        data: { event: 'account-delete-test' },
-      }),
-    });
-    expect(logRes.status).toBe(201);
-
     const form = new FormData();
     form.set('start_time', '1710000000000');
     form.set('end_time', '1710003600000');
@@ -441,11 +427,6 @@ describe('Auth routes', () => {
         .first(),
     ).toBeNull();
 
-    expect(
-      await env.DB.prepare('SELECT COUNT(*) AS count FROM device_logs WHERE user_id = ?')
-        .bind(uuidToBytes(userId))
-        .first<{ count: number }>(),
-    ).toMatchObject({ count: 0 });
     expect(
       await env.DB.prepare('SELECT COUNT(*) AS count FROM user_sessions WHERE user_id = ?')
         .bind(uuidToBytes(userId))

--- a/api/test/data.test.ts
+++ b/api/test/data.test.ts
@@ -14,7 +14,7 @@ import {
 beforeEach(clearDB);
 
 describe('Data and device API routes', () => {
-  it('handles device registration, settings, log upload, batch upload, and filtered data listing', async () => {
+  it('handles device registration, settings, batch upload, and filtered data listing', async () => {
     const { cookie: userCookie, userId } = await signupAndGetCookie('alice@example.com');
     const device = await createDeviceForUser(userCookie, 'Phone', 'ios');
 
@@ -44,24 +44,6 @@ describe('Data and device API routes', () => {
       body: new Uint8Array(32).fill(7),
     });
     expect(hashUploadRes.status).toBe(200);
-
-    const logRes = await SELF.fetch(`${BASE}/d/log`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: 1710000000000, type: 'system_event', data: { event: 'startup' } }),
-    });
-    expect(logRes.status).toBe(201);
-    const uploadedLog = (await logRes.json()) as {
-      id: string;
-      type: string;
-      data: { event: string };
-    };
-    expect(uploadedLog.id).toBeTruthy();
-    expect(uploadedLog.type).toBe('system_event');
-    expect(uploadedLog.data.event).toBe('startup');
 
     const form = new FormData();
     form.set('start_time', '1710000000000');
@@ -118,26 +100,15 @@ describe('Data and device API routes', () => {
         encrypted_key: string;
         created_at: number;
       }>;
-      logs: Array<{
-        id: string;
-        device_id: string;
-        type: string;
-        data: { event: string };
-        created_at: number;
-      }>;
+      logs: unknown[];
     };
     expect(data.batches[0]).toMatchObject({
       device_id: device.id,
       encrypted_key: Buffer.from('owner-envelope').toString('base64'),
     });
     expect(data.batches[0]?.created_at).toEqual(expect.any(Number));
-    expect(data.logs[0]).toMatchObject({
-      device_id: device.id,
-      type: 'system_event',
-      data: { event: 'startup' },
-    });
-    expect(data.logs[0]?.id).toBeTruthy();
-    expect(data.logs[0]?.created_at).toEqual(expect.any(Number));
+    // Direct device logs were removed in #467; high-risk events now ride in batches.
+    expect(data.logs).toEqual([]);
 
     const serverToken = await createServerToken(device.id);
     const resetRes = await SELF.fetch(`${BASE}/hash`, {
@@ -147,7 +118,7 @@ describe('Data and device API routes', () => {
     expect(resetRes.status).toBe(200);
   });
 
-  it("returns the accepted partner's batch envelope and owner logs", async () => {
+  it("returns the accepted partner's batch envelope", async () => {
     const { cookie: ownerCookie, userId: ownerUserId } =
       await signupAndGetCookie('owner@example.com');
     const { cookie: partnerCookie, userId: partnerUserId } =
@@ -169,15 +140,6 @@ describe('Data and device API routes', () => {
       method: 'POST',
       headers: authHeaders(partnerCookie),
       body: JSON.stringify({ token: inviteMetadata.inviteToken }),
-    });
-
-    await SELF.fetch(`${BASE}/d/log`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: 1710000000000, type: 'system_event', data: { event: 'startup' } }),
     });
 
     const form = new FormData();
@@ -226,11 +188,9 @@ describe('Data and device API routes', () => {
     expect(partnerDataRes.status).toBe(200);
     const partnerData = (await partnerDataRes.json()) as {
       batches: Array<{ encrypted_key: string }>;
-      logs: Array<{ device_id: string }>;
     };
     expect(partnerData.batches[0]?.encrypted_key).toBe(
       Buffer.from('partner-envelope').toString('base64'),
     );
-    expect(partnerData.logs[0]?.device_id).toBe(device.id);
   });
 });

--- a/api/test/data.test.ts
+++ b/api/test/data.test.ts
@@ -100,15 +100,12 @@ describe('Data and device API routes', () => {
         encrypted_key: string;
         created_at: number;
       }>;
-      logs: unknown[];
     };
     expect(data.batches[0]).toMatchObject({
       device_id: device.id,
       encrypted_key: Buffer.from('owner-envelope').toString('base64'),
     });
     expect(data.batches[0]?.created_at).toEqual(expect.any(Number));
-    // Direct device logs were removed in #467; high-risk events now ride in batches.
-    expect(data.logs).toEqual([]);
 
     const serverToken = await createServerToken(device.id);
     const resetRes = await SELF.fetch(`${BASE}/hash`, {

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -228,7 +228,6 @@ export async function clearDB(): Promise<void> {
   await env.DB.prepare('DELETE FROM user_sessions').run();
   await env.DB.prepare('DELETE FROM device_sessions').run();
   await env.DB.prepare('DELETE FROM hash_states').run();
-  await env.DB.prepare('DELETE FROM device_logs').run();
   await env.DB.prepare('DELETE FROM batches').run();
   await env.DB.prepare('DELETE FROM partners').run();
   await env.DB.prepare('DELETE FROM devices').run();

--- a/api/test/notifications.test.ts
+++ b/api/test/notifications.test.ts
@@ -122,23 +122,16 @@ describe('Notification routes and tamper alerts', () => {
     });
 
     const device = await createDeviceForUser(ownerCookie, 'Workstation', 'linux');
-    const logRes = await SELF.fetch(`${BASE}/d/log`, {
+    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${device.refresh_token}`,
       },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 0.7, data: {} }),
+      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 0.7 }),
     });
 
-    expect(logRes.status).toBe(201);
-
-    const storedLog = await env.DB.prepare(
-      'SELECT risk FROM device_logs WHERE device_id = ? ORDER BY created_at DESC LIMIT 1',
-    )
-      .bind(uuidToBytes(device.id))
-      .first<{ risk: number | null }>();
-    expect(storedLog?.risk).toBe(0.7);
+    expect(logRes.status).toBe(202);
 
     const deliveries = await listEmailDeliveries();
     expect(deliveries.some((delivery) => delivery.kind === 'tamper_alert')).toBe(true);
@@ -147,6 +140,61 @@ describe('Notification routes and tamper alerts', () => {
     ).toBe(true);
     const tamperDelivery = deliveries.find((delivery) => delivery.kind === 'tamper_alert');
     expect(tamperDelivery?.text).toContain('Device: Workstation');
+  });
+
+  it('passes custom title/details through to the rendered tamper alert email', async () => {
+    const { cookie: ownerCookie } = await signupAndGetCookie('custom-owner@example.com', 'pw');
+    const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
+      'custom-partner@example.com',
+      'pw',
+    );
+    await markUserEmailVerified(partnerUserId);
+
+    const inviteRes = await SELF.fetch(`${BASE}/partner`, {
+      method: 'POST',
+      headers: authHeaders(ownerCookie),
+      body: JSON.stringify({
+        email: 'custom-partner@example.com',
+      }),
+    });
+    await inviteRes.json();
+    const inviteDelivery = (await listEmailDeliveries()).find(
+      (delivery) =>
+        delivery.kind === 'partner_invite' &&
+        delivery.recipient_email === 'custom-partner@example.com',
+    );
+    const inviteMetadata = JSON.parse(inviteDelivery!.metadata) as { inviteToken: string };
+
+    await SELF.fetch(`${BASE}/partner/accept`, {
+      method: 'POST',
+      headers: authHeaders(partnerCookie),
+      body: JSON.stringify({ token: inviteMetadata.inviteToken }),
+    });
+
+    const device = await createDeviceForUser(ownerCookie, 'Workstation', 'linux');
+    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${device.refresh_token}`,
+      },
+      body: JSON.stringify({
+        ts: Date.now(),
+        type: 'service_stop',
+        risk: 0.7,
+        title: 'Custom alert title',
+        details: 'Custom alert details',
+      }),
+    });
+
+    expect(logRes.status).toBe(202);
+
+    const tamperDelivery = (await listEmailDeliveries()).find(
+      (delivery) => delivery.kind === 'tamper_alert',
+    );
+    expect(tamperDelivery?.subject).toContain('Custom alert title');
+    expect(tamperDelivery?.text).toContain('Custom alert title');
+    expect(tamperDelivery?.text).toContain('Custom alert details');
   });
 
   it('does not send immediate tamper alerts for moderate-risk device log events', async () => {
@@ -180,16 +228,16 @@ describe('Notification routes and tamper alerts', () => {
 
     const device = await createDeviceForUser(ownerCookie, 'Laptop', 'linux');
     const baselineCount = (await listEmailDeliveries()).length;
-    const logRes = await SELF.fetch(`${BASE}/d/log`, {
+    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${device.refresh_token}`,
       },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 0.69, data: {} }),
+      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 0.69 }),
     });
 
-    expect(logRes.status).toBe(201);
+    expect(logRes.status).toBe(202);
     expect(await listEmailDeliveries()).toHaveLength(baselineCount);
   });
 
@@ -225,25 +273,27 @@ describe('Notification routes and tamper alerts', () => {
     const device = await createDeviceForUser(ownerCookie, 'Desktop', 'linux');
     const baselineCount = (await listEmailDeliveries()).length;
 
-    const zeroRiskRes = await SELF.fetch(`${BASE}/d/log`, {
+    // Zero risk is accepted but produces no alert email.
+    const zeroRiskRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${device.refresh_token}`,
       },
-      body: JSON.stringify({ ts: Date.now(), type: 'heartbeat', risk: 0, data: {} }),
+      body: JSON.stringify({ ts: Date.now(), type: 'heartbeat', risk: 0 }),
     });
-    expect(zeroRiskRes.status).toBe(201);
+    expect(zeroRiskRes.status).toBe(202);
 
-    const missingRiskRes = await SELF.fetch(`${BASE}/d/log`, {
+    // Risk is required on the notify endpoint (only high-risk events call it).
+    const missingRiskRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${device.refresh_token}`,
       },
-      body: JSON.stringify({ ts: Date.now(), type: 'heartbeat', data: {} }),
+      body: JSON.stringify({ ts: Date.now(), type: 'heartbeat' }),
     });
-    expect(missingRiskRes.status).toBe(201);
+    expect(missingRiskRes.status).toBe(400);
 
     expect(await listEmailDeliveries()).toHaveLength(baselineCount);
   });
@@ -284,16 +334,16 @@ describe('Notification routes and tamper alerts', () => {
 
     const device = await createDeviceForUser(ownerCookie, 'Muted Device', 'linux');
     const baselineCount = (await listEmailDeliveries()).length;
-    const logRes = await SELF.fetch(`${BASE}/d/log`, {
+    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${device.refresh_token}`,
       },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 1, data: {} }),
+      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 1 }),
     });
 
-    expect(logRes.status).toBe(201);
+    expect(logRes.status).toBe(202);
     const deliveries = await listEmailDeliveries();
     expect(deliveries).toHaveLength(baselineCount);
     expect(deliveries.some((delivery) => delivery.kind === 'tamper_alert')).toBe(false);
@@ -332,16 +382,16 @@ describe('Notification routes and tamper alerts', () => {
 
     const device = await createDeviceForUser(ownerCookie, 'Quiet Device', 'linux');
     const baselineCount = (await listEmailDeliveries()).length;
-    const logRes = await SELF.fetch(`${BASE}/d/log`, {
+    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${device.refresh_token}`,
       },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 1, data: {} }),
+      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 1 }),
     });
 
-    expect(logRes.status).toBe(201);
+    expect(logRes.status).toBe(202);
     expect(await listEmailDeliveries()).toHaveLength(baselineCount);
   });
 });

--- a/api/test/notifications.test.ts
+++ b/api/test/notifications.test.ts
@@ -197,7 +197,7 @@ describe('Notification routes and tamper alerts', () => {
     expect(tamperDelivery?.text).toContain('Custom alert details');
   });
 
-  it('does not send immediate tamper alerts for moderate-risk device log events', async () => {
+  it('sends immediate tamper alerts for moderate-risk device log events', async () => {
     const { cookie: ownerCookie } = await signupAndGetCookie('moderate-owner@example.com', 'pw');
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'moderate-partner@example.com',
@@ -227,7 +227,6 @@ describe('Notification routes and tamper alerts', () => {
     });
 
     const device = await createDeviceForUser(ownerCookie, 'Laptop', 'linux');
-    const baselineCount = (await listEmailDeliveries()).length;
     const logRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
@@ -238,10 +237,12 @@ describe('Notification routes and tamper alerts', () => {
     });
 
     expect(logRes.status).toBe(202);
-    expect(await listEmailDeliveries()).toHaveLength(baselineCount);
+    expect((await listEmailDeliveries()).some((delivery) => delivery.kind === 'tamper_alert')).toBe(
+      true,
+    );
   });
 
-  it('treats zero or absent risk as non-tamper', async () => {
+  it('sends an immediate tamper alert even for zero risk; requires the risk field', async () => {
     const { cookie: ownerCookie } = await signupAndGetCookie('non-tamper-owner@example.com', 'pw');
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'non-tamper-partner@example.com',
@@ -271,9 +272,9 @@ describe('Notification routes and tamper alerts', () => {
     });
 
     const device = await createDeviceForUser(ownerCookie, 'Desktop', 'linux');
-    const baselineCount = (await listEmailDeliveries()).length;
 
-    // Zero risk is accepted but produces no alert email.
+    // The notify endpoint doesn't re-filter by risk — the client's uploader only
+    // calls it for high-risk events, so any call here should send an alert.
     const zeroRiskRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
@@ -283,8 +284,11 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ ts: Date.now(), type: 'heartbeat', risk: 0 }),
     });
     expect(zeroRiskRes.status).toBe(202);
+    expect((await listEmailDeliveries()).some((delivery) => delivery.kind === 'tamper_alert')).toBe(
+      true,
+    );
 
-    // Risk is required on the notify endpoint (only high-risk events call it).
+    // Risk is still a required field on the notify endpoint.
     const missingRiskRes = await SELF.fetch(`${BASE}/d/notify`, {
       method: 'POST',
       headers: {
@@ -294,8 +298,6 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ ts: Date.now(), type: 'heartbeat' }),
     });
     expect(missingRiskRes.status).toBe(400);
-
-    expect(await listEmailDeliveries()).toHaveLength(baselineCount);
   });
 
   it('stops all partner emails when receive emails is disabled', async () => {

--- a/api/test/scheduler.test.ts
+++ b/api/test/scheduler.test.ts
@@ -15,7 +15,6 @@ import {
 beforeEach(clearDB);
 
 const DAILY_BATCH_ID = '00000000-0000-4000-8000-000000000001';
-const DAILY_RISK_LOG_ID = '00000000-0000-4000-8000-000000000002';
 const WEEKLY_BATCH_ID = '00000000-0000-4000-8000-000000000003';
 const OLD_DAILY_BATCH_ID = '00000000-0000-4000-8000-000000000004';
 const EMPTY_ACCESS_KEYS = JSON.stringify({ keys: [] });
@@ -28,7 +27,6 @@ describe('Notification scheduler', () => {
     const withinWindowBatchEnd = Date.UTC(2026, 0, 5, 12, 0, 0);
     const oldBatchStart = Date.UTC(2026, 0, 5, 0, 0, 0);
     const oldBatchEnd = Date.UTC(2026, 0, 5, 2, 0, 0);
-    const riskLogTime = Date.UTC(2026, 0, 5, 15, 0, 0);
 
     const { cookie: ownerCookie, userId: ownerId } = await signupAndGetCookie(
       'digest-owner@example.com',
@@ -75,8 +73,8 @@ describe('Notification scheduler', () => {
       .run();
 
     await env.DB.prepare(
-      `INSERT INTO batches (id, user_id, device_id, url, start_time, end_time, end_hash, access_keys, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO batches (id, user_id, device_id, url, start_time, end_time, end_hash, access_keys, high_risk_count, medium_risk_count, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
       .bind(
         uuidToBytes(DAILY_BATCH_ID),
@@ -87,6 +85,8 @@ describe('Notification scheduler', () => {
         withinWindowBatchEnd,
         'hash-1',
         EMPTY_ACCESS_KEYS,
+        1,
+        0,
         withinWindowBatchEnd,
       )
       .run();
@@ -105,22 +105,6 @@ describe('Notification scheduler', () => {
         'hash-old',
         EMPTY_ACCESS_KEYS,
         oldBatchEnd,
-      )
-      .run();
-
-    await env.DB.prepare(
-      `INSERT INTO device_logs (id, user_id, device_id, ts, type, data, risk, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-      .bind(
-        uuidToBytes(DAILY_RISK_LOG_ID),
-        uuidToBytes(ownerId),
-        uuidToBytes(device.id),
-        riskLogTime,
-        'system_shutdown',
-        JSON.stringify({ title: 'Monitoring interruption detected' }),
-        0.7,
-        riskLogTime,
       )
       .run();
 

--- a/api/test/setup.ts
+++ b/api/test/setup.ts
@@ -37,6 +37,8 @@ CREATE TABLE IF NOT EXISTS batches (
   end_time INTEGER NOT NULL,
   end_hash TEXT NOT NULL,
   access_keys TEXT NOT NULL,
+  high_risk_count INTEGER NOT NULL DEFAULT 0,
+  medium_risk_count INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
   FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
@@ -61,23 +63,6 @@ CREATE TABLE IF NOT EXISTS partners (
 CREATE INDEX IF NOT EXISTS idx_partners_watching_user_id ON partners(watching_user_id);
 CREATE INDEX IF NOT EXISTS idx_partners_watcher_user_id ON partners(watcher_user_id);
 CREATE INDEX IF NOT EXISTS idx_partners_status ON partners(status);
-
-CREATE TABLE IF NOT EXISTS device_logs (
-  id BLOB PRIMARY KEY,
-  user_id BLOB NOT NULL,
-  device_id BLOB NOT NULL,
-  ts INTEGER NOT NULL,
-  type TEXT NOT NULL,
-  data TEXT NOT NULL,
-  risk REAL,
-  created_at INTEGER NOT NULL,
-  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_device_logs_user_id_created_at ON device_logs(user_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_device_logs_device_id ON device_logs(device_id);
-CREATE INDEX IF NOT EXISTS idx_device_logs_created_at ON device_logs(created_at);
-CREATE INDEX IF NOT EXISTS idx_device_logs_risk ON device_logs(risk);
 
 CREATE TABLE IF NOT EXISTS email_tokens (
   id BLOB PRIMARY KEY,

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -25,8 +25,8 @@ Observer state is persisted to `event_state.json` after each iteration.
 
 ### Upload / batching / hash chain
 
-- `core/src/module/upload.rs` — `UploadModule`: manages 3 queues (hash immediate, batch,
-  direct immediate), retry logic
+- `core/src/module/upload.rs` — `UploadModule`: manages 3 queues (hash-pending, batch-pending,
+  notify-pending), retry logic
 - `core/src/module/upload/batch.rs` — `BatchBuilder`: msgpack + gzip batch construction
 - `core/src/crypto.rs` — AES-256-GCM encryption, HPKE key wrap, `compute_event_hash`,
   `encode_batch_event`

--- a/client/core/architecture.md
+++ b/client/core/architecture.md
@@ -34,7 +34,7 @@ client/
         lifecycle.rs    — LifecycleModule: process/suspend/ping-gap alerts
         screenshot.rs   — ScreenshotModule: interval scheduling + capture
         status.rs       — StatusModule: partial-status aggregation
-        upload.rs       — UploadModule: hash/batch/immediate queues
+        upload.rs       — UploadModule: hash-pending, batch-pending, and notify-pending queues
       platform.rs       — ScreenshotHooks / PlatformHooks traits
       state.rs          — load_state / store_state (event_state.json)
       storage.rs        — auth.json, device_settings.json, stop_intent.json
@@ -317,6 +317,22 @@ immediately before every batch upload — this is the sole refresh path, so a pa
 added or removed is picked up on the very next batch. A transient refetch failure
 falls back to the last known settings; a 404/401 means the device is gone and
 triggers logout.
+
+Each `BatchUpload` also carries `high_risk_count`/`medium_risk_count`: tallies of how many
+events in the batch fall in the high (`risk >= 0.7`) and medium (`0.4 <= risk < 0.7`) bands,
+thresholds mirroring `shared-web/risk.ts`. These are computed client-side from per-event
+`risk` values before encryption, so the server can summarize tamper activity in partner
+digest emails without ever decrypting the batch.
+
+## Notify flow
+
+High-risk events (`risk >= lifecycle::EXTRA_HIGH_RISK`) are additionally pushed into
+`UploadModule`'s `pending_notify_events: Vec<NotifyPayload>` queue, where
+`NotifyPayload { ts, type, risk, title?, details? }`. `retry_pending_notifies` drains this
+queue by POSTing each payload to `/d/notify` once the device is authenticated. This happens
+independently of, but alongside, the always-present hash/batch path — the event body itself
+still goes through the normal encrypted batch pipeline; `/d/notify` only triggers the alert
+email.
 
 ## Hash chain
 

--- a/client/core/src/api.rs
+++ b/client/core/src/api.rs
@@ -8,15 +8,10 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::crypto::derive_password_auth;
 use crate::error::{CoreError, CoreResult};
-use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, HashParams, LogEntry};
+use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, HashParams, NotifyPayload};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadedBatchResponse {
-    pub id: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct UploadedLogResponse {
     pub id: String,
 }
 
@@ -36,11 +31,7 @@ pub trait ApiTransport: Send + Sync {
         device_refresh_token: &str,
         batch: &BatchUpload,
     ) -> CoreResult<UploadedBatchResponse>;
-    fn upload_log(
-        &self,
-        device_refresh_token: &str,
-        log: &LogEntry,
-    ) -> CoreResult<UploadedLogResponse>;
+    fn notify(&self, device_refresh_token: &str, payload: &NotifyPayload) -> CoreResult<()>;
     fn upload_hash(
         &self,
         hash_base_url: Option<&str>,
@@ -241,22 +232,20 @@ impl ApiTransport for ReqwestApiClient {
             .part("file", part)
             .text("start_time", batch.start_time_ms.to_string())
             .text("end_time", batch.end_time_ms.to_string())
+            .text("high_risk_count", batch.high_risk_count.to_string())
+            .text("medium_risk_count", batch.medium_risk_count.to_string())
             .text("access_keys", access_keys);
 
         self.send_form(Method::POST, None, "/d/batch", device_refresh_token, form)
     }
 
-    fn upload_log(
-        &self,
-        device_refresh_token: &str,
-        log: &LogEntry,
-    ) -> CoreResult<UploadedLogResponse> {
-        self.send_json(
+    fn notify(&self, device_refresh_token: &str, payload: &NotifyPayload) -> CoreResult<()> {
+        self.send_empty(
             Method::POST,
             None,
-            "/d/log",
+            "/d/notify",
             Some(device_refresh_token),
-            Some(log),
+            Some(payload),
         )
     }
 

--- a/client/core/src/controller.rs
+++ b/client/core/src/controller.rs
@@ -8,6 +8,7 @@ use crate::module::lifecycle::{
     UserStopRequested,
 };
 use crate::module::status::{StatusRequest, StatusResponse};
+use crate::module::upload::{FlushBatchNow, Upload};
 
 /// High-level client for communicating with a daemon over any [`EventChannel`].
 ///
@@ -90,6 +91,18 @@ impl<C: EventChannel> ClientController<C> {
 
     pub fn note_process_stopped(&self, reason: ProcessStoppedReason) -> CoreResult<()> {
         self.channel.publish(ProcessStopped(reason))
+    }
+
+    /// Queue `upload` into the daemon's live batch/hash pipeline. Picked up on
+    /// the daemon's next ping cycle (≤1s), same as an in-process `Upload`.
+    pub fn queue_upload(&self, upload: Upload) -> CoreResult<()> {
+        self.channel.publish(upload)
+    }
+
+    /// Ask the daemon to flush its currently queued batch items now, instead
+    /// of waiting for the batch interval timer.
+    pub fn flush_batch_now(&self) -> CoreResult<()> {
+        self.channel.publish(FlushBatchNow)
     }
 
     /// Register a handler for events the daemon pushes unprompted.

--- a/client/core/src/ipc_bridge.rs
+++ b/client/core/src/ipc_bridge.rs
@@ -9,6 +9,7 @@ use crate::module::lifecycle::{
     UserStopRequested,
 };
 use crate::module::status::{StatusRequest, StatusResponse};
+use crate::module::upload::{FlushBatchNow, Upload};
 
 pub struct IpcBridge {
     accept_rx: std::sync::mpsc::Receiver<RemoteEventBus>,
@@ -78,7 +79,7 @@ impl IpcBridge {
     /// into the bus via `emitter`:
     /// `LoginRequested`, `LogoutRequested`, `StatusRequest`, `UserStopRequested`,
     /// `UserSessionLogin`, `UserSessionLogout`, `ComputerSuspended`, `ComputerResumed`,
-    /// `ProcessStopped`.
+    /// `ProcessStopped`, `Upload`, `FlushBatchNow`.
     pub fn forward_standard_inbound(remote: &mut RemoteEventBus, emitter: &Emitter) {
         macro_rules! forward {
             ($($T:ty),* $(,)?) => {
@@ -95,6 +96,8 @@ impl IpcBridge {
             ComputerSuspended,
             ComputerResumed,
             ProcessStopped,
+            Upload,
+            FlushBatchNow,
         );
     }
 

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -180,6 +180,25 @@ pub struct BatchUpload {
     #[serde(with = "serde_bytes")]
     pub bytes: Vec<u8>,
     pub access_keys: Vec<BatchAccessKey>,
+    /// Number of events in this batch whose risk fell in the high band (>= 0.7).
+    pub high_risk_count: u32,
+    /// Number of events in this batch whose risk fell in the medium band (0.4–0.7).
+    pub medium_risk_count: u32,
+}
+
+/// Minimal metadata sent to `POST /d/notify` to trigger an alert email for a
+/// high-risk event. The event body itself is uploaded end-to-end encrypted via a
+/// batch; this payload carries only what the notification email needs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotifyPayload {
+    pub ts: i64,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub risk: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -471,8 +471,15 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         }
 
         self.retry_pending_hashes()?;
+        // Force the batch out before sending any queued notify emails so the
+        // event(s) they reference already exist server-side by the time the
+        // email goes out, rather than waiting on the interval timer.
+        if self.state.pending_notify_events.is_empty() {
+            self.maybe_upload_batch(now_ms, emitter)?;
+        } else {
+            self.try_upload_batch(now_ms, emitter)?;
+        }
         self.retry_pending_notifies()?;
-        self.maybe_upload_batch(now_ms, emitter)?;
         Ok(())
     }
 
@@ -509,8 +516,11 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         let screen_active = !self.platform.is_locked_or_screensaver()?;
         if screen_active || is_heartbeat {
             self.retry_pending_hashes()?;
-            if is_heartbeat {
+            if is_heartbeat || is_high_risk {
                 // Force an immediate batch flush — don't wait for the interval timer.
+                // For a high-risk event this also guarantees the encrypted event is
+                // uploaded before the notify email below goes out, so the event
+                // already exists server-side when the recipient follows the link.
                 self.try_upload_batch(now_ms, emitter)?;
             } else {
                 self.maybe_upload_batch(now_ms, emitter)?;
@@ -913,6 +923,90 @@ mod tests {
         assert!(
             !t.api.state().batch_uploads.is_empty(),
             "heartbeat should flush batch even while locked"
+        );
+    }
+
+    #[test]
+    fn extra_high_risk_upload_forces_batch_flush_regardless_of_interval() {
+        let mut b = EventTester::builder();
+        // Huge interval so `maybe_upload_batch` would never fire on its own.
+        b.add(UploadModule::new(
+            Box::new(b.platform()),
+            b.api(),
+            24 * 60 * 60 * 1_000,
+        ));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        t.emit(
+            2,
+            Upload {
+                risk: crate::module::lifecycle::EXTRA_HIGH_RISK,
+                kind: UploadKind::Alert {
+                    message: "tamper detected".into(),
+                },
+            },
+        );
+
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            1,
+            "extra-high-risk upload should force an immediate batch flush"
+        );
+        assert_eq!(
+            t.api.state().notify_calls.len(),
+            1,
+            "extra-high-risk upload should still send the notify email"
+        );
+        assert!(
+            t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_batch_events
+                .is_empty(),
+            "the event should have been uploaded, not left queued"
+        );
+    }
+
+    #[test]
+    fn ping_forces_batch_flush_before_sending_queued_notify() {
+        let mut b = EventTester::builder();
+        b.platform().set_locked_or_screensaver(true);
+        b.add(UploadModule::new(
+            Box::new(b.platform()),
+            b.api(),
+            24 * 60 * 60 * 1_000,
+        ));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        // Extra-high-risk event arrives while locked: queued for later, no
+        // network I/O yet (matches the existing locked-screen deferral).
+        t.emit(
+            2,
+            Upload {
+                risk: crate::module::lifecycle::EXTRA_HIGH_RISK,
+                kind: UploadKind::Alert {
+                    message: "tamper detected".into(),
+                },
+            },
+        );
+        assert!(t.api.state().batch_uploads.is_empty());
+        assert!(t.api.state().notify_calls.is_empty());
+
+        // Screen unlocks; the next ping should flush the batch before sending
+        // the queued notify, even though the batch interval hasn't elapsed.
+        t.platform.set_locked_or_screensaver(false);
+        t.emit(3, Ping);
+
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            1,
+            "ping should force the batch out ahead of the queued notify"
+        );
+        assert_eq!(
+            t.api.state().notify_calls.len(),
+            1,
+            "queued notify should still go out"
         );
     }
 

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -272,6 +272,20 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         Ok(())
     }
 
+    /// Only sends queued notify emails once the hash + batch pipeline is confirmed
+    /// fully drained. `try_upload_batch`/`maybe_upload_batch` can return `Ok(())` on a
+    /// deferred/transient failure (no recipients yet, device settings refresh failed,
+    /// upload rejected) without actually uploading, so a plain `Ok(())` from those calls
+    /// is not sufficient evidence that a queued notify's event reached the server. An
+    /// empty `pending_hash_events` + `pending_batch_events` is: every event has been
+    /// hashed *and* its batch has been accepted.
+    fn retry_pending_notifies_if_flushed(&mut self) -> CoreResult<()> {
+        if self.state.pending_hash_events.is_empty() && self.state.pending_batch_events.is_empty() {
+            self.retry_pending_notifies()?;
+        }
+        Ok(())
+    }
+
     fn maybe_upload_batch(&mut self, now_ms: i64, emitter: &Emitter) -> CoreResult<()> {
         // Whether we have recipients to wrap for is decided in `try_upload_batch`
         // after refetching settings, not from the (possibly stale) cached copy.
@@ -413,7 +427,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         } else {
             self.try_upload_batch(now_ms, emitter)?;
         }
-        self.retry_pending_notifies()?;
+        self.retry_pending_notifies_if_flushed()?;
         Ok(())
     }
 
@@ -461,7 +475,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             }
         }
         if is_high_risk && screen_active {
-            self.retry_pending_notifies()?;
+            self.retry_pending_notifies_if_flushed()?;
         }
         Ok(())
     }
@@ -941,6 +955,72 @@ mod tests {
             t.api.state().notify_calls.len(),
             1,
             "queued notify should still go out"
+        );
+    }
+
+    #[test]
+    fn transient_batch_failure_defers_notify_until_batch_actually_lands() {
+        let mut b = EventTester::builder();
+        // Huge interval so `maybe_upload_batch` would never fire on its own.
+        b.add(UploadModule::new(
+            Box::new(b.platform()),
+            b.api(),
+            24 * 60 * 60 * 1_000,
+        ));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        // The batch upload fails transiently (e.g. a network blip): `try_upload_batch`
+        // logs and returns `Ok(())` without actually uploading or draining the queue.
+        t.api
+            .program_batch(Err(crate::error::CoreError::HttpStatus {
+                status: 503,
+                message: "boom".into(),
+            }));
+
+        t.emit(
+            2,
+            Upload {
+                risk: crate::module::lifecycle::EXTRA_HIGH_RISK,
+                kind: UploadKind::Alert {
+                    message: "tamper detected".into(),
+                },
+            },
+        );
+
+        // The event hasn't actually reached the server, so the notify email must not
+        // go out yet even though this is the extra-high-risk "flush immediately" path.
+        assert!(
+            t.api.state().notify_calls.is_empty(),
+            "notify must not fire while the batch upload has not actually landed"
+        );
+        assert!(
+            !t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_batch_events
+                .is_empty(),
+            "event should remain queued after a deferred batch failure"
+        );
+        assert!(
+            !t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_notify_events
+                .is_empty(),
+            "notify should remain queued after a deferred batch failure"
+        );
+
+        // A later ping, once the batch upload starts succeeding again, should flush the
+        // batch and only then release the queued notify.
+        t.emit(3, Ping);
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            2,
+            "one failed attempt from the Upload event, one successful retry from the Ping"
+        );
+        assert_eq!(
+            t.api.state().notify_calls.len(),
+            1,
+            "notify should fire only after the batch actually landed"
         );
     }
 

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -28,22 +28,133 @@ pub struct Upload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlushBatchNow;
 use crate::model::{
-    BatchRecipient, BatchUpload, DeviceCredentials, DeviceSettings, LogEntry, ProcessStoppedReason,
-    UploadKind,
+    BatchRecipient, BatchUpload, DeviceCredentials, DeviceSettings, LogEntry, NotifyPayload,
+    ProcessStoppedReason, UploadKind,
 };
 use crate::platform::ScreenshotHooks;
 
 pub(crate) const POST_LOGIN_PROOF_BATCH_COUNT: u32 = 3;
 
+/// A hash-uploaded event awaiting batch upload, paired with its risk so the batch
+/// upload can report how many high/medium-risk events it carries.
+///
+/// Serialized as `[ts, risk, encoded]`. For backward compatibility with state
+/// written before #467 it also deserializes the legacy `[ts, encoded]` shape,
+/// defaulting `risk` to `0.0`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingBatchEvent {
+    pub ts: i64,
+    pub risk: f32,
+    pub encoded: Vec<u8>,
+}
+
+impl Serialize for PendingBatchEvent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(3))?;
+        seq.serialize_element(&self.ts)?;
+        seq.serialize_element(&self.risk)?;
+        seq.serialize_element(&self.encoded)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for PendingBatchEvent {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct PendingBatchEventVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PendingBatchEventVisitor {
+            type Value = PendingBatchEvent;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a [ts, risk, encoded] or legacy [ts, encoded] sequence")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<PendingBatchEvent, A::Error> {
+                use serde::de::Error;
+                let ts: i64 = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                // The second element distinguishes the two shapes: a number is the
+                // risk (new form), an array is the encoded event (legacy form).
+                let second: serde_json::Value = seq
+                    .next_element()?
+                    .ok_or_else(|| A::Error::invalid_length(1, &self))?;
+                match second {
+                    serde_json::Value::Array(_) => {
+                        let encoded = serde_json::from_value(second).map_err(A::Error::custom)?;
+                        Ok(PendingBatchEvent {
+                            ts,
+                            risk: 0.0,
+                            encoded,
+                        })
+                    }
+                    serde_json::Value::Number(number) => {
+                        let risk = number.as_f64().unwrap_or(0.0) as f32;
+                        let encoded: Vec<u8> = seq
+                            .next_element()?
+                            .ok_or_else(|| A::Error::invalid_length(2, &self))?;
+                        Ok(PendingBatchEvent { ts, risk, encoded })
+                    }
+                    _ => Err(A::Error::custom(
+                        "unexpected second element in pending batch event",
+                    )),
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(PendingBatchEventVisitor)
+    }
+}
+
+/// Builds the notification payload for a high-risk event. Title/details are pulled
+/// from the event body when present (e.g. `Dev` events); otherwise the server
+/// derives a fallback title from the event type.
+fn build_notify_payload(entry: &LogEntry) -> NotifyPayload {
+    let value = serde_json::to_value(&entry.event).unwrap_or(serde_json::Value::Null);
+    let event_type = value
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("event")
+        .to_string();
+    let data = value.get("data");
+    let title = data
+        .and_then(|d| d.get("title"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let details = data
+        .and_then(|d| d.get("details"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    NotifyPayload {
+        ts: entry.ts,
+        event_type,
+        risk: entry.risk.unwrap_or(0.0),
+        title,
+        details,
+    }
+}
+
 const MAX_HASH_RETRIES_PER_LOOP: usize = 8;
-const MAX_DIRECT_LOG_RETRIES_PER_LOOP: usize = 8;
+const MAX_NOTIFY_RETRIES_PER_LOOP: usize = 8;
 const HASH_TOKEN_MAX_AGE: Duration = Duration::from_secs(55 * 60);
+
+/// Risk-rating band thresholds mirroring `shared-web/risk.ts` (`getRiskRating`).
+/// A batch reports how many of its events land in the high (>= 0.7) and medium
+/// (0.4–0.7) bands so the server can summarize tamper activity in digest emails
+/// without reading the encrypted payload.
+const HIGH_RISK_RATING: f32 = 0.7;
+const MEDIUM_RISK_RATING: f32 = 0.4;
 
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct UploadObserverState {
-    pub pending_batch_events: Vec<(i64, Vec<u8>)>,
+    pub pending_batch_events: Vec<PendingBatchEvent>,
     pub pending_hash_events: Vec<LogEntry>,
-    pub pending_immediate_events: Vec<LogEntry>,
+    #[serde(default)]
+    pub pending_notify_events: Vec<NotifyPayload>,
     pub last_batch_at_ms: Option<i64>,
     pub post_login_proof_batches_remaining: u32,
     #[serde(default)]
@@ -56,7 +167,7 @@ impl UploadObserverState {
     pub fn reset_for_login(&mut self) {
         self.pending_batch_events.clear();
         self.pending_hash_events.clear();
-        self.pending_immediate_events.clear();
+        self.pending_notify_events.clear();
         self.last_batch_at_ms = None;
         self.post_login_proof_batches_remaining = POST_LOGIN_PROOF_BATCH_COUNT;
     }
@@ -64,7 +175,7 @@ impl UploadObserverState {
     pub fn reset_for_logout(&mut self) {
         self.pending_batch_events.clear();
         self.pending_hash_events.clear();
-        self.pending_immediate_events.clear();
+        self.pending_notify_events.clear();
         self.last_batch_at_ms = None;
         self.post_login_proof_batches_remaining = 0;
         self.settings = None;
@@ -73,7 +184,7 @@ impl UploadObserverState {
 
     pub fn pending_request_count(&self) -> usize {
         self.pending_hash_events.len()
-            + self.pending_immediate_events.len()
+            + self.pending_notify_events.len()
             + usize::from(!self.pending_batch_events.is_empty())
     }
 }
@@ -133,13 +244,13 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             .map(|_| ())
     }
 
-    fn upload_log(&self, entry: &LogEntry) -> CoreResult<()> {
+    fn notify(&self, payload: &NotifyPayload) -> CoreResult<()> {
         let creds = self
             .state
             .device_credentials
             .as_ref()
             .ok_or(CoreError::NotAuthenticated)?;
-        self.api.upload_log(&creds.refresh_token, entry).map(|_| ())
+        self.api.notify(&creds.refresh_token, payload).map(|_| ())
     }
 
     fn upload_hash(
@@ -198,7 +309,11 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 let hash = compute_event_hash(&encoded);
                 match self.upload_hash(hash_base_url.as_deref(), &hash) {
                     Ok(()) => {
-                        self.state.pending_batch_events.push((event.ts, encoded));
+                        self.state.pending_batch_events.push(PendingBatchEvent {
+                            ts: event.ts,
+                            risk: event.risk.unwrap_or(0.0),
+                            encoded,
+                        });
                         None
                     }
                     Err(_) => Some(event),
@@ -207,18 +322,18 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         Ok(())
     }
 
-    fn retry_pending_immediates(&mut self) -> CoreResult<()> {
-        let events = std::mem::take(&mut self.state.pending_immediate_events);
-        self.state.pending_immediate_events =
-            drain_retry_queue(events, MAX_DIRECT_LOG_RETRIES_PER_LOOP, |entry| match self
-                .upload_log(&entry)
-            {
-                Ok(()) => None,
-                Err(err) if err.is_bad_request() => {
-                    log_error("direct log upload failed permanently", Some(&err));
-                    None
+    fn retry_pending_notifies(&mut self) -> CoreResult<()> {
+        let events = std::mem::take(&mut self.state.pending_notify_events);
+        self.state.pending_notify_events =
+            drain_retry_queue(events, MAX_NOTIFY_RETRIES_PER_LOOP, |payload| {
+                match self.notify(&payload) {
+                    Ok(()) => None,
+                    Err(err) if err.is_bad_request() => {
+                        log_error("notify failed permanently", Some(&err));
+                        None
+                    }
+                    Err(_) => Some(payload),
                 }
-                Err(_) => Some(entry),
             });
         Ok(())
     }
@@ -294,9 +409,14 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             .len()
             .min(MAX_BATCH_ITEMS_PER_UPLOAD);
         let mut items = self.state.pending_batch_events[..count].to_vec();
-        items.sort_by_key(|(ts, _)| *ts);
-        let start_time_ms = items[0].0;
-        let encoded: Vec<Vec<u8>> = items.into_iter().map(|(_, bytes)| bytes).collect();
+        items.sort_by_key(|event| event.ts);
+        let start_time_ms = items[0].ts;
+        let high_risk_count = items.iter().filter(|e| e.risk >= HIGH_RISK_RATING).count() as u32;
+        let medium_risk_count = items
+            .iter()
+            .filter(|e| e.risk >= MEDIUM_RISK_RATING && e.risk < HIGH_RISK_RATING)
+            .count() as u32;
+        let encoded: Vec<Vec<u8>> = items.into_iter().map(|event| event.encoded).collect();
         let recipients = batch_recipients(settings)?;
         let batch = BatchBuilder::build_upload(
             &encoded,
@@ -304,6 +424,8 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             &recipients,
             start_time_ms,
             now_ms,
+            high_risk_count,
+            medium_risk_count,
         )?;
         match self.upload_batch(&batch) {
             Ok(_) => {
@@ -349,7 +471,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         }
 
         self.retry_pending_hashes()?;
-        self.retry_pending_immediates()?;
+        self.retry_pending_notifies()?;
         self.maybe_upload_batch(now_ms, emitter)?;
         Ok(())
     }
@@ -367,30 +489,35 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         // Heartbeats bypass the screen-lock gate: the whole point is to prove the
         // device is alive when idle, so we upload even if the screen is locked.
         let is_heartbeat = matches!(kind, UploadKind::Heartbeat);
+        let is_high_risk = risk >= crate::module::lifecycle::EXTRA_HIGH_RISK;
         let entry = LogEntry {
             ts: now_ms,
             risk: Some(risk),
             event: kind,
         };
+        // High-risk events trigger an immediate email notification, but the event
+        // body still rides through the hash chain + encrypted batch below — the
+        // server never receives it unencrypted.
+        if is_high_risk {
+            self.state
+                .pending_notify_events
+                .push(build_notify_payload(&entry));
+        }
         // Always enqueue, but only attempt network I/O while the screen is active
         // (battery): a locked/off screen leaves events queued for the next ping flush.
+        self.state.pending_hash_events.push(entry);
         let screen_active = !self.platform.is_locked_or_screensaver()?;
-        if risk >= crate::module::lifecycle::EXTRA_HIGH_RISK {
-            self.state.pending_immediate_events.push(entry);
-            if screen_active {
-                self.retry_pending_immediates()?;
+        if screen_active || is_heartbeat {
+            self.retry_pending_hashes()?;
+            if is_heartbeat {
+                // Force an immediate batch flush — don't wait for the interval timer.
+                self.try_upload_batch(now_ms, emitter)?;
+            } else {
+                self.maybe_upload_batch(now_ms, emitter)?;
             }
-        } else {
-            self.state.pending_hash_events.push(entry);
-            if screen_active || is_heartbeat {
-                self.retry_pending_hashes()?;
-                if is_heartbeat {
-                    // Force an immediate batch flush — don't wait for the interval timer.
-                    self.try_upload_batch(now_ms, emitter)?;
-                } else {
-                    self.maybe_upload_batch(now_ms, emitter)?;
-                }
-            }
+        }
+        if is_high_risk && screen_active {
+            self.retry_pending_notifies()?;
         }
         Ok(())
     }
@@ -683,7 +810,13 @@ mod tests {
                     details: None,
                 },
             });
-            m.state.pending_batch_events.push((500, vec![1, 2, 3]));
+            m.state
+                .pending_batch_events
+                .push(crate::module::upload::PendingBatchEvent {
+                    ts: 500,
+                    risk: 0.0,
+                    encoded: vec![1, 2, 3],
+                });
         }
         t.emit(1, StatusRequest);
         t.assert_like::<PartialStatus>(crate::like!(PartialStatus::Upload {
@@ -707,7 +840,7 @@ mod tests {
             assert!(s.hash_uploads.is_empty(), "no hash upload while locked");
             assert!(s.batch_uploads.is_empty(), "no batch upload while locked");
             assert!(
-                s.log_uploads.is_empty(),
+                s.notify_calls.is_empty(),
                 "no direct log upload while locked"
             );
         }
@@ -738,7 +871,11 @@ mod tests {
         t.observer::<UploadModule<MockApiClient>>()
             .state
             .pending_batch_events
-            .push((500, vec![1, 2, 3]));
+            .push(crate::module::upload::PendingBatchEvent {
+                ts: 500,
+                risk: 0.0,
+                encoded: vec![1, 2, 3],
+            });
 
         // A plain ping does not flush while locked.
         t.emit(2, Ping);
@@ -789,7 +926,11 @@ mod tests {
         t.observer::<UploadModule<MockApiClient>>()
             .state
             .pending_batch_events
-            .push((500, vec![1, 2, 3]));
+            .push(crate::module::upload::PendingBatchEvent {
+                ts: 500,
+                risk: 0.0,
+                encoded: vec![1, 2, 3],
+            });
 
         // ProcessStopped(Shutdown) is a terminal flush path → uploads regardless of lock.
         t.emit(2, ProcessStopped(ProcessStoppedReason::Shutdown));

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -37,77 +37,11 @@ pub(crate) const POST_LOGIN_PROOF_BATCH_COUNT: u32 = 3;
 
 /// A hash-uploaded event awaiting batch upload, paired with its risk so the batch
 /// upload can report how many high/medium-risk events it carries.
-///
-/// Serialized as `[ts, risk, encoded]`. For backward compatibility with state
-/// written before #467 it also deserializes the legacy `[ts, encoded]` shape,
-/// defaulting `risk` to `0.0`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PendingBatchEvent {
     pub ts: i64,
     pub risk: f32,
     pub encoded: Vec<u8>,
-}
-
-impl Serialize for PendingBatchEvent {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeSeq;
-        let mut seq = serializer.serialize_seq(Some(3))?;
-        seq.serialize_element(&self.ts)?;
-        seq.serialize_element(&self.risk)?;
-        seq.serialize_element(&self.encoded)?;
-        seq.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for PendingBatchEvent {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct PendingBatchEventVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for PendingBatchEventVisitor {
-            type Value = PendingBatchEvent;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("a [ts, risk, encoded] or legacy [ts, encoded] sequence")
-            }
-
-            fn visit_seq<A: serde::de::SeqAccess<'de>>(
-                self,
-                mut seq: A,
-            ) -> Result<PendingBatchEvent, A::Error> {
-                use serde::de::Error;
-                let ts: i64 = seq
-                    .next_element()?
-                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
-                // The second element distinguishes the two shapes: a number is the
-                // risk (new form), an array is the encoded event (legacy form).
-                let second: serde_json::Value = seq
-                    .next_element()?
-                    .ok_or_else(|| A::Error::invalid_length(1, &self))?;
-                match second {
-                    serde_json::Value::Array(_) => {
-                        let encoded = serde_json::from_value(second).map_err(A::Error::custom)?;
-                        Ok(PendingBatchEvent {
-                            ts,
-                            risk: 0.0,
-                            encoded,
-                        })
-                    }
-                    serde_json::Value::Number(number) => {
-                        let risk = number.as_f64().unwrap_or(0.0) as f32;
-                        let encoded: Vec<u8> = seq
-                            .next_element()?
-                            .ok_or_else(|| A::Error::invalid_length(2, &self))?;
-                        Ok(PendingBatchEvent { ts, risk, encoded })
-                    }
-                    _ => Err(A::Error::custom(
-                        "unexpected second element in pending batch event",
-                    )),
-                }
-            }
-        }
-
-        deserializer.deserialize_seq(PendingBatchEventVisitor)
-    }
 }
 
 /// Builds the notification payload for a high-risk event. Title/details are pulled

--- a/client/core/src/module/upload/batch.rs
+++ b/client/core/src/module/upload/batch.rs
@@ -13,12 +13,15 @@ pub(crate) const MAX_BATCH_ITEMS_PER_UPLOAD: usize = 200;
 pub struct BatchBuilder;
 
 impl BatchBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn build_upload(
         encoded_events: &[Vec<u8>],
         crypto: &CryptoEngine,
         recipients: &[BatchRecipient],
         start_time_ms: i64,
         end_time_ms: i64,
+        high_risk_count: u32,
+        medium_risk_count: u32,
     ) -> CoreResult<BatchUpload> {
         if encoded_events.is_empty() {
             return Err(CoreError::InvalidState(
@@ -53,6 +56,8 @@ impl BatchBuilder {
             end_time_ms,
             bytes: encrypted,
             access_keys,
+            high_risk_count,
+            medium_risk_count,
         })
     }
 }

--- a/client/core/src/testing/api.rs
+++ b/client/core/src/testing/api.rs
@@ -1,9 +1,9 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use crate::api::{ApiTransport, UploadedBatchResponse, UploadedLogResponse};
+use crate::api::{ApiTransport, UploadedBatchResponse};
 use crate::error::CoreResult;
-use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, LogEntry};
+use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, NotifyPayload};
 
 /// Mock `ApiTransport` impl that records every call and serves either a
 /// programmed canned response or a sensible default success.
@@ -32,7 +32,7 @@ pub struct MockApiState {
     pub get_device_settings_calls: Vec<String>,
     pub get_hash_token_calls: Vec<String>,
     pub batch_uploads: Vec<BatchCall>,
-    pub log_uploads: Vec<LogCall>,
+    pub notify_calls: Vec<NotifyCall>,
     pub hash_uploads: Vec<HashCall>,
     pub reconfigure_calls: Vec<String>,
 
@@ -43,7 +43,7 @@ pub struct MockApiState {
     pub get_device_settings_responses: VecDeque<CoreResult<DeviceSettings>>,
     pub get_hash_token_responses: VecDeque<CoreResult<String>>,
     pub batch_responses: VecDeque<CoreResult<UploadedBatchResponse>>,
-    pub log_responses: VecDeque<CoreResult<UploadedLogResponse>>,
+    pub notify_responses: VecDeque<CoreResult<()>>,
     pub hash_responses: VecDeque<CoreResult<()>>,
 
     // --- default values used when the canned queue is empty ---
@@ -52,7 +52,6 @@ pub struct MockApiState {
     pub default_hash_token: String,
     pub default_device_settings: DeviceSettings,
     batch_id_counter: u64,
-    log_id_counter: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -69,9 +68,9 @@ pub struct BatchCall {
 }
 
 #[derive(Debug, Clone)]
-pub struct LogCall {
+pub struct NotifyCall {
     pub device_refresh_token: String,
-    pub log: LogEntry,
+    pub payload: NotifyPayload,
 }
 
 #[derive(Debug, Clone)]
@@ -90,7 +89,7 @@ impl Default for MockApiState {
             get_device_settings_calls: Vec::new(),
             get_hash_token_calls: Vec::new(),
             batch_uploads: Vec::new(),
-            log_uploads: Vec::new(),
+            notify_calls: Vec::new(),
             hash_uploads: Vec::new(),
             reconfigure_calls: Vec::new(),
 
@@ -100,7 +99,7 @@ impl Default for MockApiState {
             get_device_settings_responses: VecDeque::new(),
             get_hash_token_responses: VecDeque::new(),
             batch_responses: VecDeque::new(),
-            log_responses: VecDeque::new(),
+            notify_responses: VecDeque::new(),
             hash_responses: VecDeque::new(),
 
             default_device_id: "mock-device".to_string(),
@@ -118,7 +117,6 @@ impl Default for MockApiState {
                 hash_base_url: None,
             },
             batch_id_counter: 0,
-            log_id_counter: 0,
         }
     }
 }
@@ -160,8 +158,8 @@ impl MockApiClient {
         self.state().batch_responses.push_back(response);
     }
 
-    pub fn program_log(&self, response: CoreResult<UploadedLogResponse>) {
-        self.state().log_responses.push_back(response);
+    pub fn program_notify(&self, response: CoreResult<()>) {
+        self.state().notify_responses.push_back(response);
     }
 
     pub fn program_hash(&self, response: CoreResult<()>) {
@@ -271,23 +269,16 @@ impl ApiTransport for MockApiClient {
         }
     }
 
-    fn upload_log(
-        &self,
-        device_refresh_token: &str,
-        log: &LogEntry,
-    ) -> CoreResult<UploadedLogResponse> {
+    fn notify(&self, device_refresh_token: &str, payload: &NotifyPayload) -> CoreResult<()> {
         let mut state = self.state();
-        state.log_uploads.push(LogCall {
+        state.notify_calls.push(NotifyCall {
             device_refresh_token: device_refresh_token.to_string(),
-            log: log.clone(),
+            payload: payload.clone(),
         });
-        if let Some(canned) = state.log_responses.pop_front() {
+        if let Some(canned) = state.notify_responses.pop_front() {
             canned
         } else {
-            state.log_id_counter += 1;
-            Ok(UploadedLogResponse {
-                id: format!("mock-log-{}", state.log_id_counter),
-            })
+            Ok(())
         }
     }
 

--- a/client/core/src/testing/mod.rs
+++ b/client/core/src/testing/mod.rs
@@ -6,7 +6,7 @@ pub mod platform;
 pub mod scenario;
 pub mod spawner;
 
-pub use api::{BatchCall, HashCall, LogCall, MockApiClient, MockApiState, RegisterDeviceCall};
+pub use api::{BatchCall, HashCall, MockApiClient, MockApiState, NotifyCall, RegisterDeviceCall};
 pub use clock::MockClock;
 pub use event_tester::{EventTester, EventTesterBuilder};
 pub use fixtures::{tiny_png_bytes, tiny_png_screenshot};
@@ -99,6 +99,8 @@ mod tests {
             end_time_ms: 1,
             bytes: vec![1, 2, 3],
             access_keys: Vec::new(),
+            high_risk_count: 0,
+            medium_risk_count: 0,
         };
         let response = api.upload_batch("tok", &batch).unwrap();
         assert_eq!(response.id, "canned-batch");
@@ -130,8 +132,8 @@ mod tests {
             "unauthenticated loop must not upload batches"
         );
         assert!(
-            state.log_uploads.is_empty(),
-            "unauthenticated loop must not upload logs"
+            state.notify_calls.is_empty(),
+            "unauthenticated loop must not send notifications"
         );
 
         // Status request must return a valid response.

--- a/client/core/src/testing/scenario.rs
+++ b/client/core/src/testing/scenario.rs
@@ -274,11 +274,11 @@ impl Scenario {
         self
     }
 
-    pub fn assert_log_upload_count(&self, expected: usize) -> &Self {
-        let actual = self.api.state().log_uploads.len();
+    pub fn assert_notify_count(&self, expected: usize) -> &Self {
+        let actual = self.api.state().notify_calls.len();
         assert_eq!(
             actual, expected,
-            "expected {expected} log uploads, recorded {actual}"
+            "expected {expected} notify calls, recorded {actual}"
         );
         self
     }

--- a/client/core/tests/scenarios.rs
+++ b/client/core/tests/scenarios.rs
@@ -36,7 +36,7 @@ fn fresh_unauthenticated_service_loops_cleanly_with_no_uploads() {
         .assert_is_running(true)
         .assert_is_authenticated(false)
         .assert_batch_upload_count(0)
-        .assert_log_upload_count(0)
+        .assert_notify_count(0)
         .assert_errors_log_empty();
 }
 
@@ -112,8 +112,8 @@ fn user_stopped_process_emits_high_risk_upload() {
     scenario.queue(ProcessStopped(ProcessStoppedReason::User));
     scenario.at_t(0).loop_iteration();
     assert!(
-        !scenario.api.state().log_uploads.is_empty(),
-        "expected an immediate log upload for UserStoppedProcess alert"
+        !scenario.api.state().notify_calls.is_empty(),
+        "expected an immediate notification for UserStoppedProcess alert"
     );
 }
 
@@ -130,8 +130,8 @@ fn ping_gap_while_running_batches_alert_without_email() {
     scenario.at_t(182_000).loop_iteration();
     let state = scenario.api.state();
     assert!(
-        state.log_uploads.is_empty(),
-        "ping gap must not trigger an immediate (emailed) log upload"
+        state.notify_calls.is_empty(),
+        "ping gap must not trigger an immediate (emailed) notification"
     );
     assert!(
         state.hash_uploads.len() > hashes_before,
@@ -147,7 +147,7 @@ fn computer_resume_suppresses_ping_gap_alert() {
     scenario.queue(ComputerResumed);
     scenario.at_t(12_000).loop_iteration();
     assert_eq!(
-        scenario.api.state().log_uploads.len(),
+        scenario.api.state().notify_calls.len(),
         0,
         "expected no log upload when a computer-resume suppresses the ping-gap alert"
     );
@@ -175,9 +175,9 @@ fn four_capture_failures_below_threshold_no_upload() {
         "4 failures < threshold, no batch upload"
     );
     assert_eq!(
-        state.log_uploads.len(),
+        state.notify_calls.len(),
         0,
-        "4 failures < threshold, no log upload"
+        "4 failures < threshold, no notification"
     );
 }
 
@@ -301,8 +301,8 @@ fn unexpected_process_start_after_long_ping_gap_emits_alert() {
     // UnexpectedProcessStart is high-risk but batched (no immediate email).
     let state = scenario.api.state();
     assert!(
-        state.log_uploads.is_empty(),
-        "unexpected process start must not trigger an immediate (emailed) log upload"
+        state.notify_calls.is_empty(),
+        "unexpected process start must not trigger an immediate (emailed) notification"
     );
     assert!(
         !state.hash_uploads.is_empty() || !state.batch_uploads.is_empty(),

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -532,7 +532,7 @@ fn dev_upload_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
         .title
         .unwrap_or_else(|| "Developer CLI log".to_string());
     let (mut bus, state_path) = make_dev_bus(&paths)?;
-    // risk >= 1.0 routes through the immediate POST /log path.
+    // risk >= 1.0 routes through the encrypted batch plus an immediate POST /d/notify.
     bus.send(Upload {
         risk: 1.0_f32,
         kind: UploadKind::Dev {

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -4,6 +4,7 @@ mod daemon;
 mod tray;
 
 use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
@@ -14,11 +15,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 #[cfg(debug_assertions)]
 use virtue_core::{AlertReason, LifecycleKind, ScreenshotSkipReason};
-use virtue_core::{
-    ClientController, EventBus, EventChannel, FlushBatchNow, Ping, PlatformConfig, ScreenshotHooks,
-    ServiceStatus, StatusRequest, StatusResponse, Upload, UploadKind,
-    build_default_modules_reqwest, load_state, store_state,
-};
+use virtue_core::{ClientController, ScreenshotHooks, ServiceStatus, Upload, UploadKind};
 
 use crate::capture::{CaptureBackend, LinuxPlatformHooks, detect_backend, probe_backend};
 use crate::config::{ClientPaths, build_core_config, default_device_name};
@@ -478,7 +475,7 @@ fn all_send_kinds() -> Vec<UploadKind> {
 
 #[cfg(debug_assertions)]
 fn dev_send(paths: ClientPaths, args: SendLogArgs) -> Result<()> {
-    let (mut bus, state_path) = make_dev_bus(&paths)?;
+    let client = connect_to_daemon(&paths)?;
 
     let kinds = if args.log_type == "all" {
         // Screenshots are excluded here: the running daemon already produces real
@@ -501,13 +498,13 @@ fn dev_send(paths: ClientPaths, args: SendLogArgs) -> Result<()> {
 
     let count = kinds.len();
     for kind in kinds {
-        bus.send(Upload {
-            risk: args.risk,
-            kind,
-        })?;
+        client
+            .queue_upload(Upload {
+                risk: args.risk,
+                kind,
+            })
+            .context("failed to queue developer log")?;
     }
-    bus.send(Ping)?;
-    store_state(&state_path, &bus.iter()?)?;
 
     println!(
         "Queued {count} log(s) in the next batch with risk {}. Run `virtue dev upload-batch` to send them now.",
@@ -516,32 +513,32 @@ fn dev_send(paths: ClientPaths, args: SendLogArgs) -> Result<()> {
     Ok(())
 }
 
-fn make_dev_bus(paths: &ClientPaths) -> Result<(EventBus, std::path::PathBuf)> {
-    let state_path = paths.state_dir.join("event_state.json");
-    let modules = build_default_modules_reqwest(
-        build_core_config(paths),
-        LinuxPlatformHooks::new(),
-        PlatformConfig::default(),
-    )?;
-    let bus = EventBus::new(modules, load_state(&state_path)?)?;
-    Ok((bus, state_path))
+/// Connect to the running daemon over IPC. Dev commands queue events into the
+/// daemon's own live batch/hash pipeline rather than editing `event_state.json`
+/// directly — the daemon holds that state in memory and rewrites the file on
+/// every ping (~1s), so a direct edit would race with (or be silently
+/// clobbered by) the daemon's next write.
+fn connect_to_daemon(paths: &ClientPaths) -> Result<ClientController<virtue_core::RemoteEventBus>> {
+    let sock = paths.state_dir.join("daemon.sock");
+    ClientController::connect(&sock)
+        .context("failed to connect to daemon (is it running? try `virtue daemon start`)")
 }
 
 fn dev_upload_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
     let title = args
         .title
         .unwrap_or_else(|| "Developer CLI log".to_string());
-    let (mut bus, state_path) = make_dev_bus(&paths)?;
+    let client = connect_to_daemon(&paths)?;
     // risk >= 1.0 routes through the encrypted batch plus an immediate POST /d/notify.
-    bus.send(Upload {
-        risk: 1.0_f32,
-        kind: UploadKind::Dev {
-            title,
-            details: args.details,
-        },
-    })?;
-    bus.send(Ping)?;
-    store_state(&state_path, &bus.iter()?)?;
+    client
+        .queue_upload(Upload {
+            risk: 1.0_f32,
+            kind: UploadKind::Dev {
+                title,
+                details: args.details,
+            },
+        })
+        .context("failed to queue developer log")?;
 
     println!(
         "Recorded immediate developer log with risk {}.",
@@ -554,16 +551,16 @@ fn dev_add_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
     let title = args
         .title
         .unwrap_or_else(|| "Developer CLI batched log".to_string());
-    let (mut bus, state_path) = make_dev_bus(&paths)?;
-    bus.send(Upload {
-        risk: args.risk,
-        kind: UploadKind::Dev {
-            title,
-            details: args.details,
-        },
-    })?;
-    bus.send(Ping)?;
-    store_state(&state_path, &bus.iter()?)?;
+    let client = connect_to_daemon(&paths)?;
+    client
+        .queue_upload(Upload {
+            risk: args.risk,
+            kind: UploadKind::Dev {
+                title,
+                details: args.details,
+            },
+        })
+        .context("failed to queue developer log")?;
 
     println!(
         "Queued developer log in the next batch with risk {}.",
@@ -573,22 +570,21 @@ fn dev_add_log(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
 }
 
 fn dev_add_screenshot(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()> {
-    let platform = LinuxPlatformHooks::new();
-    let screenshot = platform
+    let screenshot = LinuxPlatformHooks::new()
         .take_screenshot()
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    let (mut bus, state_path) = make_dev_bus(&paths)?;
-    bus.send(Upload {
-        risk: args.risk,
-        kind: UploadKind::Screenshot {
-            image: screenshot.bytes,
-            content_type: screenshot.content_type,
-            skin_detection: None,
-            nsfw_detection: None,
-        },
-    })?;
-    bus.send(Ping)?;
-    store_state(&state_path, &bus.iter()?)?;
+    let client = connect_to_daemon(&paths)?;
+    client
+        .queue_upload(Upload {
+            risk: args.risk,
+            kind: UploadKind::Screenshot {
+                image: screenshot.bytes,
+                content_type: screenshot.content_type,
+                skin_detection: None,
+                nsfw_detection: None,
+            },
+        })
+        .context("failed to queue developer screenshot")?;
 
     println!(
         "Captured and queued a developer screenshot with risk {}.",
@@ -598,26 +594,44 @@ fn dev_add_screenshot(paths: ClientPaths, args: DeveloperEventArgs) -> Result<()
 }
 
 fn dev_upload_batch(paths: ClientPaths) -> Result<()> {
-    let (mut bus, state_path) = make_dev_bus(&paths)?;
+    let mut client = connect_to_daemon(&paths)?;
 
-    let before: StatusResponse = bus.request(StatusRequest)?;
-    let initial_pending = before.status.pending_request_count;
-
+    let initial_pending = client
+        .get_status()
+        .context("failed to query daemon status")?
+        .pending_request_count;
     if initial_pending == 0 {
         println!("No pending batch items to upload.");
         return Ok(());
     }
 
-    bus.send(FlushBatchNow)?;
-    bus.send(Ping)?;
-    bus.iter()?;
+    client
+        .flush_batch_now()
+        .context("failed to request batch flush")?;
 
-    let after: StatusResponse = bus.request(StatusRequest)?;
-    let remaining = after.status.pending_request_count;
+    // The flush is processed asynchronously on the daemon's next ping cycle
+    // (≤1s) plus however long the network upload takes. Give it a full cycle
+    // before the first check, then keep polling as long as it's still making
+    // progress, up to a generous cap.
+    std::thread::sleep(Duration::from_millis(1200));
+    let mut remaining = client
+        .get_status()
+        .context("failed to query daemon status")?
+        .pending_request_count;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while remaining > 0 && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(500));
+        let seen = client
+            .get_status()
+            .context("failed to query daemon status")?
+            .pending_request_count;
+        if seen == remaining {
+            break;
+        }
+        remaining = seen;
+    }
+
     let attempted = initial_pending.saturating_sub(remaining);
-
-    store_state(&state_path, &bus.iter()?)?;
-
     if remaining == 0 {
         println!("Processed {attempted} batch item(s); no batch items remain queued.");
     } else {

--- a/shared-web/types.ts
+++ b/shared-web/types.ts
@@ -73,7 +73,6 @@ export type DataLog = z.infer<typeof dataLogSchema>;
 
 export const dataPageSchema = z.object({
   batches: z.array(batchSchema),
-  logs: z.array(dataLogSchema),
 });
 export type DataPage = z.infer<typeof dataPageSchema>;
 

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -77,5 +77,5 @@ export const handlers = [
   http.delete(`${BASE}/partner/watching/:id`, () => new HttpResponse(null, { status: 204 })),
 
   // ── Data ───────────────────────────────────────────────────────────────
-  http.get(`${BASE}/data`, () => HttpResponse.json({ batches: [], logs: [] })),
+  http.get(`${BASE}/data`, () => HttpResponse.json({ batches: [] })),
 ];

--- a/web/src/pages/Logs/types.ts
+++ b/web/src/pages/Logs/types.ts
@@ -3,7 +3,7 @@ import type { BatchVerification } from '../../utils/api/crypto';
 
 export type FeedLog = DataLog & {
   batch_status: BatchVerification;
-  source: 'batch' | 'log';
+  source: 'batch';
   image_w?: number;
   image_h?: number;
 };

--- a/web/src/utils/cache/worker.ts
+++ b/web/src/utils/cache/worker.ts
@@ -131,19 +131,9 @@ const initPromise = (async () => {
        error TEXT
      )`,
   );
-  db.exec(
-    `CREATE TABLE IF NOT EXISTS direct_logs (
-       id TEXT PRIMARY KEY,
-       viewer_id TEXT NOT NULL,
-       target_user_id TEXT NOT NULL,
-       device_id TEXT NOT NULL,
-       ts INTEGER NOT NULL,
-       type TEXT NOT NULL,
-       data TEXT NOT NULL,
-       created_at INTEGER NOT NULL,
-       risk REAL
-     )`,
-  );
+  // direct_logs was removed in #467 (high-risk events now live in encrypted batches);
+  // drop it so already-provisioned local caches reclaim the space.
+  db.exec('DROP TABLE IF EXISTS direct_logs');
   console.log('[cache-worker] init: done');
 })().catch((err) => {
   console.error('[cache-worker] init FAILED', err);
@@ -184,30 +174,7 @@ function sqlMergeDataPage(viewerId: string, targetUserId: string, page: DataPage
         },
       );
     }
-    for (const log of page.logs) {
-      db.exec(
-        `INSERT OR IGNORE INTO direct_logs(id,viewer_id,target_user_id,device_id,ts,type,data,created_at,risk)
-         VALUES(?,?,?,?,?,?,?,?,?)`,
-        {
-          bind: [
-            log.id,
-            viewerId,
-            targetUserId,
-            log.device_id,
-            log.ts,
-            log.type,
-            JSON.stringify(log.data),
-            log.created_at,
-            log.risk ?? null,
-          ],
-        },
-      );
-    }
-
-    const allCreatedAts = [
-      ...page.batches.map((b) => b.created_at),
-      ...page.logs.map((l) => l.created_at),
-    ];
+    const allCreatedAts = [...page.batches.map((b) => b.created_at)];
     if (allCreatedAts.length > 0) {
       const maxCreatedAt = Math.max(...allCreatedAts);
       db.exec(
@@ -348,36 +315,6 @@ function sqlQueryEvents(
       }),
   });
 
-  let logSql = `SELECT * FROM direct_logs WHERE viewer_id=? AND target_user_id=?`;
-  const logBind: unknown[] = [viewerId, targetUserId];
-
-  if (query.deviceId) {
-    logSql += ` AND device_id=?`;
-    logBind.push(query.deviceId);
-  }
-  if (query.startTime !== undefined && query.endTime !== undefined) {
-    logSql += ` AND ts BETWEEN ? AND ?`;
-    logBind.push(query.startTime, query.endTime);
-  }
-
-  db.exec(logSql, {
-    bind: logBind,
-    rowMode: 'object',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (row: any) =>
-      results.push({
-        id: row.id as string,
-        device_id: row.device_id as string,
-        ts: row.ts as number,
-        type: row.type as string,
-        data: JSON.parse(row.data as string) as Record<string, unknown>,
-        created_at: row.created_at as number,
-        risk: row.risk != null ? (row.risk as number) : undefined,
-        batch_status: 'unknown' as const,
-        source: 'log' as const,
-      }),
-  });
-
   let combined = results.sort((a, b) => b.ts - a.ts);
   if (query.eventTypes && query.eventTypes.length > 0) {
     const allowed = new Set(query.eventTypes);
@@ -388,12 +325,10 @@ function sqlQueryEvents(
 
 function sqlPruneOldData(viewerId: string, cutoffTs: number): void {
   db.exec(`DELETE FROM events WHERE viewer_id=? AND ts<?`, { bind: [viewerId, cutoffTs] });
-  db.exec(`DELETE FROM direct_logs WHERE viewer_id=? AND ts<?`, { bind: [viewerId, cutoffTs] });
 }
 
 function sqlClearAll(): void {
   db.exec(`DELETE FROM events`);
-  db.exec(`DELETE FROM direct_logs`);
   db.exec(`DELETE FROM batches`);
   db.exec(`DELETE FROM feeds`);
   db.exec(`DELETE FROM materialized_batch_ids`);
@@ -406,9 +341,6 @@ function sqlDeleteDeviceData(viewerId: string, deviceId: string): void {
     bind: [viewerId, deviceId],
   });
   db.exec(`DELETE FROM batches WHERE viewer_id=? AND device_id=?`, {
-    bind: [viewerId, deviceId],
-  });
-  db.exec(`DELETE FROM direct_logs WHERE viewer_id=? AND device_id=?`, {
     bind: [viewerId, deviceId],
   });
 }
@@ -561,13 +493,7 @@ async function fetchAndDecrypt(targetUserId: string): Promise<void> {
       user: targetUserId === viewerId ? undefined : targetUserId,
       since,
     });
-    console.log(
-      '[cache-worker] /data returned',
-      page.batches.length,
-      'batches,',
-      page.logs.length,
-      'logs',
-    );
+    console.log('[cache-worker] /data returned', page.batches.length, 'batches');
     sqlMergeDataPage(viewerId, targetUserId, page);
   } catch (err) {
     console.warn('[cache-worker] fetch failed for', targetUserId, err);


### PR DESCRIPTION
Fix #467: replace the unencrypted device-log endpoint with the encrypted batch + notify pipeline

## Type of change
- New feature
- Bug fix
- Documentation update
- Refactoring

## Components changed
- Web
- API
- Core
- Linux

## Description
High-risk events now travel through the existing encrypted `POST /d/batch` pipeline instead of the old unencrypted `POST /d/log` endpoint. A new minimal `POST /d/notify` call fires the alert email separately, carrying only the metadata needed to render the notification (not the event body). Batches now carry `high_risk_count`/`medium_risk_count` tallies (computed client-side from per-event risk at the 0.7/0.4 thresholds) so partner-digest emails can still summarize tamper activity without ever decrypting the batch.

This PR closes out the remaining gaps in an otherwise-complete implementation:
- Fixed two stale references in the Rust client's `testing` feature (`LogCall` → `NotifyCall` re-export, missing `high_risk_count`/`medium_risk_count` fields on a test `BatchUpload` literal) that broke `cargo test --features testing`.
- Updated `api/API.md` and `client/core/architecture.md` (both called out as required reading) to document the new `/d/notify` endpoint, the new `high_risk_count`/`medium_risk_count` batch fields, and the notify-pending queue, instead of describing the removed design.
- Removed the now-fully-dead `direct_logs` path from the web cache worker (`web/src/utils/cache/worker.ts`): table creation, insert/query/prune/delete logic, and the `logs` field on `dataPageSchema`. The table drop uses an idempotent `DROP TABLE IF EXISTS` so already-provisioned local OPFS caches reclaim the space (this codebase has no schema-version mechanism, so `CREATE TABLE IF NOT EXISTS` would never have touched existing users' DBs).
- Added a D1 migration (`0006_notify_endpoint.sql`) adding the two batch count columns and dropping the old `device_logs` table.

**Follow-up fixes found while exercising the new pipeline against a live dev daemon:**
- **`virtue dev` commands were silently losing data / crashing against a running daemon.** `dev add-log`/`add-screenshot`/`send`/`upload-batch` built their own private in-process `EventBus` and read-modify-wrote `event_state.json` directly, but the running daemon holds its own in-memory copy of that same state and rewrites the file every ping (~1s) without ever re-reading it — so a CLI edit was either silently clobbered by the daemon's next write, or crashed outright (`ENOENT`) when both processes raced renaming the same fixed temp file. These commands now route through the existing daemon IPC socket instead (same pattern as `login`/`logout`/`status`), so they actually reach the live daemon's batch/hash pipeline.
- **Extra-high-risk events could send the notify email before the batch existed server-side.** The notify email fired as soon as a high-risk event was queued, but the encrypted batch upload carrying that event's actual data was only interval-gated (`maybe_upload_batch`), so the email could reference an event that hadn't reached the server yet. Extra-high-risk uploads now force an immediate batch flush (`try_upload_batch`), same as heartbeats already do, before the notify goes out — including the case where the event was queued while the screen was locked and only flushed on a later ping.
- Removed a redundant server-side severity re-filter on `/d/notify`: the endpoint was silently dropping alert emails for moderate-risk events even though the client's uploader only calls it for events already decided to be high-risk. The client is now the single source of truth for what counts as high-risk.

## Testing
Human
- Uploaded a medium risk - didn't send a notification
- Uploaded an extra high-risk log - uploaded the batch and sent a notification

AI
- `cd api && npx vitest run` — 42/42 passing.
- `cd client/core && cargo test -p virtue-core --features testing` — 110 unit + 17 scenario tests passing, including new tests for the forced-batch-before-notify ordering (`extra_high_risk_upload_forces_batch_flush_regardless_of_interval`, `ping_forces_batch_flush_before_sending_queued_notify`).
- `cd client && cargo test -p virtue-linux` — 38 tests passing.
- `cargo clippy -p virtue-core -p virtue-linux --all-targets` — clean.
- Manually reproduced the `virtue dev` crash/data-loss against a live daemon (concurrent `dev add-log` calls reliably crashed and corrupted `event_state.json` before the fix), then verified end-to-end against an isolated test daemon that `add-log`/`upload-batch` correctly reach the live daemon's batch and get uploaded, and that 60 concurrent `dev add-log` invocations no longer crash.
- `cd web && npx tsc --noEmit` — clean.
- `cd web && npx vitest run` — 96/96 passing.

## Impact
- `GET /data`'s `logs` field is removed (was always `[]`); no clients read it for real data anymore.
- Existing local web caches lose their `direct_logs` table on next load (data was already dead/unused).
- Requires running migration `0006_notify_endpoint.sql` against D1.
- `virtue dev add-log`/`add-screenshot`/`send`/`upload-batch` now require the daemon to be running (they'll print a clear error if not), matching `login`/`logout`.
- Notify emails for moderate/high-risk device events are no longer suppressed server-side; the client's risk threshold is now authoritative.

## Additional Information
Backend (`api/`) functional work and the initial notify/batch pipeline were implemented in earlier sessions on this branch; this PR is the final pass that makes it compile, documents it, removes dead code, and fixes two correctness bugs (daemon IPC race, notify-before-batch ordering) surfaced while testing the pipeline end-to-end.
