### PR TITLE
Polish devices/logs UI: pending count, sidebar user display, loading state

### DIFF
--- a/api/src/lib/email/templates.ts
+++ b/api/src/lib/email/templates.ts
@@ -12,6 +12,14 @@ const EMAIL_COLORS = {
   border: '#d9d1bc', // --border
 } as const;
 
+// Mirrors --font / --font-serif in shared-web/tokens.css. Custom web fonts
+// aren't loaded in most email clients, so these fall back to the same
+// generic stacks the app itself falls back to.
+const EMAIL_FONTS = {
+  sans: "'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+  serif: "'Source Serif 4', Georgia, serif",
+} as const;
+
 function inlineStyle(rules: Record<string, string>) {
   return Object.entries(rules)
     .map(([key, value]) => `${key}:${value}`)
@@ -39,22 +47,24 @@ function paragraph(text: string) {
     margin: '0 0 16px 0',
     color: EMAIL_COLORS.text,
     'font-size': '16px',
-    'line-height': '1.6',
+    'line-height': '1.5',
   })}">${escapeHtml(text)}</p>`;
 }
 
+// Mirrors .vi-btn--primary in shared-web/components/Button/Button.css.
 function actionButton(url: string, label: string) {
-  return `<p style="${inlineStyle({ margin: '0 0 18px 0' })}"><a href="${escapeHtml(url)}" style="${inlineStyle(
+  return `<p style="${inlineStyle({ margin: '0 0 16px 0' })}"><a href="${escapeHtml(url)}" style="${inlineStyle(
     {
       display: 'inline-block',
       background: EMAIL_COLORS.accent,
       color: EMAIL_COLORS.textOnAccent,
       'text-decoration': 'none',
-      'font-weight': '600',
-      'font-size': '15px',
+      'font-weight': '500',
+      'font-size': '14px',
+      'letter-spacing': '0.005em',
       'line-height': '1',
-      padding: '12px 18px',
-      'border-radius': '8px',
+      padding: '11px 13px',
+      'border-radius': '2px',
     },
   )}">${escapeHtml(label)}</a></p>`;
 }
@@ -63,7 +73,7 @@ function listItem(text: string) {
   return `<li style="${inlineStyle({
     margin: '0 0 8px 0',
     color: EMAIL_COLORS.text,
-    'font-size': '15px',
+    'font-size': '14px',
     'line-height': '1.5',
   })}">${escapeHtml(text)}</li>`;
 }
@@ -90,7 +100,7 @@ function renderEmailDocument(input: {
     margin: '0',
     padding: '24px',
     background: EMAIL_COLORS.pageBg,
-    'font-family': "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif",
+    'font-family': EMAIL_FONTS.sans,
     color: EMAIL_COLORS.text,
   })}">
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="${inlineStyle({ 'border-collapse': 'collapse' })}">
@@ -103,11 +113,11 @@ function renderEmailDocument(input: {
             },
           )}">
             <tr>
-              <td style="${inlineStyle({ padding: '0 0 14px 0' })}">
+              <td style="${inlineStyle({ padding: '0 0 16px 0' })}">
                 <p style="${inlineStyle({
                   margin: '0',
                   color: EMAIL_COLORS.textMuted,
-                  'font-size': '13px',
+                  'font-size': '12px',
                   'font-weight': '600',
                 })}">${escapeHtml(input.appName)}</p>
               </td>
@@ -116,13 +126,16 @@ function renderEmailDocument(input: {
               <td style="${inlineStyle({
                 background: EMAIL_COLORS.surface,
                 border: `1px solid ${EMAIL_COLORS.border}`,
-                'border-radius': '14px',
-                padding: '26px 24px',
+                'border-radius': '4px',
+                padding: '20px',
               })}">
                 <h1 style="${inlineStyle({
                   margin: '0 0 16px 0',
