### PR TITLE
Single source of truth for default capture/batch intervals (#496)

### DIFF
--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -24,8 +24,8 @@ use virtue_core::{
 static CORE: OnceCell<AndroidCore> = OnceCell::new();
 
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
-const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
-const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
+const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS;
+const DEFAULT_BATCH_WINDOW_SECONDS: u64 = virtue_core::DEFAULT_BATCH_WINDOW_SECONDS;
 const ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(20);
 const LOOP_INTERVAL: Duration = Duration::from_secs(1);
 

--- a/client/core/src/config.rs
+++ b/client/core/src/config.rs
@@ -11,6 +11,9 @@ pub const DEFAULT_API_BASE_URL: &str = env!("VIRTUE_DEFAULT_API_URL");
 const MIN_CAPTURE_INTERVAL_SECONDS: u64 = 15;
 const MIN_BATCH_INTERVAL_SECONDS: u64 = 1;
 
+pub const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
+pub const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub api_base_url: String,

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -19,7 +19,9 @@ pub mod testing;
 
 pub use assembly::{build_default_modules, build_default_modules_reqwest};
 pub use build_info::{BUILD_LABEL, build_label};
-pub use config::{Config, DEFAULT_API_BASE_URL};
+pub use config::{
+    Config, DEFAULT_API_BASE_URL, DEFAULT_BATCH_WINDOW_SECONDS, DEFAULT_CAPTURE_INTERVAL_SECONDS,
+};
 pub use controller::ClientController;
 pub use error::{CoreError, CoreResult};
 pub use events::{

--- a/client/ios/app/Shared/VirtueShared.swift
+++ b/client/ios/app/Shared/VirtueShared.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+@_silgen_name("virtue_ios_default_capture_interval_seconds")
+private func virtue_ios_default_capture_interval_seconds() -> UInt64
+
+@_silgen_name("virtue_ios_default_batch_window_seconds")
+private func virtue_ios_default_batch_window_seconds() -> UInt64
+
 enum VirtueShared {
     static let appGroupID = "group.org.virtueinitiative.virtueios"
     static let buildLabel: String = {
@@ -22,8 +28,8 @@ enum VirtueShared {
     static let safariPauseStopIssuedKey = "VIRTUE_SAFARI_PAUSE_STOP_ISSUED"
 
     static let defaultBaseApiUrl = "https://api.virtueinitiative.org"
-    static let defaultCaptureIntervalSeconds = "15"
-    static let defaultBatchWindowSeconds = "30"
+    static let defaultCaptureIntervalSeconds = String(virtue_ios_default_capture_interval_seconds())
+    static let defaultBatchWindowSeconds = String(virtue_ios_default_batch_window_seconds())
     static let defaultMonitoringEnabled = true
 
     static let safariLastMessageAtKey = "VIRTUE_SAFARI_LAST_MESSAGE_AT"

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -21,8 +21,8 @@ use virtue_core::{
 static CORE: OnceCell<IosCore> = OnceCell::new();
 
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
-const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
-const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
+const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS;
+const DEFAULT_BATCH_WINDOW_SECONDS: u64 = virtue_core::DEFAULT_BATCH_WINDOW_SECONDS;
 const ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(20);
 // Ping every second (like the Android client), independent of capture cadence
 // (governed separately by `capture_interval_seconds`). Lifecycle detection is
@@ -131,6 +131,16 @@ impl LifecycleHooks for IosPlatformHooks {
 }
 
 impl PlatformHooks for IosPlatformHooks {}
+
+#[no_mangle]
+pub extern "C" fn virtue_ios_default_capture_interval_seconds() -> u64 {
+    DEFAULT_CAPTURE_INTERVAL_SECONDS
+}
+
+#[no_mangle]
+pub extern "C" fn virtue_ios_default_batch_window_seconds() -> u64 {
+    DEFAULT_BATCH_WINDOW_SECONDS
+}
 
 #[no_mangle]
 pub extern "C" fn virtue_ios_native_init(

--- a/client/linux/src/config.rs
+++ b/client/linux/src/config.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 use virtue_core::Config;
 
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
-const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
-const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
+const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS;
+const DEFAULT_BATCH_WINDOW_SECONDS: u64 = virtue_core::DEFAULT_BATCH_WINDOW_SECONDS;
 
 /// Set at build time by passing `VIRTUE_INSTANCE=<name>` to cargo. Controls
 /// which XDG subdirectory and systemd service name this binary uses.

--- a/client/mac/app/Sources/MonitoringCoordinator.swift
+++ b/client/mac/app/Sources/MonitoringCoordinator.swift
@@ -9,18 +9,18 @@ enum PermissionPhase {
     case needsRelaunch
 }
 
-/// UserDefaults keys + built-in defaults for runtime overrides, matching the
-/// daemon's actual defaults in `config.rs` (mac's own capture/batch cadence,
-/// not iOS's dev-oriented 15s/30s). Blank fields mean "use the built-in
-/// default" — the FFI layer omits blank keys from the override JSON entirely.
+/// UserDefaults keys + built-in defaults for runtime overrides. Capture/batch
+/// defaults are read from the Rust core via NativeBridge rather than
+/// duplicated here. Blank fields mean "use the built-in default" — the FFI
+/// layer omits blank keys from the override JSON entirely.
 private enum OverrideDefaults {
     static let baseApiUrlKey = "VIRTUE_BASE_API_URL"
     static let captureIntervalKey = "VIRTUE_CAPTURE_INTERVAL_SECONDS"
     static let batchWindowKey = "VIRTUE_BATCH_WINDOW_SECONDS"
 
     static let baseApiUrl = "https://api.virtueinitiative.org"
-    static let captureIntervalSeconds = "300"
-    static let batchWindowSeconds = "3600"
+    static let captureIntervalSeconds = String(NativeBridge.defaultCaptureIntervalSeconds())
+    static let batchWindowSeconds = String(NativeBridge.defaultBatchWindowSeconds())
 }
 
 /// Faithfully ports `main.rs`'s tray event loop state machine: the daemon

--- a/client/mac/app/Sources/NativeBridge.swift
+++ b/client/mac/app/Sources/NativeBridge.swift
@@ -65,6 +65,12 @@ private func virtue_mac_native_get_build_label() -> UnsafeMutablePointer<CChar>?
 @_silgen_name("virtue_mac_native_default_device_name")
 private func virtue_mac_native_default_device_name() -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("virtue_mac_native_default_capture_interval_seconds")
+private func virtue_mac_native_default_capture_interval_seconds() -> UInt64
+
+@_silgen_name("virtue_mac_native_default_batch_window_seconds")
+private func virtue_mac_native_default_batch_window_seconds() -> UInt64
+
 @_silgen_name("virtue_mac_native_daemon_exe_path")
 private func virtue_mac_native_daemon_exe_path(
     _ appBundlePath: UnsafePointer<CChar>?
@@ -195,6 +201,14 @@ enum NativeBridge {
 
     static func defaultDeviceName() -> String {
         consumeOptionalString(virtue_mac_native_default_device_name()) ?? "mac-device"
+    }
+
+    static func defaultCaptureIntervalSeconds() -> UInt64 {
+        virtue_mac_native_default_capture_interval_seconds()
+    }
+
+    static func defaultBatchWindowSeconds() -> UInt64 {
+        virtue_mac_native_default_batch_window_seconds()
     }
 
     static func daemonExePath(appBundlePath: String) -> String {

--- a/client/mac/rust/src/lib.rs
+++ b/client/mac/rust/src/lib.rs
@@ -249,6 +249,16 @@ pub extern "C" fn virtue_mac_native_default_device_name() -> *mut c_char {
     string_to_c(virtue_mac_platform::config::default_device_name())
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn virtue_mac_native_default_capture_interval_seconds() -> u64 {
+    virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn virtue_mac_native_default_batch_window_seconds() -> u64 {
+    virtue_core::DEFAULT_BATCH_WINDOW_SECONDS
+}
+
 /// Resolve the daemon executable bundled inside the app at
 /// `Contents/MacOS/virtue-daemon`, given the app bundle path
 /// (`Bundle.main.bundlePath` on the Swift side).

--- a/client/mac/src/config.rs
+++ b/client/mac/src/config.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use virtue_core::{AuthState, Config};
 
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
-const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
-const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
+const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS;
+const DEFAULT_BATCH_WINDOW_SECONDS: u64 = virtue_core::DEFAULT_BATCH_WINDOW_SECONDS;
 
 #[derive(Clone, Debug)]
 pub struct ClientPaths {

--- a/client/windows/src/config.rs
+++ b/client/windows/src/config.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use virtue_core::Config;
 
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
-const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = 300;
-const DEFAULT_BATCH_WINDOW_SECONDS: u64 = 3600;
+const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS;
+const DEFAULT_BATCH_WINDOW_SECONDS: u64 = virtue_core::DEFAULT_BATCH_WINDOW_SECONDS;
 
 #[derive(Clone, Debug)]
 pub struct ClientPaths {


### PR DESCRIPTION
## Summary

- Fixes #496: default capture-interval (300s) and batch-window (3600s) seconds were duplicated as independent literals across five platform Rust crates (`client/linux`, `client/mac`, `client/windows`, `client/android/rust`, `client/ios/rust`) with nothing enforcing they stay in sync.
- **Fixes a live bug on iOS**: `VirtueShared.swift` hard-coded `defaultCaptureIntervalSeconds = "15"` / `defaultBatchWindowSeconds = "30"`. These aren't just display fallbacks — they're used as the fallback value passed into `virtue_ios_native_init`/`set_overrides`, which unconditionally writes a non-empty override into `config.json` on every fresh install/launch. This was silently forcing the real interval from 300s down to 15s and the batch window from 3600s down to 30s on every iOS device.
- Mac had the identical force-write-on-init mechanism (`MonitoringCoordinator.swift`'s `OverrideDefaults`), correct only by coincidence — same duplication risk.
- Promotes `DEFAULT_CAPTURE_INTERVAL_SECONDS` / `DEFAULT_BATCH_WINDOW_SECONDS` to `pub const` in `client/core/src/config.rs`, re-exported from `client/core/src/lib.rs`, and has all five platform crates alias to the core constants instead of redeclaring them.
- Adds `virtue_ios_default_capture_interval_seconds`/`virtue_ios_default_batch_window_seconds` and `virtue_mac_native_default_capture_interval_seconds`/`virtue_mac_native_default_batch_window_seconds` FFI getters, called via `@_silgen_name` from Swift (matching the existing pattern for `virtue_mac_native_default_device_name`, etc.), so iOS/Mac Swift reads the real defaults from Rust instead of hard-coding its own copies.
- Android and Windows apps were already correct (Android passes overrides through as null/empty; Windows reads the resolved config back from Rust) — no changes needed there.

## Changes

Type of change: Bug fix

Components: Core, Linux, Mac, Windows, iOS, Android

## Testing

- `cargo test -p virtue-core`: 112/112 passed (no test currently pinned the literal 300/3600, only the `MIN_*` clamps, so no test updates were needed)
- `cargo build -p virtue-core -p virtue-linux`: succeeds
- `cargo check` attempted on `virtue-mac` (platform crate), `virtue-windows`, and the standalone `client/android/rust`, `client/ios/rust`, `client/mac/rust` crates from this Linux worktree. All fail only on pre-existing, unrelated cross-compilation limitations (Apple-only `objc2`, Windows-only `windows-future` bindings, an Android-`cfg`-gated module in `virtue-text-detection`, and a dependency in `ios/rust`'s lockfile requiring a newer rustc) — none of the failures are in code touched by this change, and compilation gets past our modified lines in every case before hitting the unrelated error.
- Swift (iOS/Mac) and Kotlin (Android, unchanged) code cannot be compiled or run in this Linux worktree — Xcode/Android Studio builds aren't available here. The Swift edits were double-checked by re-reading the diffs for syntax correctness since they can't be compiler-verified locally.
- `grep -rn "300\|3600" client/*/src client/*/rust client/ios/app client/mac/app client/android/app client/windows` (excluding build artifacts) confirms no remaining duplicate default literals outside the new single-source constants — remaining hits are unrelated test fixtures, UI frame sizes, and an unrelated Safari extension throttle constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161tSLsufcD9g1gzjkiiRPU