### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Purpose
+
+This project exists to help people build healthier habits and live with integrity. Given the nature of the app, we ask everyone involved — contributors, maintainers, and community members — to hold themselves to a high standard of respect, discretion, and good faith.
+
+## Our Standards
+
+We want this to be a space where people can contribute good work and get help without friction. Examples of behavior that helps us get there:
+
+- Treating others with courtesy, patience, and respect, even in disagreement
+- Giving and receiving constructive feedback gracefully
+- Being honest about mistakes and taking responsibility for them
+- Respecting the privacy and dignity of users of this app, who may be dealing with a sensitive and personal struggle
+- Assuming good faith in others' intentions before assuming the worst
+- Keeping discussions focused on the project and its goals
+
+Examples of behavior that is not acceptable:
+
+- Personal attacks, insults, or demeaning language directed at others
+- Harassment of any kind, public or private
+- Sharing someone else's private information (including app users' data or activity) without explicit permission
+- Sexually explicit or exploitative content, imagery, or language in project spaces — this includes issues, pull requests, commits, comments, and any community channels
+- Trolling, deliberately derailing discussions, or sustained disruptive behavior
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including the repository, issue tracker, pull requests, and our Discord.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers at **[INSERT CONTACT EMAIL]**. All reports will be reviewed and investigated promptly and fairly, and maintainers are obligated to respect the privacy and security of the person reporting.
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary or permanent repercussions as determined by other project leadership.
+
+Depending on the severity of a violation, consequences may include:
+
+1. **Correction** — A private, respectful note explaining the issue and what's expected going forward.
+2. **Warning** — A formal warning, with continued behavior resulting in further action.
+3. **Temporary restriction** — Temporary removal of access to contribute to the project.
+4. **Permanent removal** — Permanent ban from any kind of interaction with the project.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,7 +29,7 @@ This Code of Conduct applies within all project spaces, including the repository
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported to the project maintainers at **help@virtueinitiative.org**. All reports will be reviewed and investigated promptly and fairly, and maintainers are obligated to respect the privacy and security of the person reporting.
+Instances of unacceptable behavior may be reported to the project maintainers at [help@virtueinitiative.org](mailto:help@virtueinitiative.org). All reports will be reviewed and investigated promptly and fairly, and maintainers are obligated to respect the privacy and security of the person reporting.
 
 Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary or permanent repercussions as determined by other project leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,7 +29,7 @@ This Code of Conduct applies within all project spaces, including the repository
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported to the project maintainers at **[INSERT CONTACT EMAIL]**. All reports will be reviewed and investigated promptly and fairly, and maintainers are obligated to respect the privacy and security of the person reporting.
+Instances of unacceptable behavior may be reported to the project maintainers at **help@virtueinitiative.org**. All reports will be reviewed and investigated promptly and fairly, and maintainers are obligated to respect the privacy and security of the person reporting.
 
 Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary or permanent repercussions as determined by other project leadership.
 