-                  'font-size': '22px',
-                  'line-height': '1.25',
+                  'font-family': EMAIL_FONTS.serif,
+                  'font-size': '28px',
+                  'font-weight': '400',
+                  'line-height': '1.15',
+                  'letter-spacing': '-0.01em',
                   color: EMAIL_COLORS.text,
                 })}">${escapeHtml(input.headline)}</h1>
                 ${input.contentHtml}
@@ -168,7 +181,7 @@ function withFooter(input: {
     `<p style="${inlineStyle({
       margin: '0',
       color: EMAIL_COLORS.textMuted,
-      'font-size': '13px',
+      'font-size': '12px',
       'line-height': '1.5',
     })}">${themedLink(settingsUrl, 'Manage email preferences')}</p>`,
   ].join('');
@@ -495,10 +508,10 @@ export function renderPartnerDigestTemplate(input: {
           : '';
 
       return `<div style="${inlineStyle({
-        margin: '0 0 18px 0',
+        margin: '0 0 16px 0',
         padding: '16px',
         border: `1px solid ${EMAIL_COLORS.border}`,
-        'border-radius': '10px',
+        'border-radius': '4px',
       })}">
         <p style="${inlineStyle({
           margin: '0 0 12px 0',

--- a/api/src/lib/email/templates.ts
+++ b/api/src/lib/email/templates.ts
@@ -1,13 +1,15 @@
 import { DigestFrequency, TamperSeverity } from '../email-domain';
 
+// Mirrors the app's warm institutional palette (shared-web/tokens.css) so
+// transactional emails match the product's actual branding.
 const EMAIL_COLORS = {
-  text: '#1a1a1a',
-  textMuted: '#6b6860',
-  textOnAccent: '#ffffff',
-  accent: '#008900',
-  pageBg: '#f9f9f7',
-  surface: '#ffffff',
-  border: '#e0ddd8',
+  text: '#1b1a16', // --text
+  textMuted: '#6a6655', // --text-muted
+  textOnAccent: '#fbf7ea', // --paper-3 (matches .vi-btn--primary's text color)
+  accent: '#1e3a2e', // --accent / --forest
+  pageBg: '#f4efe3', // --bg / --paper
+  surface: '#fbf7ea', // --surface / --paper-3
+  border: '#d9d1bc', // --border
 } as const;
 
 function inlineStyle(rules: Record<string, string>) {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -174,8 +174,7 @@ export function Sidebar() {
     setDrawerOpen(false);
   };
 
-  const userLabel = user?.name ?? user?.email ?? 'Account';
-  const userSub = user?.name ? user?.email : undefined;
+  const userLabel = user?.name || user?.email || 'Account';
 
   return (
     <>
@@ -310,7 +309,6 @@ export function Sidebar() {
             <Avatar name={user?.name ?? user?.email} size="md" />
             <span class="sidebar-user-text">
               <span class="sidebar-user-name">{userLabel}</span>
-              {userSub && <span class="sidebar-user-sub">{userSub}</span>}
             </span>
             <span class={`sidebar-user-chevron${drawerOpen ? ' is-open' : ''}`}>
               <ChevronUpIcon />

--- a/web/src/pages/Devices/devices.test.tsx
+++ b/web/src/pages/Devices/devices.test.tsx
@@ -22,6 +22,41 @@ describe('Devices — device list', () => {
       expect(screen.getByRole('heading', { name: /^devices$/i })).toBeInTheDocument();
     });
   });
+
+  it('shows a loading indicator instead of "No devices" while the fetch is in flight', async () => {
+    let resolveDevices: (() => void) | undefined;
+    server.use(
+      http.get(
+        'http://localhost:8787/device',
+        () =>
+          new Promise((resolve) => {
+            resolveDevices = () => resolve(HttpResponse.json(TEST_DEVICES));
+          }),
+      ),
+    );
+
+    renderWithClient(<Devices />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.queryByText('No devices')).not.toBeInTheDocument();
+
+    await waitFor(() => expect(resolveDevices).toBeDefined());
+    resolveDevices?.();
+
+    await waitFor(() => {
+      expect(screen.getByText('My Laptop')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "No devices" once loaded with an empty list', async () => {
+    server.use(http.get('http://localhost:8787/device', () => HttpResponse.json([])));
+
+    renderWithClient(<Devices />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No devices')).toBeInTheDocument();
+    });
+  });
 });
 
 describe('Devices — Add device dialog', () => {

--- a/web/src/pages/Devices/index.tsx
+++ b/web/src/pages/Devices/index.tsx
@@ -28,7 +28,7 @@ const INSTALLATION_URL = `${LANDING_URL}/help/installation`;
 export function Devices() {
   const api = useAPIContext();
   const userId = api?.userId ?? null;
-  const { devices } = useDevices();
+  const { devices, loaded } = useDevices();
   const updateDevice = (id: string, patch: { name?: string }) =>
     api ? api.updateDevice(id, patch) : Promise.reject(new Error('Not signed in'));
   const removeDevice = (id: string) =>
@@ -44,7 +44,9 @@ export function Devices() {
       <PageHeading icon={<DevicesIcon />} actions={<AddDeviceButton />}>
         Devices
       </PageHeading>
-      {ownDevices.length === 0 ? (
+      {!loaded ? (
+        <p class="loading">Loading…</p>
+      ) : ownDevices.length === 0 ? (
         <p class="empty">No devices</p>
       ) : (
         <CardGrid>

--- a/web/src/pages/Logs/index.tsx
+++ b/web/src/pages/Logs/index.tsx
@@ -163,6 +163,10 @@ export function Logs({ userId: routeUserId }: { userId?: string }) {
     [deviceList, activeTargetUserId],
   );
 
+  const pendingCount = selectedDeviceInfo
+    ? selectedDeviceInfo.pending_count
+    : activeDevices.reduce((sum, d) => sum + d.pending_count, 0);
+
   useEffect(() => {
     if (sidebarLoading) return;
     if (selectedDevice && !activeDevices.some((d) => d.id === selectedDevice)) {
@@ -330,10 +334,10 @@ export function Logs({ userId: routeUserId }: { userId?: string }) {
                 ? `Syncing logs… ${logResult.processed}/${logResult.total} blocks`
                 : 'Syncing logs…'
               : 'Logs synced'}
-            {!logsLoading && selectedDeviceInfo && selectedDeviceInfo.pending_count > 0 && (
+            {!logsLoading && pendingCount > 0 && (
               <>
-                {` · ${selectedDeviceInfo.pending_count} item${selectedDeviceInfo.pending_count !== 1 ? 's' : ''} pending upload`}
-                {estimatedNextUpload && estimatedNextUpload > Date.now()
+                {` · ${pendingCount} item${pendingCount !== 1 ? 's' : ''} pending upload`}
+                {selectedDeviceInfo && estimatedNextUpload && estimatedNextUpload > Date.now()
                   ? ` · expected ${formatRelativeTimestamp(estimatedNextUpload)}`
                   : null}
               </>

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -196,7 +196,6 @@ a.sidebar-nav-group-heading {
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
-  padding: 0.5rem 0 0;
 }
 
 .sidebar-user {
@@ -204,7 +203,7 @@ a.sidebar-nav-group-heading {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  padding: 0 0.875rem 0.75rem;
+  padding: 0.75rem 0.875rem;
   border: 0;
   border-top: 1px solid transparent;
   background: transparent;

--- a/web/src/styles/sidebar.css
+++ b/web/src/styles/sidebar.css
@@ -204,7 +204,7 @@ a.sidebar-nav-group-heading {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  padding: 0.75rem 0.875rem;
+  padding: 0 0.875rem 0.75rem;
   border: 0;
   border-top: 1px solid transparent;
   background: transparent;
@@ -251,17 +251,6 @@ a.sidebar-nav-group-heading {
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--ink);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.sidebar-user-sub {
-  font-family: var(--font-mono);
-  font-size: 0.625rem;
-  letter-spacing: 0.06em;
-  color: var(--ink-3);
-  margin-top: 0.25rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Fixes four small UI bugs on the devices/logs pages, the sidebar user display, and the transactional email templates.

## Type of change
- Bug fix
- UI/UX improvement

## Components changed
- Web
- API

## Description
Four related, small polish fixes bundled into one PR:

- **Fixed #483** — The Logs page summary line only showed "pending upload" count for a single selected device. When "All devices" is selected, it now sums `pending_count` across all of the user's active devices instead of showing nothing.
- **Fixed #480** — The sidebar user display derived a `name`/`email` pair that could show the email as a secondary line under the name. Changed it to display only one value: the user's name, falling back to email if no name is set — never both. Also fixed vertical alignment of the text block with the avatar and removed the padding between the sidebar separator and the user row (the gap came from `.sidebar-footer-drawer-inner`'s top padding, not `.sidebar-user`'s own padding — removed it there so the open-drawer spacing between the nav links and the user row is unaffected).
- **Fixed #477** — The Devices page destructured only `devices` from `useDevices()`, ignoring the `loaded` flag, so "No devices" rendered immediately during the initial fetch. Now it shows a "Loading…" state until `loaded` is `true`, matching the pattern already used on the Logs page.
- **Fixed #474** — The transactional email templates (`api/src/lib/email/templates.ts`) didn't match the app's actual branding, in color and in shape:
  - `EMAIL_COLORS` used a generic scheme (`#008900` accent green, `#f9f9f7` cool-gray page background, pure `#ffffff` surfaces) instead of `shared-web/tokens.css`'s warm cream + dark forest-green palette (`--accent: #1e3a2e`, `--bg: #f4efe3`, `--surface: #fbf7ea`) — now mirrors those tokens exactly, including the button text color (`--paper-3`) instead of pure white.
  - The `<h1>` headline rendered sans-serif/browser-default-bold at 22px; the app's actual page headings use a serif font (Source Serif 4/Georgia) at weight 400. Added an `EMAIL_FONTS` constant and restyled the headline to match.
  - The CTA button was 15px/600-weight text with an 8px border-radius; `.vi-btn--primary` is 14px/500-weight with only a 2px radius. Updated to match.
  - Card/digest-summary border-radius (14px/10px) is now 4px (`--radius-md`), and card padding normalized to the Card component's 20px.
  - List items, the eyebrow app-name text, and footer text were arbitrary 13px/15px values; snapped to the app's 12px/14px type scale.

<img width="306" height="204" alt="image" src="https://github.com/user-attachments/assets/c81b3dda-5659-49bf-9f76-cc1555cd8abb" />
<img width="606" height="304" alt="image" src="https://github.com/user-attachments/assets/45aa61c9-e2a1-4e82-9078-c8e2f91727f2" />
<img width="898" height="578" alt="image" src="https://github.com/user-attachments/assets/691d7874-7221-4689-b1fe-09fb3060b28c" />


## Testing
- `bun run typecheck`, `bun run format:check`, `bun run test` (98 tests passing), and `bun run build` all pass in `web/`.
- `bun run typecheck`, `bun run format:check`, and `bun run test` (42 tests passing) all pass in `api/`.
- Added two new tests in `web/src/pages/Devices/devices.test.tsx` covering the loading state and the genuinely-empty state.
- Manually verified in a running dev instance (`./scripts/launch.sh` + seeded dev account):
  - Sidebar shows a single line (email-only when no name set, name-only once a name is set) with proper vertical centering, and the separator-to-user-row gap is gone in the closed state while the open-drawer spacing above the user row is preserved.
  - Devices page shows "No devices" only after the fetch resolves.
- Rendered `renderPartnerInviteTemplate` and `renderTamperAlertTemplate` to static HTML and screenshotted them (via Playwright) to visually confirm the new palette/typography/shape against the app's actual look.
- Existing API tests exercise every template function and confirm the new values render correctly in the generated HTML.

## Impact
UI and email-template-only changes; no API response shape or cross-component contract changes. No new dependencies.

## Additional Information
None.
