### PR TITLE
Fix false-positive Unexpected Restart / Unexpected Gap alerts on iOS

### DIFF
--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -15,8 +15,9 @@ use serde::de::DeserializeOwned;
 use virtue_core::{
     build_default_modules_reqwest, load_state, store_state, AuthState, Config, CoreError,
     CoreResult, DeviceSettings, EventBus, EventChannel, LoginRequested, LoginResult,
-    LogoutRequested, Ping, PlatformHooks, ProcessStarted, ProcessStopped, ProcessStoppedReason,
-    Redacted, Screenshot, ScreenshotHooks, StatusRequest, StatusResponse, UserStopRequested,
+    LogoutRequested, Ping, PlatformConfig, PlatformHooks, ProcessStarted, ProcessStopped,
+    ProcessStoppedReason, Redacted, Screenshot, ScreenshotHooks, StatusRequest, StatusResponse,
+    UserStopRequested,
 };
 
 static CORE: OnceCell<AndroidCore> = OnceCell::new();
@@ -456,12 +457,17 @@ pub fn is_interactive(env: &mut JNIEnv) -> jni::errors::Result<bool> {
 
 fn build_bus(core: &AndroidCore) -> Result<(EventBus, PathBuf)> {
     let cfg = build_core_config(core);
+    // Default `PlatformConfig` (supports_sleep_wake_detection: true) is correct
+    // here: unlike iOS, the monitoring loop runs in a persistent foreground
+    // service that keeps executing regardless of screen lock, so a ping stall
+    // is a genuine one, not an artifact of the OS suspending our process.
     let modules = build_default_modules_reqwest(
         cfg,
         AndroidPlatformHooks {
             java_vm: core.java_vm.clone(),
             screenshot_service_class: core.screenshot_service_class.clone(),
         },
+        PlatformConfig::default(),
     )?;
     let state_path = core.state_dir.join("event_state.json");
     let bus = EventBus::new(modules, load_state(&state_path)?)?;

--- a/client/core/CLAUDE.md
+++ b/client/core/CLAUDE.md
@@ -40,7 +40,7 @@ Everything else belongs in `core`.
 The daemon loop is:
 
 ```rust
-let observers = build_default_modules(config, platform, api)?;
+let observers = build_default_modules(config, platform, api, PlatformConfig::default())?;
 let mut bus = EventBus::new(observers, saved_state)?;
 loop {
     bus.send(Ping)?;

--- a/client/core/architecture.md
+++ b/client/core/architecture.md
@@ -48,7 +48,7 @@ client/
 
 ```rust
 // Build the default set of 7 observer modules.
-let observers = build_default_modules(config, platform, api)?;
+let observers = build_default_modules(config, platform, api, PlatformConfig::default())?;
 let mut bus = EventBus::new(observers, saved_state)?;
 
 // One loop iteration: send Ping, process all cascaded events.
@@ -271,6 +271,32 @@ desktop platforms override it for the screenshot dedup lock/screensaver gate, wh
 platforms keep the default. Platform crates implement `take_screenshot`,
 `get_last_shutdown_time_utc_ms`, `get_last_startup_time_utc_ms`, and (on desktop)
 `is_locked_or_screensaver`.
+
+## PlatformConfig
+
+Fixed, per-platform capabilities that shape module behavior at startup — as opposed to
+`ScreenshotHooks`/`PlatformHooks`, which are live platform I/O queried on every tick.
+Passed once when assembling the observer modules:
+
+```rust
+pub struct PlatformConfig {
+    pub supports_sleep_wake_detection: bool, // default: true
+}
+```
+
+`supports_sleep_wake_detection` defaults to `true`, matching desktop platforms: they emit real
+`ComputerSuspended`/`ComputerResumed` events off OS power notifications, so a suspend period is
+bracketed and never counted as a ping-gap stall in the first place. iOS passes `false`: the
+monitoring process is a short-lived Safari extension host that the OS can suspend the instant
+the device locks, with no notification delivered to that process (extensions have no
+`UIApplication`) and no way to reconstruct after the fact whether a stall was a lock, a
+suspicious pause, or something else — every stall looks identical. When `false`, the lifecycle
+module skips `PingGapWhileRunning` entirely rather than risk alerting on gaps it can't
+attribute.
+
+`PlatformConfig` is deliberately named generically (not e.g. `LifecycleConfig`) so future
+platform-level capability flags can be added to it without another signature change across
+every platform crate.
 
 Everything else belongs in `core`.
 

--- a/client/core/src/assembly.rs
+++ b/client/core/src/assembly.rs
@@ -12,7 +12,7 @@ use crate::module::lifecycle::LifecycleModule;
 use crate::module::screenshot::ScreenshotModule;
 use crate::module::status::StatusModule;
 use crate::module::upload::UploadModule;
-use crate::platform::ScreenshotHooks;
+use crate::platform::{PlatformConfig, ScreenshotHooks};
 
 /// Number of observers that emit a `PartialStatus` in reply to a `StatusRequest`:
 /// `AuthModule`, `LifecycleModule`, and `UploadModule`.
@@ -22,12 +22,17 @@ const STATUS_PARTIAL_COUNT: usize = 3;
 /// and API transport. The returned modules are ready to be passed to
 /// [`EventBus::new`].
 ///
+/// `platform_config` carries fixed, per-platform capabilities (see
+/// `PlatformConfig`) forwarded to the modules that need them — currently just
+/// `LifecycleModule`. Most platforms can pass `PlatformConfig::default()`.
+///
 /// Calls `config.refresh_from_runtime_file()` once up front so overrides
 /// apply before the bus starts — critical for one-shot FFI callers.
 pub fn build_default_modules<P, A>(
     mut config: Config,
     platform: P,
     api: A,
+    platform_config: PlatformConfig,
 ) -> CoreResult<Vec<Box<dyn Observer>>>
 where
     P: ScreenshotHooks + Clone,
@@ -41,7 +46,10 @@ where
     let platform_name = config.platform_name.clone();
 
     let observers: Vec<Box<dyn Observer>> = vec![
-        Box::new(LifecycleModule::new(Box::new(platform.clone()))),
+        Box::new(LifecycleModule::new(
+            Box::new(platform.clone()),
+            platform_config,
+        )),
         Box::new(ScreenshotModule::new(
             Arc::new(platform.clone()),
             screenshot_interval_ms,
@@ -61,10 +69,12 @@ where
     Ok(observers)
 }
 
-/// Convenience wrapper that defaults to [`ReqwestApiClient`].
+/// Convenience wrapper that defaults to [`ReqwestApiClient`]. See
+/// `build_default_modules` for `platform_config`.
 pub fn build_default_modules_reqwest<P>(
     mut config: Config,
     platform: P,
+    platform_config: PlatformConfig,
 ) -> CoreResult<Vec<Box<dyn Observer>>>
 where
     P: ScreenshotHooks + Clone,
@@ -73,5 +83,5 @@ where
     // the start. build_default_modules will refresh again — that's harmless.
     config.refresh_from_runtime_file()?;
     let api = ReqwestApiClient::new(&config)?;
-    build_default_modules(config, platform, api)
+    build_default_modules(config, platform, api, platform_config)
 }

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -46,5 +46,5 @@ pub use module::screenshot::CaptureFailed;
 pub use module::status::{StatusRequest, StatusResponse};
 pub use module::upload::FlushBatchNow;
 pub use module::upload::Upload;
-pub use platform::{PlatformHooks, ScreenshotHooks};
+pub use platform::{PlatformConfig, PlatformHooks, ScreenshotHooks};
 pub use state::{load_state, store_state};

--- a/client/core/src/module/lifecycle.rs
+++ b/client/core/src/module/lifecycle.rs
@@ -33,7 +33,7 @@ pub struct UserSessionLogout;
 pub struct UserStopRequested {
     pub source: String,
 }
-use crate::platform::ScreenshotHooks;
+use crate::platform::{PlatformConfig, ScreenshotHooks};
 
 pub(crate) const EXTRA_HIGH_RISK: f32 = 0.9;
 /// High-risk lifecycle alerts that are still noteworthy but don't warrant an
@@ -97,13 +97,15 @@ pub struct LifecycleObserverState {
 pub struct LifecycleModule {
     pub state: LifecycleObserverState,
     platform: Box<dyn ScreenshotHooks>,
+    config: PlatformConfig,
 }
 
 impl LifecycleModule {
-    pub fn new(platform: Box<dyn ScreenshotHooks>) -> Self {
+    pub fn new(platform: Box<dyn ScreenshotHooks>, config: PlatformConfig) -> Self {
         Self {
             state: LifecycleObserverState::default(),
             platform,
+            config,
         }
     }
 
@@ -201,10 +203,17 @@ impl LifecycleModule {
             });
         }
 
-        if now_ms - old.last_login > 120000
+        // Only alert when the platform can report a real boot time: the check below
+        // only makes sense relative to a known boot ("this restart isn't explained by
+        // the device having just booted"). Without that signal (e.g. iOS, where the
+        // monitoring process is a short-lived Safari extension host that the OS may
+        // suspend or recycle at any time as routine behavior) we have no way to tell
+        // a benign restart from a suspicious one, so we stay silent rather than
+        // alerting on every routine restart.
+        if let Some(boot_ms) = startup_time_ms
+            && now_ms - old.last_login > 120000
             && old.last_process_started > old.last_process_stopped_user
         {
-            let boot_ms = startup_time_ms.unwrap_or(0);
             let ping_gap = if old.last_ping > 0 {
                 now_ms - old.last_ping
             } else {
@@ -290,7 +299,13 @@ impl LifecycleModule {
         self.maybe_backfill_missed_events(last_shutdown, startup_time_ms, emitter)?;
         self.state.last_ping = now_ms;
 
-        if now_ms - old.last_login > LIFECYCLE_LOGIN_GRACE_MS {
+        // See the doc comment on `PlatformConfig::supports_sleep_wake_detection`:
+        // platforms that can't reliably tell us about suspend/resume have no way
+        // to distinguish a benign gap from a suspicious one, so we don't
+        // evaluate this check.
+        if self.config.supports_sleep_wake_detection
+            && now_ms - old.last_login > LIFECYCLE_LOGIN_GRACE_MS
+        {
             let ping_gap = now_ms - old.last_ping;
             let start_gap = now_ms - old.last_running_started;
 
@@ -453,12 +468,16 @@ mod tests {
     use crate::model::{AlertReason, LifecycleKind, ProcessStoppedReason, UploadKind};
     use crate::module::status::StatusRequest;
     use crate::module::upload::Upload;
+    use crate::platform::PlatformConfig;
     use crate::testing::EventTester;
 
     #[test]
     fn status_request_emits_lifecycle_partial_status() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, StatusRequest);
         t.assert_like::<PartialStatus>(crate::like!(PartialStatus::Lifecycle { .. }));
@@ -467,7 +486,10 @@ mod tests {
     #[test]
     fn process_started_emits_lifecycle_upload() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ProcessStarted);
         t.assert_like(crate::like!(Upload {
@@ -489,7 +511,10 @@ mod tests {
     #[test]
     fn process_stopped_shutdown_emits_upload() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(2, ProcessStopped(ProcessStoppedReason::Shutdown));
         t.assert_like(crate::like!(Upload {
@@ -509,7 +534,10 @@ mod tests {
     #[test]
     fn process_stopped_user_emits_upload_and_high_risk_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(4, ProcessStopped(ProcessStoppedReason::User));
         t.assert_like(crate::like!(Upload {
@@ -548,7 +576,10 @@ mod tests {
     #[test]
     fn computer_suspended_emits_upload() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(5, ComputerSuspended);
         t.assert_like(crate::like!(Upload {
@@ -570,7 +601,10 @@ mod tests {
     #[test]
     fn computer_resumed_after_suspend_emits_upload() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(6, ComputerSuspended);
         t.clear_captured();
@@ -598,7 +632,10 @@ mod tests {
     #[test]
     fn fourth_ping_while_suspended_triggers_missing_resume_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
 
         t.emit(1, ComputerSuspended);
@@ -640,7 +677,10 @@ mod tests {
     #[test]
     fn session_login_emits_lifecycle_upload() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, UserSessionLogin);
         t.assert_like(crate::like!(Upload {
@@ -655,7 +695,10 @@ mod tests {
     #[test]
     fn session_logout_emits_high_risk_lifecycle_upload() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, UserSessionLogout);
         t.assert_like(crate::like!(Upload {
@@ -682,7 +725,10 @@ mod tests {
     #[test]
     fn ping_gap_while_running_emits_high_risk_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
 
         // ProcessStarted + first Ping both at 1s — within 120s grace window, no alert.
@@ -722,9 +768,74 @@ mod tests {
     }
 
     #[test]
+    fn ping_gap_is_not_evaluated_when_sleep_wake_unsupported() {
+        let mut b = EventTester::builder();
+        // Platform can't tell us about suspend/resume (e.g. iOS, where the Safari
+        // extension host can be suspended by a device lock with zero signal) — a
+        // stall like this is indistinguishable from a suspicious one, so it must
+        // not be evaluated at all, regardless of size.
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig {
+                supports_sleep_wake_detection: false,
+            },
+        ));
+        let mut t = b.build();
+
+        t.emit(1, ProcessStarted);
+        t.emit(1, Ping);
+        t.clear_captured();
+
+        t.emit(200, Ping);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::PingGapWhileRunning
+            },
+            ..
+        }));
+        assert_eq!(
+            t.observer::<LifecycleModule>().state.ping_gaps.len(),
+            0,
+            "gap should not even be recorded when the platform can't detect sleep/wake"
+        );
+    }
+
+    #[test]
+    fn unexpected_process_start_requires_known_boot_time() {
+        let mut b = EventTester::builder();
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
+        let mut t = b.build();
+
+        // Seed a state where the desktop-style heuristic would otherwise fire: long
+        // since login, process apparently left running, and a large ping gap.
+        // Platform boot time is unknown (the default), as on iOS — since we can't
+        // tell whether this restart followed a genuine device boot, we must not
+        // alert on every routine restart.
+        {
+            let s = &mut t.observer::<LifecycleModule>().state;
+            s.last_login = 1_000;
+            s.last_process_started = 2_000;
+            s.last_ping = 3_000;
+        }
+        t.emit(200, ProcessStarted);
+        t.assert_not_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::UnexpectedProcessStart
+            },
+            ..
+        }));
+    }
+
+    #[test]
     fn ping_within_login_grace_period_does_not_emit_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ProcessStarted);
         t.emit(1, Ping);
@@ -743,7 +854,10 @@ mod tests {
     #[test]
     fn sub_budget_ping_gap_does_not_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         // Seed a running process whose last ping is already past the login grace
         // window (last_login stays 0).
@@ -767,7 +881,10 @@ mod tests {
     #[test]
     fn accumulated_ping_gaps_cross_budget_and_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         {
             let s = &mut t.observer::<LifecycleModule>().state;
@@ -796,7 +913,10 @@ mod tests {
     #[test]
     fn aged_out_ping_gaps_are_pruned_and_do_not_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         // An old 50s gap recorded ~700s before "now"; it sits outside the 10-min
         // window once the new ping lands and must be pruned before summing.
@@ -822,7 +942,10 @@ mod tests {
     #[test]
     fn cooldown_suppresses_repeat_ping_gap_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         // Seed a state that already alerted recently with enough banked gap time to
         // cross the budget again.
@@ -855,7 +978,10 @@ mod tests {
     #[test]
     fn process_killed_before_shutdown_emits_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ProcessStarted);
         t.emit(1, ProcessStopped(ProcessStoppedReason::Other));
@@ -886,7 +1012,10 @@ mod tests {
     #[test]
     fn force_killed_process_with_platform_shutdown_emits_high_risk_alert() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
 
         // Run 1: process starts, pings, then is killed (Other stop — no shutdown event yet)
@@ -967,7 +1096,10 @@ mod tests {
     #[test]
     fn state_round_trips_through_save_and_load() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
 
         t.emit(30, UserSessionLogin); // last_login = 30_000
@@ -996,7 +1128,10 @@ mod tests {
         let saved = t.bus.save().unwrap();
 
         let mut b2 = EventTester::builder();
-        b2.add(LifecycleModule::new(Box::new(b2.platform())));
+        b2.add(LifecycleModule::new(
+            Box::new(b2.platform()),
+            PlatformConfig::default(),
+        ));
         b2.with_state(saved);
         let mut t2 = b2.build();
 

--- a/client/core/src/platform.rs
+++ b/client/core/src/platform.rs
@@ -36,3 +36,39 @@ pub trait ScreenshotHooks: Send + Sync + 'static {
 /// `ScreenshotHooks` to minimize churn at call sites while `Custom` event
 /// support is removed.
 pub trait PlatformHooks: ScreenshotHooks {}
+
+/// Static, per-platform capabilities that shape module behavior at startup —
+/// as opposed to `ScreenshotHooks`, which is live platform I/O queried on every
+/// tick. Passed once when assembling the observer modules (see
+/// `assembly::build_default_modules`) rather than modeled as trait methods,
+/// since these never change at runtime and aren't tied to a specific platform
+/// I/O call.
+#[derive(Debug, Clone, Copy)]
+pub struct PlatformConfig {
+    /// Whether the platform can reliably tell the lifecycle module about
+    /// suspend/resume (sleep/wake) — i.e. whether a ping stall can be
+    /// attributed to a legitimate, OS-driven pause rather than an unexplained
+    /// one.
+    ///
+    /// Desktop platforms emit explicit `ComputerSuspended`/`ComputerResumed`
+    /// events off real OS power notifications, so a suspend period is
+    /// bracketed and never counted as a stall in the first place — `true` is
+    /// correct for them. Some platforms have no way to observe this at all: on
+    /// iOS the monitoring process is a short-lived Safari extension host that
+    /// the OS can suspend the instant the device locks, with no notification
+    /// delivered to that process (extensions have no `UIApplication`) and no
+    /// way to reconstruct after the fact whether a given stall was a lock, a
+    /// suspicious pause, or something else — every stall looks identical. When
+    /// `false`, `LifecycleModule` must not evaluate `PingGapWhileRunning` at
+    /// all, since we have no way to distinguish a benign gap from a suspicious
+    /// one.
+    pub supports_sleep_wake_detection: bool,
+}
+
+impl Default for PlatformConfig {
+    fn default() -> Self {
+        Self {
+            supports_sleep_wake_detection: true,
+        }
+    }
+}

--- a/client/core/src/testing/api.rs
+++ b/client/core/src/testing/api.rs
@@ -14,7 +14,7 @@ use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, LogEntry};
 /// ```ignore
 /// let mock = MockApiClient::new();
 /// let inspector = mock.clone();
-/// let observers = build_default_modules(cfg, platform, mock)?;
+/// let observers = build_default_modules(cfg, platform, mock, PlatformConfig::default())?;
 /// let mut bus = EventBus::new(observers, StateType::Null)?;
 /// // ... drive the bus ...
 /// assert_eq!(inspector.state().batch_uploads.len(), 2);

--- a/client/core/src/testing/event_tester.rs
+++ b/client/core/src/testing/event_tester.rs
@@ -340,6 +340,7 @@ mod tests {
     use crate::module::lifecycle::{
         ComputerSuspended, LifecycleModule, LifecycleStatus, ProcessStarted,
     };
+    use crate::platform::PlatformConfig;
 
     /// Minimal observer that counts how many Ping events it receives.
     struct PingCounter {
@@ -405,7 +406,10 @@ mod tests {
     #[test]
     fn observer_lookup_returns_correct_module() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ProcessStarted);
         assert_eq!(
@@ -418,7 +422,10 @@ mod tests {
     #[should_panic(expected = "assert_like failed")]
     fn assert_like_panics_when_no_match() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         // ComputerSuspended at 1s emits a Lifecycle upload but NOT a LifecycleAlert.
         t.emit(1, ComputerSuspended);
@@ -433,7 +440,10 @@ mod tests {
     #[test]
     fn assert_not_like_passes_when_absent() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ComputerSuspended);
         t.assert_not_like(crate::like!(Upload {
@@ -447,7 +457,10 @@ mod tests {
     #[test]
     fn clear_captured_resets_buffers() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ProcessStarted);
         assert!(!t.captured::<Upload>().is_empty());
@@ -458,7 +471,10 @@ mod tests {
     #[test]
     fn assert_like_matches_lifecycle_kind() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
         t.emit(1, ComputerSuspended);
         t.assert_like(crate::like!(Upload {
@@ -472,7 +488,10 @@ mod tests {
     #[test]
     fn missing_resume_fires_on_fourth_ping_with_enable_disable_pings() {
         let mut b = EventTester::builder();
-        b.add(LifecycleModule::new(Box::new(b.platform())));
+        b.add(LifecycleModule::new(
+            Box::new(b.platform()),
+            PlatformConfig::default(),
+        ));
         let mut t = b.build();
 
         t.emit(1, ComputerSuspended);

--- a/client/core/src/testing/mod.rs
+++ b/client/core/src/testing/mod.rs
@@ -28,7 +28,7 @@ mod tests {
     use crate::events::Ping;
     use crate::events::bus::{EventBus, EventChannel, StateType};
     use crate::module::status::{StatusRequest, StatusResponse};
-    use crate::platform::ScreenshotHooks;
+    use crate::platform::{PlatformConfig, ScreenshotHooks};
 
     static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -116,8 +116,8 @@ mod tests {
         let api = MockApiClient::new();
         let inspector = api.clone();
 
-        let observers =
-            build_default_modules(config, platform, api).expect("build modules must succeed");
+        let observers = build_default_modules(config, platform, api, PlatformConfig::default())
+            .expect("build modules must succeed");
         let mut bus = EventBus::new(observers, StateType::Null).expect("bus must construct");
 
         // No auth state → ping must not upload anything.

--- a/client/core/src/testing/scenario.rs
+++ b/client/core/src/testing/scenario.rs
@@ -17,6 +17,7 @@ use crate::module::screenshot::ScreenshotModule;
 use crate::module::status::StatusModule;
 use crate::module::status::{StatusRequest, StatusResponse};
 use crate::module::upload::{UploadModule, UploadObserverState};
+use crate::platform::PlatformConfig;
 use crate::state::load_state;
 use crate::testing::api::MockApiClient;
 use crate::testing::clock::MockClock;
@@ -33,6 +34,7 @@ pub struct Scenario {
     pub api: MockApiClient,
     pub clock: MockClock,
     pub state_dir: PathBuf,
+    pub platform: TestPlatformHooks,
 }
 
 impl Scenario {
@@ -99,7 +101,10 @@ impl Scenario {
         let api_handle = api.clone();
 
         let observers: Vec<Box<dyn Observer>> = vec![
-            Box::new(LifecycleModule::new(Box::new(platform.clone()))),
+            Box::new(LifecycleModule::new(
+                Box::new(platform.clone()),
+                PlatformConfig::default(),
+            )),
             Box::new(ScreenshotModule::new(
                 Arc::new(platform.clone()),
                 screenshot_interval_ms,
@@ -141,6 +146,7 @@ impl Scenario {
             api: api_handle,
             clock,
             state_dir,
+            platform,
         }
     }
 
@@ -358,7 +364,10 @@ impl Scenario {
         let api_handle = api.clone();
 
         let observers: Vec<Box<dyn Observer>> = vec![
-            Box::new(LifecycleModule::new(Box::new(platform.clone()))),
+            Box::new(LifecycleModule::new(
+                Box::new(platform.clone()),
+                PlatformConfig::default(),
+            )),
             Box::new(ScreenshotModule::new(
                 Arc::new(platform.clone()),
                 screenshot_interval_ms,
@@ -385,6 +394,7 @@ impl Scenario {
             api: api_handle,
             clock,
             state_dir,
+            platform,
         }
     }
 }

--- a/client/core/tests/scenarios.rs
+++ b/client/core/tests/scenarios.rs
@@ -292,6 +292,10 @@ fn unexpected_process_start_after_long_ping_gap_emits_alert() {
         last_process_started: 1,
         ..Default::default()
     });
+    // A real boot time is required for this alert: it only makes sense relative to
+    // a known boot ("this restart isn't explained by the device having just
+    // booted"). Platforms that can't report one (e.g. iOS) don't get this alert.
+    scenario.platform.set_last_startup_time(Some(1));
     scenario.queue(ProcessStarted);
     scenario.at_t(130_000).loop_iteration();
     // UnexpectedProcessStart is high-risk but batched (no immediate email).

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -13,8 +13,8 @@ use serde::de::DeserializeOwned;
 use virtue_core::{
     build_default_modules_reqwest, load_state, store_state, AuthState, Config, CoreError,
     CoreResult, DeviceSettings, EventBus, EventChannel, LoginRequested, LoginResult,
-    LogoutRequested, Ping, PlatformHooks, ProcessStarted, ProcessStopped, ProcessStoppedReason,
-    Redacted, Screenshot, ScreenshotHooks, StatusRequest, StatusResponse,
+    LogoutRequested, Ping, PlatformConfig, PlatformHooks, ProcessStarted, ProcessStopped,
+    ProcessStoppedReason, Redacted, Screenshot, ScreenshotHooks, StatusRequest, StatusResponse,
     UserStopRequested,
 };
 
@@ -422,7 +422,15 @@ fn sleep_interruptible(stop: &AtomicBool, duration: Duration) {
 
 fn build_bus(core: &IosCore) -> Result<(EventBus, PathBuf)> {
     let cfg = build_core_config(core);
-    let modules = build_default_modules_reqwest(cfg, IosPlatformHooks)?;
+    // The Safari extension host has no `UIApplication` and can be suspended by
+    // the OS the instant the device locks, with no notification delivered to
+    // this process. There's no reliable way to tell a benign lock/unlock from a
+    // suspicious pause, so the lifecycle module must not evaluate
+    // `PingGapWhileRunning` on iOS at all.
+    let platform_config = PlatformConfig {
+        supports_sleep_wake_detection: false,
+    };
+    let modules = build_default_modules_reqwest(cfg, IosPlatformHooks, platform_config)?;
     let state_path = core.state_dir.join("event_state.json");
     let bus = EventBus::new(modules, load_state(&state_path)?)?;
     Ok((bus, state_path))

--- a/client/linux/src/daemon.rs
+++ b/client/linux/src/daemon.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use tokio::sync::mpsc;
 use virtue_core::ProcessStoppedReason;
 use virtue_core::{
-    ComputerResumed, ComputerSuspended, EventBus, IpcBridge, Ping, ProcessStarted, ProcessStopped,
-    build_default_modules_reqwest, load_state, store_state,
+    ComputerResumed, ComputerSuspended, EventBus, IpcBridge, Ping, PlatformConfig, ProcessStarted,
+    ProcessStopped, build_default_modules_reqwest, load_state, store_state,
 };
 use zbus::proxy;
 
@@ -36,7 +36,7 @@ pub async fn run_daemon(paths: &ClientPaths) -> Result<()> {
     let config = build_core_config(paths);
     let state_path = paths.state_dir.join("event_state.json");
     let modules = tokio::task::block_in_place(|| {
-        build_default_modules_reqwest(config, LinuxPlatformHooks::new())
+        build_default_modules_reqwest(config, LinuxPlatformHooks::new(), PlatformConfig::default())
     })?;
     let mut bus = EventBus::new(modules, load_state(&state_path)?)?;
 

--- a/client/linux/src/main.rs
+++ b/client/linux/src/main.rs
@@ -15,9 +15,9 @@ use clap::{Args, Parser, Subcommand};
 #[cfg(debug_assertions)]
 use virtue_core::{AlertReason, LifecycleKind, ScreenshotSkipReason};
 use virtue_core::{
-    ClientController, EventBus, EventChannel, FlushBatchNow, Ping, ScreenshotHooks, ServiceStatus,
-    StatusRequest, StatusResponse, Upload, UploadKind, build_default_modules_reqwest, load_state,
-    store_state,
+    ClientController, EventBus, EventChannel, FlushBatchNow, Ping, PlatformConfig, ScreenshotHooks,
+    ServiceStatus, StatusRequest, StatusResponse, Upload, UploadKind,
+    build_default_modules_reqwest, load_state, store_state,
 };
 
 use crate::capture::{CaptureBackend, LinuxPlatformHooks, detect_backend, probe_backend};
@@ -518,8 +518,11 @@ fn dev_send(paths: ClientPaths, args: SendLogArgs) -> Result<()> {
 
 fn make_dev_bus(paths: &ClientPaths) -> Result<(EventBus, std::path::PathBuf)> {
     let state_path = paths.state_dir.join("event_state.json");
-    let modules =
-        build_default_modules_reqwest(build_core_config(paths), LinuxPlatformHooks::new())?;
+    let modules = build_default_modules_reqwest(
+        build_core_config(paths),
+        LinuxPlatformHooks::new(),
+        PlatformConfig::default(),
+    )?;
     let bus = EventBus::new(modules, load_state(&state_path)?)?;
     Ok((bus, state_path))
 }

--- a/client/mac/src/daemon.rs
+++ b/client/mac/src/daemon.rs
@@ -11,7 +11,7 @@ use objc2_app_kit::{NSWorkspace, NSWorkspaceWillPowerOffNotification};
 use tokio::sync::mpsc;
 use virtue_core::{
     ComputerResumed, ComputerSuspended, EventBus, EventChannel, FlushBatchNow, IpcBridge, Ping,
-    ProcessStarted, ProcessStopped, ProcessStoppedReason, UserStopRequested,
+    PlatformConfig, ProcessStarted, ProcessStopped, ProcessStoppedReason, UserStopRequested,
     build_default_modules_reqwest, load_state, store_state,
 };
 
@@ -223,7 +223,7 @@ async fn run_daemon_service_loop(
     let state_path = paths.state_dir.join("event_state.json");
 
     let modules = tokio::task::block_in_place(|| {
-        build_default_modules_reqwest(config, MacPlatformHooks::new())
+        build_default_modules_reqwest(config, MacPlatformHooks::new(), PlatformConfig::default())
     })?;
     let mut bus = EventBus::new(modules, load_state(&state_path)?)?;
 

--- a/client/windows/src/resident_monitor.rs
+++ b/client/windows/src/resident_monitor.rs
@@ -11,9 +11,10 @@ use anyhow::Result;
 use serde::Serialize;
 use virtue_core::{
     ComputerResumed, ComputerSuspended, CoreError, EventBus, EventChannel, LoginRequested,
-    LoginResult, LogoutRequested, LogoutResult, Ping, ProcessStarted, ProcessStopped,
-    ProcessStoppedReason, Redacted, StatusRequest, StatusResponse, UserSessionLogin,
-    UserSessionLogout, UserStopRequested, build_default_modules_reqwest, load_state, store_state,
+    LoginResult, LogoutRequested, LogoutResult, Ping, PlatformConfig, ProcessStarted,
+    ProcessStopped, ProcessStoppedReason, Redacted, StatusRequest, StatusResponse,
+    UserSessionLogin, UserSessionLogout, UserStopRequested, build_default_modules_reqwest,
+    load_state, store_state,
 };
 
 use crate::capture::WindowsPlatformHooks;
@@ -278,7 +279,11 @@ fn run_monitor_loop(shutdown: Arc<AtomicBool>, command_rx: Receiver<MonitorComma
     let state_path = paths.state_dir.join("event_state.json");
     let config = build_core_config(&paths);
 
-    let modules = match build_default_modules_reqwest(config, WindowsPlatformHooks::new()) {
+    let modules = match build_default_modules_reqwest(
+        config,
+        WindowsPlatformHooks::new(),
+        PlatformConfig::default(),
+    ) {
         Ok(m) => m,
         Err(err) => {
             update_snapshot(|s| {

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,3 +1,3 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
 git lfs post-checkout "$@"

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
 git lfs post-commit "$@"

--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,3 +1,3 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
 git lfs post-merge "$@"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,3 +1,3 @@
 #!/bin/sh
-command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
 git lfs pre-push "$@"


### PR DESCRIPTION
## Type of change
- Bug fix

## Components changed
- Core
- iOS
- Android
- Linux
- Mac
- Windows

## Description
Fixes #435. Two lifecycle alerts were firing on iOS for completely benign, user-uncontrollable events:

**"Unexpected Restart" (`UnexpectedProcessStart`)** fired on nearly every routine iOS restart, not just genuine tampering. The check gates on being outside a grace window following device boot, but iOS's `get_last_startup_time_utc_ms()` always returns `None` (no boot-time API for a Safari Web Extension host) — the old code defaulted the missing value to `0`, which made the "this restart isn't explained by a recent boot" guard trivially true on every real-world timestamp. Since iOS routinely suspends/recycles the Safari extension process as normal behavior (confirmed via `SafariWebExtensionHandler.swift`/`ios/rust/src/lib.rs`), this fired constantly. Fixed by only evaluating the check when the platform can report a real boot time.

**"Unexpected Gap" (`PingGapWhileRunning`)** fired after simply locking the phone. Locking suspends the Safari extension host with zero signal delivered to that process — no `UIApplication` (extensions don't have one), so there's no way to observe suspend/resume the way desktop platforms do via `ComputerSuspended`/`ComputerResumed`. A benign lock and a suspicious pause look bit-for-bit identical from inside the process. Rather than approximate this (a prior attempt using the container app's protected-data notifications was tested on-device and proved unreliable — the app is usually already suspended by the time a lock happens), the fix is to not evaluate `PingGapWhileRunning` at all on platforms that can't tell.

Added `PlatformConfig` (`client/core/src/platform.rs`): a small struct of fixed, per-platform capabilities passed once at module-assembly time, as opposed to `ScreenshotHooks`/`PlatformHooks`, which is live I/O queried every tick. Currently one field, `supports_sleep_wake_detection` (defaults to `true`), forwarded through `build_default_modules`/`build_default_modules_reqwest` to `LifecycleModule`. Named generically so future platform-level capability flags can be added without another signature change across every platform crate. All platforms except iOS pass `PlatformConfig::default()` unchanged; iOS explicitly sets `supports_sleep_wake_detection: false`.

Also includes the git-lfs hook template auto-updates (`echo` → `printf`) that were regenerated incidentally while running git commands this session — unrelated to the fix, purely mechanical.

## Testing
- `cargo test -p virtue-core --features testing`: 112 unit + 17 scenario tests pass, including 3 new/updated tests covering both fixes (`unexpected_process_start_requires_known_boot_time`, `ping_gap_is_not_evaluated_when_sleep_wake_unsupported`, and the updated `unexpected_process_start_after_long_ping_gap_emits_alert` scenario which now explicitly seeds a boot time to preserve its desktop-style intent).
- `cargo clippy -p virtue-core --features testing --tests`: clean.
- `cargo check`/`clippy` on `virtue-core`, `virtue-mac`, `virtue-linux`, `virtue-ios`, `virtue-android`: all clean.
- Built and installed on a physical iPhone via `client/ios/scripts/run-on-device.sh` at each stage of the fix; manually verified no "Unexpected Restart" alert after Safari extension restarts and no "Unexpected Gap" alert after locking the phone for 3+ minutes.

## Impact
iOS loses `UnexpectedProcessStart` and `PingGapWhileRunning` detection entirely — there's currently no reliable client-side telemetry to distinguish a benign cause from a suspicious one for either signal on this platform, so alerting on every occurrence produced pure noise. Desktop platforms (mac/linux/windows) and Android are unaffected (`PlatformConfig::default()` preserves prior behavior exactly). Other lifecycle alerts (e.g. `UserStoppedProcess`, `ForceKilledBeforeShutdown`) are untouched and continue to apply on iOS where reachable.

## Additional Information
Real device-lock visibility on iOS would require Apple's Screen Time `DeviceActivityMonitor`/Family Controls framework (OS-driven, independent of our process's liveness) — a separate, Apple-approval-gated project, not a small follow-up.