--- a/client/text-detection/src/linux.rs
+++ b/client/text-detection/src/linux.rs
@@ -303,10 +303,9 @@ fn extract_bbox(tag: &str) -> Option<BoundingBox> {
     let rest = &tag[ti..];
     let (quote, rest) = if let Some(rest) = rest.strip_prefix('"') {
         ('"', rest)
-    } else if let Some(rest) = rest.strip_prefix('\'') {
-        ('\'', rest)
     } else {
-        return None;
+        let rest = rest.strip_prefix('\'')?;
+        ('\'', rest)
     };
     let title = &rest[..rest.find(quote)?];
     let bi = title.find("bbox ")? + "bbox ".len();

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -5,6 +5,7 @@
         href="/privacy">Privacy Policy</a
       > &nbsp;·&nbsp;
       <a href="/terms">Terms of Use</a> &nbsp;·&nbsp;
+      <a href="/code-of-conduct">Code of Conduct</a> &nbsp;·&nbsp;
       <a href="/blog">Blog</a> &nbsp;·&nbsp;
       <a href="https://github.com/virtue-initiative/virtue-initiative"> GitHub </a> &nbsp;·&nbsp;
       <a href="https://discord.gg/4kNsbRuzQD"> Discord </a>

--- a/landing/src/legal/code-of-conduct.md
+++ b/landing/src/legal/code-of-conduct.md
@@ -1,0 +1,1 @@
+../../../CODE_OF_CONDUCT.md

--- a/landing/src/pages/code-of-conduct.astro
+++ b/landing/src/pages/code-of-conduct.astro
@@ -53,10 +53,10 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 
     <h2>Enforcement</h2>
     <p>
-      Instances of unacceptable behavior may be reported to the project maintainers at
-      <strong>[INSERT CONTACT EMAIL]</strong>. All reports will be reviewed and investigated
-      promptly and fairly, and maintainers are obligated to respect the privacy and security of
-      the person reporting.
+      Instances of unacceptable behavior may be reported to the project maintainers at <a
+        href="mailto:help@virtueinitiative.org">help@virtueinitiative.org</a
+      >. All reports will be reviewed and investigated promptly and fairly, and maintainers are
+      obligated to respect the privacy and security of the person reporting.
     </p>
     <p>
       Maintainers who do not follow or enforce this Code of Conduct in good faith may face

--- a/landing/src/pages/code-of-conduct.astro
+++ b/landing/src/pages/code-of-conduct.astro
@@ -1,0 +1,85 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+---
+
+<SiteLayout pageTitle="Code of Conduct">
+  <section class="legal">
+    <h1>Code of Conduct</h1>
+
+    <h2>Our Purpose</h2>
+    <p>
+      This project exists to help people build healthier habits and live with integrity. Given the
+      nature of the app, we ask everyone involved — contributors, maintainers, and community
+      members — to hold themselves to a high standard of respect, discretion, and good faith.
+    </p>
+
+    <h2>Our Standards</h2>
+    <p>
+      We want this to be a space where people can contribute good work and get help without
+      friction. Examples of behavior that helps us get there:
+    </p>
+    <ul>
+      <li>Treating others with courtesy, patience, and respect, even in disagreement</li>
+      <li>Giving and receiving constructive feedback gracefully</li>
+      <li>Being honest about mistakes and taking responsibility for them</li>
+      <li>
+        Respecting the privacy and dignity of users of this app, who may be dealing with a
+        sensitive and personal struggle
+      </li>
+      <li>Assuming good faith in others' intentions before assuming the worst</li>
+      <li>Keeping discussions focused on the project and its goals</li>
+    </ul>
+
+    <p>Examples of behavior that is not acceptable:</p>
+    <ul>
+      <li>Personal attacks, insults, or demeaning language directed at others</li>
+      <li>Harassment of any kind, public or private</li>
+      <li>
+        Sharing someone else's private information (including app users' data or activity)
+        without explicit permission
+      </li>
+      <li>
+        Sexually explicit or exploitative content, imagery, or language in project spaces — this
+        includes issues, pull requests, commits, comments, and any community channels
+      </li>
+      <li>Trolling, deliberately derailing discussions, or sustained disruptive behavior</li>
+    </ul>
+
+    <h2>Scope</h2>
+    <p>
+      This Code of Conduct applies within all project spaces, including the repository, issue
+      tracker, pull requests, and our Discord.
+    </p>
+
+    <h2>Enforcement</h2>
+    <p>
+      Instances of unacceptable behavior may be reported to the project maintainers at
+      <strong>[INSERT CONTACT EMAIL]</strong>. All reports will be reviewed and investigated
+      promptly and fairly, and maintainers are obligated to respect the privacy and security of
+      the person reporting.
+    </p>
+    <p>
+      Maintainers who do not follow or enforce this Code of Conduct in good faith may face
+      temporary or permanent repercussions as determined by other project leadership.
+    </p>
+    <p>Depending on the severity of a violation, consequences may include:</p>
+    <ul>
+      <li>
+        <strong>Correction</strong> — A private, respectful note explaining the issue and what's
+        expected going forward.
+      </li>
+      <li>
+        <strong>Warning</strong> — A formal warning, with continued behavior resulting in further
+        action.
+      </li>
+      <li>
+        <strong>Temporary restriction</strong> — Temporary removal of access to contribute to the
+        project.
+      </li>
+      <li>
+        <strong>Permanent removal</strong> — Permanent ban from any kind of interaction with the
+        project.
+      </li>
+    </ul>
+  </section>
+</SiteLayout>

