### PR TITLE
Add upload retry backoff and API rate limiting

### DIFF
--- a/api/src/middleware/rate-limit.ts
+++ b/api/src/middleware/rate-limit.ts
@@ -1,0 +1,16 @@
+import { Context, Next } from 'hono';
+import { Env, Variables } from '../types/bindings';
+
+/** Must run after an auth middleware that calls `c.set('sub', ...)`. */
+export function rateLimitByDevice() {
+  return async function rateLimitMiddleware(
+    c: Context<{ Bindings: Env; Variables: Variables }>,
+    next: Next,
+  ) {
+    const { success } = await c.env.RATE_LIMITER.limit({ key: c.get('sub') });
+    if (!success) {
+      return c.json({ error: 'Too many requests' }, 429);
+    }
+    await next();
+  };
+}

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -2,6 +2,7 @@ import { Context, Hono } from 'hono';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { authenticateWebSession, authenticateDeviceSession } from '../middleware/auth';
+import { rateLimitByDevice } from '../middleware/rate-limit';
 import { validateZ } from '../middleware/validation';
 import {
   createBatch,
@@ -133,7 +134,7 @@ deviceOnly.post(
 /**
  * GET /d/device - Get device settings for the authenticated device.
  */
-deviceOnly.get('/device', authenticateDeviceSession(), async (c) => {
+deviceOnly.get('/device', authenticateDeviceSession(), rateLimitByDevice(), async (c) => {
   const device = await findDeviceById(c.env.DB, c.get('sub'));
 
   if (!device) {
@@ -185,6 +186,7 @@ deviceOnly.post('/token', authenticateDeviceSession(), async (c) => {
 deviceOnly.post(
   '/batch',
   authenticateDeviceSession(),
+  rateLimitByDevice(),
   validateZ('form', uploadBatchSchema),
   async (c) => {
     const device = await findDeviceById(c.env.DB, c.get('sub'));
@@ -246,6 +248,7 @@ deviceOnly.post(
 deviceOnly.post(
   '/notify',
   authenticateDeviceSession(),
+  rateLimitByDevice(),
   validateZ('json', notifySchema),
   async (c) => {
     const device = await findDeviceById(c.env.DB, c.get('sub'));

--- a/api/src/routes/hashes.ts
+++ b/api/src/routes/hashes.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono';
 import { authenticate } from '../middleware/auth';
+import { rateLimitByDevice } from '../middleware/rate-limit';
 import { findDeviceById, getHashState, resetHashState, upsertHashState } from '../lib/db';
 import { Env, Variables } from '../types/bindings';
 
 const hashes = new Hono<{ Bindings: Env; Variables: Variables }>();
 const ZERO_STATE = new Uint8Array(32);
 
-hashes.post('/', authenticate('hash-server'), async (c) => {
+hashes.post('/', authenticate('hash-server'), rateLimitByDevice(), async (c) => {
   const body = await c.req.arrayBuffer();
 
   if (body.byteLength !== 32) {
@@ -31,7 +32,7 @@ hashes.post('/', authenticate('hash-server'), async (c) => {
   return c.json({ ok: true });
 });
 
-hashes.get('/', authenticate('hash-server'), async (c) => {
+hashes.get('/', authenticate('hash-server'), rateLimitByDevice(), async (c) => {
   const state = await getHashState(c.env.DB, c.get('sub'));
   const body = state ? new Uint8Array(state.state) : ZERO_STATE;
 

--- a/api/src/types/bindings.ts
+++ b/api/src/types/bindings.ts
@@ -1,6 +1,7 @@
 export interface Env {
   DB: D1Database;
   BUCKET: R2Bucket;
+  RATE_LIMITER: RateLimit;
   JWT_PRIVATE_KEY: string;
   JWT_PUBLIC_KEY: string;
   API_BASE_PATH?: string;

--- a/api/test/rate-limit.test.ts
+++ b/api/test/rate-limit.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SELF } from 'cloudflare:test';
+import { BASE, clearDB, createDeviceForUser, signupAndGetCookie } from './helpers';
+
+beforeEach(clearDB);
+
+describe('Per-device rate limiting', () => {
+  it('returns 429 once a device exceeds the configured request rate', async () => {
+    const { cookie } = await signupAndGetCookie('rate-limited@example.com');
+    const device = await createDeviceForUser(cookie, 'Rate Limited Device', 'linux');
+    const headers = { Authorization: `Bearer ${device.refresh_token}` };
+
+    // wrangler.json's staging RATE_LIMITER is configured for 60 requests/60s.
+    const responses = await Promise.all(
+      Array.from({ length: 65 }, () => SELF.fetch(`${BASE}/d/device`, { headers })),
+    );
+
+    const statuses = responses.map((res: Response) => res.status);
+    expect(statuses).toContain(200);
+    expect(statuses).toContain(429);
+
+    const limited = responses.find((res: Response) => res.status === 429)!;
+    expect(await limited.json()).toEqual({ error: 'Too many requests' });
+  });
+
+  it('does not rate limit two different devices independently of each other', async () => {
+    const { cookie } = await signupAndGetCookie('two-devices@example.com');
+    const deviceA = await createDeviceForUser(cookie, 'Device A', 'linux');
+    const deviceB = await createDeviceForUser(cookie, 'Device B', 'macos');
+
+    const resA = await SELF.fetch(`${BASE}/d/device`, {
+      headers: { Authorization: `Bearer ${deviceA.refresh_token}` },
+    });
+    const resB = await SELF.fetch(`${BASE}/d/device`, {
+      headers: { Authorization: `Bearer ${deviceB.refresh_token}` },
+    });
+
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+  });
+});

--- a/api/wrangler.json
+++ b/api/wrangler.json
@@ -46,6 +46,13 @@
         "EMAIL_DELIVERY_MODE": "ses",
         "HASH_SERVER_URL": "https://app.virtueinitiative.org/api"
       },
+      "ratelimits": [
+        {
+          "name": "RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 60, "period": 60 }
+        }
+      ],
       "routes": [
         {
           "pattern": "api.virtueinitiative.org/*",
@@ -85,6 +92,13 @@
         "EMAIL_DELIVERY_MODE": "ses",
         "HASH_SERVER_URL": "https://staging.app.virtueinitiative.org/api"
       },
+      "ratelimits": [
+        {
+          "name": "RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 60, "period": 60 }
+        }
+      ],
       "routes": [
         {
           "pattern": "staging.app.virtueinitiative.org/api/*",

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -26,7 +26,6 @@ static CORE: OnceCell<AndroidCore> = OnceCell::new();
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
-const ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(20);
 const LOOP_INTERVAL: Duration = Duration::from_secs(1);
 
 const SCREENSHOT_SERVICE_CLASS: &str = "org/virtueinitiative/virtue/ScreenshotService";
@@ -544,19 +543,15 @@ fn run_daemon_loop(core: &AndroidCore) -> Result<()> {
         // Screen-off is now handled inside the bus via the `is_locked_or_screensaver`
         // hook: the screenshot module records a `ScreenshotSkipped` and the upload
         // module defers network I/O while the screen is off.
-        let sleep_duration = match (|| -> Result<()> {
+        if let Err(err) = (|| -> Result<()> {
             bus.send(Ping)?;
             let state = bus.iter()?;
             store_state(&state_path, &state)?;
             Ok(())
         })() {
-            Ok(()) => LOOP_INTERVAL,
-            Err(err) => {
-                eprintln!("android-daemon: {err}");
-                ERROR_RETRY_INTERVAL
-            }
-        };
-        sleep_interruptible(&core.stop, sleep_duration);
+            eprintln!("android-daemon: {err}");
+        }
+        sleep_interruptible(&core.stop, LOOP_INTERVAL);
     }
 
     bus.send(ProcessStopped)?;

--- a/client/core/src/assembly.rs
+++ b/client/core/src/assembly.rs
@@ -45,6 +45,7 @@ where
     let batch_interval_ms = config.batch_interval.as_millis() as i64;
     let device_name = config.device_name.clone();
     let platform_name = config.platform_name.clone();
+    let state_dir = config.state_dir.clone();
 
     let lifecycle: Box<dyn Observer> = if platform_config.lifecycle_enabled {
         Box::new(LifecycleModule::new(Box::new(platform.clone())))
@@ -58,11 +59,10 @@ where
             Arc::new(platform.clone()),
             screenshot_interval_ms,
         )),
-        Box::new(UploadModule::new(
-            Box::new(platform.clone()),
-            api.clone(),
-            batch_interval_ms,
-        )),
+        Box::new(
+            UploadModule::new(Box::new(platform.clone()), api.clone(), batch_interval_ms)
+                .with_error_log(crate::storage::FileStateStore::new(&state_dir)?),
+        ),
         Box::new(CaptureAvailabilityModule::new(Box::new(platform.clone()))),
         Box::new(HeartbeatModule::new(Box::new(platform))),
         Box::new(AuthModule::new(api, device_name, platform_name)),

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -76,6 +76,45 @@ const MAX_HASH_RETRIES_PER_LOOP: usize = 8;
 const MAX_NOTIFY_RETRIES_PER_LOOP: usize = 8;
 const HASH_TOKEN_MAX_AGE: Duration = Duration::from_secs(55 * 60);
 
+const INITIAL_BACKOFF_MS: i64 = 1_000; // 1s — matches today's single-failure retry-next-tick behavior
+const MAX_BACKOFF_MS: i64 = 20 * 60 * 1_000; // cap at 20 minutes — batch uploads normally happen
+// about once an hour (see DEFAULT_BATCH_WINDOW_SECONDS = 3600 in the Android/iOS crates), so a
+// 20-minute ceiling still guarantees at least ~3 retry attempts within a nominal batch period
+// during a sustained outage, rather than retrying at a rate disconnected from that cadence.
+
+/// Tracks per-queue exponential backoff. Not persisted — resets on process restart,
+/// which is fine: worst case is one immediate retry after a restart, then backoff
+/// re-accumulates.
+#[derive(Default)]
+struct RetryBackoff {
+    next_attempt_at_ms: i64,
+    current_backoff_ms: i64, // 0 until first failure; treated as INITIAL_BACKOFF_MS on first use
+}
+
+impl RetryBackoff {
+    fn ready(&self, now_ms: i64) -> bool {
+        now_ms >= self.next_attempt_at_ms
+    }
+
+    fn record_failure(&mut self, now_ms: i64) {
+        let backoff = if self.current_backoff_ms == 0 {
+            INITIAL_BACKOFF_MS
+        } else {
+            self.current_backoff_ms
+        };
+        // Cheap jitter (not security-sensitive) so many devices hitting the same
+        // outage don't all retry in lockstep once it clears.
+        let jitter_ms = now_ms % 250;
+        self.next_attempt_at_ms = now_ms + backoff + jitter_ms;
+        self.current_backoff_ms = (backoff * 2).min(MAX_BACKOFF_MS);
+    }
+
+    fn record_success(&mut self) {
+        self.next_attempt_at_ms = 0;
+        self.current_backoff_ms = 0;
+    }
+}
+
 /// Risk-rating band thresholds mirroring `shared-web/risk.ts` (`getRiskRating`).
 /// A batch reports how many of its events land in the high (>= 0.7) and medium
 /// (0.4–0.7) bands so the server can summarize tamper activity in digest emails
@@ -153,6 +192,10 @@ pub struct UploadModule<A: ApiTransport + Clone + Send + Sync + 'static> {
     pub batch_interval_ms: i64,
     platform: Box<dyn ScreenshotHooks>,
     pub authenticated: bool,
+    hash_backoff: RetryBackoff,
+    notify_backoff: RetryBackoff,
+    batch_backoff: RetryBackoff,
+    error_log: Option<crate::storage::FileStateStore>,
 }
 
 impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
@@ -164,7 +207,19 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             batch_interval_ms,
             platform,
             authenticated: false,
+            hash_backoff: RetryBackoff::default(),
+            notify_backoff: RetryBackoff::default(),
+            batch_backoff: RetryBackoff::default(),
+            error_log: None,
         }
+    }
+
+    /// Records permanently-rejected (400) events for operator visibility. Purely
+    /// additive — tests that don't call this leave `error_log` as `None`, and
+    /// permanent-failure logging silently no-ops.
+    pub fn with_error_log(mut self, store: crate::storage::FileStateStore) -> Self {
+        self.error_log = Some(store);
+        self
     }
 
     fn upload_batch(&self, batch: &BatchUpload) -> CoreResult<()> {
@@ -221,13 +276,30 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         }
     }
 
-    fn retry_pending_hashes(&mut self) -> CoreResult<()> {
+    fn log_permanent_hash_failure(&self, now_ms: i64, event: &LogEntry, err: &CoreError) {
+        log_error(
+            "hash upload failed permanently (400), dropping event",
+            Some(err),
+        );
+        if let Some(store) = &self.error_log {
+            let _ = store.append_error_log(&format!(
+                "{now_ms} hash upload permanently rejected (400) for event ts={}: {err}",
+                event.ts
+            ));
+        }
+    }
+
+    fn retry_pending_hashes(&mut self, now_ms: i64) -> CoreResult<()> {
+        if self.state.pending_hash_events.is_empty() || !self.hash_backoff.ready(now_ms) {
+            return Ok(());
+        }
         let hash_base_url = self
             .state
             .settings
             .as_ref()
             .and_then(|s| s.hash_base_url.clone());
         let events = std::mem::take(&mut self.state.pending_hash_events);
+        let mut had_failure = false;
         self.state.pending_hash_events =
             drain_retry_queue(events, MAX_HASH_RETRIES_PER_LOOP, |event| {
                 let encoded = match encode_batch_event(&event) {
@@ -250,14 +322,31 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                         });
                         None
                     }
-                    Err(_) => Some(event),
+                    Err(err) if err.is_bad_request() => {
+                        self.log_permanent_hash_failure(now_ms, &event, &err);
+                        None
+                    }
+                    Err(err) => {
+                        had_failure = true;
+                        log_error("hash upload failed, will retry", Some(&err));
+                        Some(event)
+                    }
                 }
             });
+        if had_failure {
+            self.hash_backoff.record_failure(now_ms);
+        } else {
+            self.hash_backoff.record_success();
+        }
         Ok(())
     }
 
-    fn retry_pending_notifies(&mut self) -> CoreResult<()> {
+    fn retry_pending_notifies(&mut self, now_ms: i64) -> CoreResult<()> {
+        if self.state.pending_notify_events.is_empty() || !self.notify_backoff.ready(now_ms) {
+            return Ok(());
+        }
         let events = std::mem::take(&mut self.state.pending_notify_events);
+        let mut had_failure = false;
         self.state.pending_notify_events =
             drain_retry_queue(events, MAX_NOTIFY_RETRIES_PER_LOOP, |payload| {
                 match self.notify(&payload) {
@@ -266,9 +355,17 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                         log_error("notify failed permanently", Some(&err));
                         None
                     }
-                    Err(_) => Some(payload),
+                    Err(_) => {
+                        had_failure = true;
+                        Some(payload)
+                    }
                 }
             });
+        if had_failure {
+            self.notify_backoff.record_failure(now_ms);
+        } else {
+            self.notify_backoff.record_success();
+        }
         Ok(())
     }
 
@@ -279,9 +376,9 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
     /// is not sufficient evidence that a queued notify's event reached the server. An
     /// empty `pending_hash_events` + `pending_batch_events` is: every event has been
     /// hashed *and* its batch has been accepted.
-    fn retry_pending_notifies_if_flushed(&mut self) -> CoreResult<()> {
+    fn retry_pending_notifies_if_flushed(&mut self, now_ms: i64) -> CoreResult<()> {
         if self.state.pending_hash_events.is_empty() && self.state.pending_batch_events.is_empty() {
-            self.retry_pending_notifies()?;
+            self.retry_pending_notifies(now_ms)?;
         }
         Ok(())
     }
@@ -300,7 +397,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 .unwrap_or(true)
             || self.state.pending_batch_events.len() >= MAX_BATCH_ITEMS_PER_UPLOAD;
         if should {
-            self.try_upload_batch(now_ms, emitter)?;
+            self.try_upload_batch(now_ms, emitter, true)?;
         }
         Ok(())
     }
@@ -338,8 +435,16 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         }
     }
 
-    pub(crate) fn try_upload_batch(&mut self, now_ms: i64, emitter: &Emitter) -> CoreResult<()> {
+    pub(crate) fn try_upload_batch(
+        &mut self,
+        now_ms: i64,
+        emitter: &Emitter,
+        respect_backoff: bool,
+    ) -> CoreResult<()> {
         if self.state.pending_batch_events.is_empty() {
+            return Ok(());
+        }
+        if respect_backoff && !self.batch_backoff.ready(now_ms) {
             return Ok(());
         }
         if !self.refresh_settings_before_batch(emitter) {
@@ -384,6 +489,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                     self.state.post_login_proof_batches_remaining -= 1;
                 }
                 self.state.last_batch_at_ms = Some(now_ms);
+                self.batch_backoff.record_success();
                 Ok(())
             }
             Err(err) if err.is_not_found() || err.is_unauthorized() => {
@@ -396,6 +502,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             }
             Err(err) => {
                 log_error("batch upload deferred", Some(&err));
+                self.batch_backoff.record_failure(now_ms);
                 Ok(())
             }
         }
@@ -418,16 +525,16 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             self.state.last_batch_at_ms = None;
         }
 
-        self.retry_pending_hashes()?;
+        self.retry_pending_hashes(now_ms)?;
         // Force the batch out before sending any queued notify emails so the
         // event(s) they reference already exist server-side by the time the
         // email goes out, rather than waiting on the interval timer.
         if self.state.pending_notify_events.is_empty() {
             self.maybe_upload_batch(now_ms, emitter)?;
         } else {
-            self.try_upload_batch(now_ms, emitter)?;
+            self.try_upload_batch(now_ms, emitter, true)?;
         }
-        self.retry_pending_notifies_if_flushed()?;
+        self.retry_pending_notifies_if_flushed(now_ms)?;
         Ok(())
     }
 
@@ -463,19 +570,19 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         self.state.pending_hash_events.push(entry);
         let screen_active = !self.platform.is_locked_or_screensaver()?;
         if screen_active || is_heartbeat {
-            self.retry_pending_hashes()?;
+            self.retry_pending_hashes(now_ms)?;
             if is_heartbeat || is_high_risk {
                 // Force an immediate batch flush — don't wait for the interval timer.
                 // For a high-risk event this also guarantees the encrypted event is
                 // uploaded before the notify email below goes out, so the event
                 // already exists server-side when the recipient follows the link.
-                self.try_upload_batch(now_ms, emitter)?;
+                self.try_upload_batch(now_ms, emitter, true)?;
             } else {
                 self.maybe_upload_batch(now_ms, emitter)?;
             }
         }
         if is_high_risk && screen_active {
-            self.retry_pending_notifies_if_flushed()?;
+            self.retry_pending_notifies_if_flushed(now_ms)?;
         }
         Ok(())
     }
@@ -526,7 +633,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> Observer for UploadModule<
             _: ProcessStopped => {
                 if self.authenticated && !self.state.pending_batch_events.is_empty() {
                     let now_ms = self.platform.get_time_utc_ms()?;
-                    let _ = self.try_upload_batch(now_ms, emitter);
+                    let _ = self.try_upload_batch(now_ms, emitter, false);
                 }
                 Ok(())
             },
@@ -534,7 +641,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> Observer for UploadModule<
             _: FlushBatchNow => {
                 if self.authenticated {
                     let now_ms = self.platform.get_time_utc_ms()?;
-                    self.try_upload_batch(now_ms, emitter)?;
+                    self.try_upload_batch(now_ms, emitter, false)?;
                 }
                 Ok(())
             },
@@ -1040,5 +1147,217 @@ mod tests {
         // ProcessStopped is a terminal flush path → uploads regardless of lock.
         t.emit(2, ProcessStopped);
         assert_eq!(t.api.state().batch_uploads.len(), 1);
+    }
+
+    #[test]
+    fn sustained_hash_upload_failure_backs_off_instead_of_retrying_every_tick() {
+        let mut b = EventTester::builder();
+        // Huge interval so batch logic never interferes with this hash-only test.
+        b.add(UploadModule::new(
+            Box::new(b.platform()),
+            b.api(),
+            24 * 60 * 60 * 1_000,
+        ));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        for _ in 0..10 {
+            t.api.program_hash(Err(crate::error::CoreError::HttpStatus {
+                status: 503,
+                message: "boom".into(),
+            }));
+        }
+
+        // The first attempt happens immediately when the event is queued.
+        t.emit(2, skipped_upload());
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            1,
+            "first attempt happens immediately"
+        );
+
+        // Backoff after one failure is 1s: a ping exactly 1s later should retry.
+        t.emit(3, Ping);
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            2,
+            "backoff should allow a retry after 1s"
+        );
+
+        // Backoff doubles to 2s: a ping only 1s after that must NOT retry yet.
+        t.emit(4, Ping);
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            2,
+            "must not retry every tick during a sustained outage"
+        );
+
+        // ...but 2s after the last attempt (t=5) it should.
+        t.emit(5, Ping);
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            3,
+            "backoff window elapsed, retry should fire"
+        );
+
+        // Backoff doubles again to 4s: pings at t=6,7,8 must not retry.
+        t.emit(6, Ping);
+        t.emit(7, Ping);
+        t.emit(8, Ping);
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            3,
+            "gap should keep growing, not reset back to 1s"
+        );
+
+        // 4s after the t=5 attempt (t=9) the retry should fire again.
+        t.emit(9, Ping);
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            4,
+            "retry fires again once the longer window elapses"
+        );
+
+        assert_eq!(
+            t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_hash_events
+                .len(),
+            1,
+            "event should remain queued through the whole sustained outage"
+        );
+    }
+
+    #[test]
+    fn permanent_hash_failure_400_drops_event_without_retry() {
+        let mut b = EventTester::builder();
+        b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
+        let mut t = b.build();
+        t.emit(1, login_event());
+
+        t.api.program_hash(Err(crate::error::CoreError::HttpStatus {
+            status: 400,
+            message: "bad event".into(),
+        }));
+
+        t.emit(2, skipped_upload());
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            1,
+            "one attempt should be made"
+        );
+        assert!(
+            t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_hash_events
+                .is_empty(),
+            "permanently rejected event should be dropped, not kept for retry"
+        );
+
+        // No pending events remain, so a later ping makes no further hash calls.
+        t.emit(3, Ping);
+        assert_eq!(
+            t.api.state().hash_uploads.len(),
+            1,
+            "no further attempts for a permanently rejected event"
+        );
+    }
+
+    #[test]
+    fn flush_batch_now_bypasses_batch_backoff_cooldown() {
+        let mut b = EventTester::builder();
+        b.add(UploadModule::new(
+            Box::new(b.platform()),
+            b.api(),
+            24 * 60 * 60 * 1_000,
+        ));
+        let mut t = b.build();
+        t.emit(1, login_event());
+        t.observer::<UploadModule<MockApiClient>>()
+            .state
+            .pending_batch_events
+            .push(crate::module::upload::PendingBatchEvent {
+                ts: 500,
+                risk: 0.0,
+                encoded: vec![1, 2, 3],
+            });
+
+        // First flush fails, putting `batch_backoff` into a ~1s cooldown.
+        t.api
+            .program_batch(Err(crate::error::CoreError::HttpStatus {
+                status: 503,
+                message: "boom".into(),
+            }));
+        t.emit(2, FlushBatchNow);
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            1,
+            "first flush attempts and fails"
+        );
+
+        // A plain ping still inside the cooldown window must not retry — this
+        // is the backoff-respecting path that keeps a stuck endpoint from
+        // being hammered once per tick.
+        t.emit(2.5, Ping);
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            1,
+            "ping should respect the batch backoff cooldown"
+        );
+
+        // An explicit FlushBatchNow, still inside that same cooldown window,
+        // must bypass it and attempt immediately.
+        t.emit(2.6, FlushBatchNow);
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            2,
+            "FlushBatchNow should bypass the cooldown and retry immediately"
+        );
+        assert!(
+            t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .pending_batch_events
+                .is_empty(),
+            "the bypassed retry should have succeeded and drained the queue"
+        );
+    }
+
+    #[test]
+    fn process_stopped_bypasses_batch_backoff_cooldown() {
+        let mut b = EventTester::builder();
+        b.add(UploadModule::new(
+            Box::new(b.platform()),
+            b.api(),
+            24 * 60 * 60 * 1_000,
+        ));
+        let mut t = b.build();
+        t.emit(1, login_event());
+        t.observer::<UploadModule<MockApiClient>>()
+            .state
+            .pending_batch_events
+            .push(crate::module::upload::PendingBatchEvent {
+                ts: 500,
+                risk: 0.0,
+                encoded: vec![1, 2, 3],
+            });
+
+        // First flush fails, putting `batch_backoff` into a ~1s cooldown.
+        t.api
+            .program_batch(Err(crate::error::CoreError::HttpStatus {
+                status: 503,
+                message: "boom".into(),
+            }));
+        t.emit(2, FlushBatchNow);
+        assert_eq!(t.api.state().batch_uploads.len(), 1);
+
+        // ProcessStopped fires well inside the cooldown window but, like
+        // FlushBatchNow, is a terminal one-shot flush and must not be
+        // silently swallowed by an unrelated earlier failure's backoff.
+        t.emit(2.2, ProcessStopped);
+        assert_eq!(
+            t.api.state().batch_uploads.len(),
+            2,
+            "ProcessStopped should bypass the cooldown and flush immediately"
+        );
     }
 }

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -23,7 +23,6 @@ static CORE: OnceCell<IosCore> = OnceCell::new();
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
 const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
-const ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(20);
 // Ping every second (like the Android client), independent of capture cadence
 // (governed separately by `capture_interval_seconds`). Lifecycle detection is
 // disabled entirely on iOS (see `build_bus`), so this cadence is purely about
@@ -390,19 +389,15 @@ fn run_daemon_loop(core: &IosCore) -> Result<()> {
     store_state(&state_path, &state)?;
 
     while !core.stop.load(Ordering::SeqCst) {
-        let sleep_duration = match (|| -> Result<()> {
+        if let Err(err) = (|| -> Result<()> {
             bus.send(Ping)?;
             let state = bus.iter()?;
             store_state(&state_path, &state)?;
             Ok(())
         })() {
-            Ok(()) => LOOP_INTERVAL,
-            Err(err) => {
-                eprintln!("ios-daemon: {err}");
-                ERROR_RETRY_INTERVAL
-            }
-        };
-        sleep_interruptible(&core.stop, sleep_duration);
+            eprintln!("ios-daemon: {err}");
+        }
+        sleep_interruptible(&core.stop, LOOP_INTERVAL);
     }
 
     bus.send(ProcessStopped)?;


### PR DESCRIPTION
## Summary

Adds backoff-based retry throttling on the client upload path and a per-device rate limit on the hot API routes, so a misbehaving or offline device can't hammer the API in a tight loop.

## Changes

**Type of change:** Feature
**Components:** API, Core, Android, iOS

1. **Retry backoff** (`client/core/src/module/upload.rs`) — Added a `RetryBackoff` struct (1s initial, doubling, 20-min cap, cheap jitter) with three independent instances on `UploadModule` (hash/notify/batch). Wired into `retry_pending_hashes`, `retry_pending_notifies`, and `try_upload_batch`, which gained a `respect_backoff: bool` param (`true` for automated retry paths, `false` for the explicit `FlushBatchNow`/`ProcessStopped` one-shot flushes, so manual/shutdown flushes aren't held back by an in-progress cooldown).

2. **Permanent hash failure logging** — `retry_pending_hashes` now drops HTTP 400s instead of retrying forever, logging via a new `log_permanent_hash_failure` helper that writes to `FileStateStore::append_error_log`. Wired real usage into `assembly.rs` via `UploadModule::with_error_log`.

3. **Unified 1s tick** — Removed `ERROR_RETRY_INTERVAL` from `client/android/rust/src/lib.rs` and `client/ios/rust/src/lib.rs`; both now always sleep `LOOP_INTERVAL` (1s) on error too, matching Linux/Mac/Windows. Backoff is handled inside the upload module instead of the daemon loop's sleep duration.

4. **API rate limiting** (`api/`) — Added a `RATE_LIMITER` Workers Rate Limiting binding (60 req/min, per-device key) to `wrangler.json` for both `staging` and `production`, added `RATE_LIMITER: RateLimit` to the `Env` type, and a new `rate-limit.ts` middleware wired into the hot device-authenticated routes: `hashes.ts` `POST`/`GET`, and `device-only.ts` `GET /device`, `POST /batch`, `POST /notify`. This is defense-in-depth alongside the existing dashboard-level WAF rate-limiting rule (unchanged, out-of-repo config).

## Testing

- `cargo test -p virtue-core --features testing`: 116 unit + 17 integration tests pass, including 4 new ones covering sustained-failure backoff growth, permanent-400 drop, and `FlushBatchNow`/`ProcessStopped` cooldown bypass.
- `cargo clippy -p virtue-core --features testing`: clean.
- `npm test` in `api/`: 44 tests pass (42 existing + 2 new), including one that drives a device past the configured limit and confirms a real 429.
- `npx tsc --noEmit` and `npx prettier --check` in `api/`: pass (after regenerating `worker-configuration.d.ts` via `wrangler types` to pick up the new `RATE_LIMITER` binding — gitignored, not part of this diff).
- Android/iOS `lib.rs` changes are identical in shape; not independently cross-compiled in this session but mirror the previously-verified Android build shape.