--- a/landing/src/pages/code-of-conduct.astro
+++ b/landing/src/pages/code-of-conduct.astro
@@ -9,8 +9,8 @@ import SiteLayout from '../layouts/SiteLayout.astro';
     <h2>Our Purpose</h2>
     <p>
       This project exists to help people build healthier habits and live with integrity. Given the
-      nature of the app, we ask everyone involved — contributors, maintainers, and community
-      members — to hold themselves to a high standard of respect, discretion, and good faith.
+      nature of the app, we ask everyone involved — contributors, maintainers, and community members
+      — to hold themselves to a high standard of respect, discretion, and good faith.
     </p>
 
     <h2>Our Standards</h2>
@@ -23,8 +23,8 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <li>Giving and receiving constructive feedback gracefully</li>
       <li>Being honest about mistakes and taking responsibility for them</li>
       <li>
-        Respecting the privacy and dignity of users of this app, who may be dealing with a
-        sensitive and personal struggle
+        Respecting the privacy and dignity of users of this app, who may be dealing with a sensitive
+        and personal struggle
       </li>
       <li>Assuming good faith in others' intentions before assuming the worst</li>
       <li>Keeping discussions focused on the project and its goals</li>
@@ -35,8 +35,8 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       <li>Personal attacks, insults, or demeaning language directed at others</li>
       <li>Harassment of any kind, public or private</li>
       <li>
-        Sharing someone else's private information (including app users' data or activity)
-        without explicit permission
+        Sharing someone else's private information (including app users' data or activity) without
+        explicit permission
       </li>
       <li>
         Sexually explicit or exploitative content, imagery, or language in project spaces — this
@@ -59,26 +59,23 @@ import SiteLayout from '../layouts/SiteLayout.astro';
       obligated to respect the privacy and security of the person reporting.
     </p>
     <p>
-      Maintainers who do not follow or enforce this Code of Conduct in good faith may face
-      temporary or permanent repercussions as determined by other project leadership.
+      Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary
+      or permanent repercussions as determined by other project leadership.
     </p>
     <p>Depending on the severity of a violation, consequences may include:</p>
     <ul>
       <li>
-        <strong>Correction</strong> — A private, respectful note explaining the issue and what's
-        expected going forward.
+        <strong>Correction</strong> — A private, respectful note explaining the issue and what's expected
+        going forward.
       </li>
       <li>
-        <strong>Warning</strong> — A formal warning, with continued behavior resulting in further
-        action.
+        <strong>Warning</strong> — A formal warning, with continued behavior resulting in further action.
       </li>
       <li>
-        <strong>Temporary restriction</strong> — Temporary removal of access to contribute to the
-        project.
+        <strong>Temporary restriction</strong> — Temporary removal of access to contribute to the project.
       </li>
       <li>
-        <strong>Permanent removal</strong> — Permanent ban from any kind of interaction with the
-        project.
+        <strong>Permanent removal</strong> — Permanent ban from any kind of interaction with the project.
       </li>
     </ul>
   </section>

--- a/landing/src/pages/code-of-conduct.astro
+++ b/landing/src/pages/code-of-conduct.astro
@@ -1,82 +1,11 @@
 ---
 import SiteLayout from '../layouts/SiteLayout.astro';
+// Symlinked to the repo-root CODE_OF_CONDUCT.md so the site and repo copies can't drift apart.
+import { Content } from '../legal/code-of-conduct.md';
 ---
 
 <SiteLayout pageTitle="Code of Conduct">
   <section class="legal">
-    <h1>Code of Conduct</h1>
-
-    <h2>Our Purpose</h2>
-    <p>
-      This project exists to help people build healthier habits and live with integrity. Given the
-      nature of the app, we ask everyone involved — contributors, maintainers, and community members
-      — to hold themselves to a high standard of respect, discretion, and good faith.
-    </p>
-
-    <h2>Our Standards</h2>
-    <p>
-      We want this to be a space where people can contribute good work and get help without
-      friction. Examples of behavior that helps us get there:
-    </p>
-    <ul>
-      <li>Treating others with courtesy, patience, and respect, even in disagreement</li>
-      <li>Giving and receiving constructive feedback gracefully</li>
-      <li>Being honest about mistakes and taking responsibility for them</li>
-      <li>
-        Respecting the privacy and dignity of users of this app, who may be dealing with a sensitive
-        and personal struggle
-      </li>
-      <li>Assuming good faith in others' intentions before assuming the worst</li>
-      <li>Keeping discussions focused on the project and its goals</li>
-    </ul>
-
-    <p>Examples of behavior that is not acceptable:</p>
-    <ul>
-      <li>Personal attacks, insults, or demeaning language directed at others</li>
-      <li>Harassment of any kind, public or private</li>
-      <li>
-        Sharing someone else's private information (including app users' data or activity) without
-        explicit permission
-      </li>
-      <li>
-        Sexually explicit or exploitative content, imagery, or language in project spaces — this
-        includes issues, pull requests, commits, comments, and any community channels
-      </li>
-      <li>Trolling, deliberately derailing discussions, or sustained disruptive behavior</li>
-    </ul>
-
-    <h2>Scope</h2>
-    <p>
-      This Code of Conduct applies within all project spaces, including the repository, issue
-      tracker, pull requests, and our Discord.
-    </p>
-
-    <h2>Enforcement</h2>
-    <p>
-      Instances of unacceptable behavior may be reported to the project maintainers at <a
-        href="mailto:help@virtueinitiative.org">help@virtueinitiative.org</a
-      >. All reports will be reviewed and investigated promptly and fairly, and maintainers are
-      obligated to respect the privacy and security of the person reporting.
-    </p>
-    <p>
-      Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary
-      or permanent repercussions as determined by other project leadership.
-    </p>
-    <p>Depending on the severity of a violation, consequences may include:</p>
-    <ul>
-      <li>
-        <strong>Correction</strong> — A private, respectful note explaining the issue and what's expected
-        going forward.
-      </li>
-      <li>
-        <strong>Warning</strong> — A formal warning, with continued behavior resulting in further action.
-      </li>
-      <li>
-        <strong>Temporary restriction</strong> — Temporary removal of access to contribute to the project.
-      </li>
-      <li>
-        <strong>Permanent removal</strong> — Permanent ban from any kind of interaction with the project.
-      </li>
-    </ul>
+    <Content />
   </section>
 </SiteLayout>

--- a/landing/src/styles/legal.css
+++ b/landing/src/styles/legal.css
@@ -38,6 +38,10 @@
     gap: 0.4rem;
     margin-top: 0.5rem;
   }
+
+  & ul + p {
+    margin-top: 0.75rem;
+  }
 }
 
 .legal-date {


### PR DESCRIPTION
## Summary

- Adds `CODE_OF_CONDUCT.md` at the repo root.
- Adds a matching `/code-of-conduct` page to the landing site and links it from the site footer, alongside Privacy Policy and Terms of Use.
- Fixes #196 

## Changes

<!-- Type of change: Feature / Bug fix / Refactor / Docs / Other -->
Docs / Feature
<!-- Components: Web / Landing / API / Core / Linux / Mac / Windows / iOS / Android -->
Landing

- `CODE_OF_CONDUCT.md` (new)
- `landing/src/pages/code-of-conduct.astro` (new) — mirrors the existing `/privacy` and `/terms` page structure
- `landing/src/components/Footer.astro` — added "Code of Conduct" link between "Terms of Use" and "Blog"

Note: the enforcement contact email in the Code of Conduct is left as a placeholder (`[INSERT CONTACT EMAIL]`) — needs to be filled in with a real address before this is final.

## Testing

- `bun run build` in `landing/` completes successfully and generates `/code-of-conduct/index.html`.
- Ran `astro dev` locally and screenshotted the rendered `/code-of-conduct` page and the homepage footer to confirm the new link and page render correctly (screenshots attached in a follow-up comment).

## Screenshots
<img width="1280" height="140" alt="footer-screenshot" src="https://github.com/user-attachments/assets/42a6f275-c74c-4d0d-b050-75501221204c" />
<img width="1280" height="1400" alt="landing-coc" src="https://github.com/user-attachments/assets/07758140-6ec5-488a-85de-7caa0eff686f" />
