### PR TITLE
Fix Windows app flashing "logged out" during status load

### DIFF
--- a/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
+++ b/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
@@ -16,7 +16,7 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     private string _passwordInput = string.Empty;
     private string _deviceNameInput = Environment.MachineName;
     private string _statusText = "Starting Virtue...";
-    private string _monitorState = "stopped";
+    private string _monitorState = "loading";
     private string? _monitorError;
     private string? _deviceId;
     private int _pendingRequestCount;
@@ -26,6 +26,7 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     private string _batchWindowSeconds = string.Empty;
     private string _configPath = "Loading config path...";
     private bool _isBusy;
+    private bool _hasLoadedStatus;
     private bool _isHydratingEmailInput;
     private bool _hasUserEditedEmailInput;
     private string? _transitionMessage;
@@ -72,6 +73,20 @@ public sealed class SessionViewModel : INotifyPropertyChanged
         }
     }
 
+    public bool HasLoadedStatus
+    {
+        get => _hasLoadedStatus;
+        private set
+        {
+            if (SetProperty(ref _hasLoadedStatus, value))
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LoggedInText)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(AccountSummary)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TrayTooltip)));
+            }
+        }
+    }
+
     public string AccountEmail
     {
         get => _accountEmail;
@@ -91,9 +106,11 @@ public sealed class SessionViewModel : INotifyPropertyChanged
 
     public string WindowsPackageVersion => _windowsPackageVersion;
 
-    public string LoggedInText => LoggedIn ? "Yes" : "No";
+    public string LoggedInText => !HasLoadedStatus ? "Loading..." : (LoggedIn ? "Yes" : "No");
 
-    public string AccountSummary => string.IsNullOrWhiteSpace(AccountEmail) ? "Not signed in" : AccountEmail;
+    public string AccountSummary => !HasLoadedStatus
+        ? "Loading..."
+        : (string.IsNullOrWhiteSpace(AccountEmail) ? "Not signed in" : AccountEmail);
 
     public string EmailInput
     {
@@ -173,6 +190,7 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     public string TrayTooltip =>
         MonitorState switch
         {
+            "loading" => "Virtue: loading status",
             "running" => "Virtue: monitoring active",
             "starting" => "Virtue: starting monitoring",
             "error" => string.IsNullOrWhiteSpace(MonitorError)
@@ -316,7 +334,7 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     private Task BackgroundRefreshInternalAsync()
     {
         var monitorStatus = _interopClient.GetMonitorStatus();
-        var resolvedMonitorState = ResolveMonitorState(_loggedIn, monitorStatus.State);
+        var resolvedMonitorState = ResolveMonitorState(_hasLoadedStatus, _loggedIn, monitorStatus.State);
 
         MonitorState = resolvedMonitorState;
         MonitorError = _loggedIn ? monitorStatus.LastError : null;
@@ -352,9 +370,10 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     private Task RefreshInternalAsync()
     {
         var status = _interopClient.GetSessionStatus();
+        HasLoadedStatus = true;
         var monitorStatus = _interopClient.GetMonitorStatus();
         var runtimeConfig = _interopClient.GetRuntimeConfig();
-        var resolvedMonitorState = ResolveMonitorState(status.LoggedIn, monitorStatus.State);
+        var resolvedMonitorState = ResolveMonitorState(_hasLoadedStatus, status.LoggedIn, monitorStatus.State);
         var isSignedIn = status.LoggedIn;
 
         BuildLabel = status.BuildLabel;
@@ -381,8 +400,13 @@ public sealed class SessionViewModel : INotifyPropertyChanged
         return Task.CompletedTask;
     }
 
-    private static string ResolveMonitorState(bool loggedIn, string monitorState)
+    private static string ResolveMonitorState(bool hasStatus, bool loggedIn, string monitorState)
     {
+        if (!hasStatus)
+        {
+            return "loading";
+        }
+
         if (!loggedIn)
         {
             return "signed_out";

--- a/client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs
+++ b/client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs
@@ -8,6 +8,19 @@ namespace Virtue.WindowsApp.Tests;
 public sealed class SessionViewModelTests
 {
     [Fact]
+    public void BeforeAnyRefresh_ReportsLoadingState()
+    {
+        var fakeClient = new FakeRustInteropClient();
+        var viewModel = new SessionViewModel(fakeClient, "0.0.5.1234");
+
+        Assert.False(viewModel.HasLoadedStatus);
+        Assert.Equal("loading", viewModel.MonitorState);
+        Assert.Equal("Loading...", viewModel.LoggedInText);
+        Assert.Equal("Loading...", viewModel.AccountSummary);
+        Assert.Equal("Virtue: loading status", viewModel.TrayTooltip);
+    }
+
+    [Fact]
     public async Task InitializeAsync_LoadsSessionAndRuntimeConfig()
     {
         var fakeClient = new FakeRustInteropClient

--- a/client/windows/Virtue.WindowsApp/MainWindow.xaml.cs
+++ b/client/windows/Virtue.WindowsApp/MainWindow.xaml.cs
@@ -559,17 +559,28 @@ public sealed partial class MainWindow : Window
         _statusDetailTextBlock.Text = BuildSecondaryStatusText();
         _buildLabelTextBlock.Text = ViewModel.BuildLabelText;
 
-        _accountSummaryTextBlock.Text = ViewModel.LoggedIn
-            ? $"Signed in as {ViewModel.AccountSummary}"
-            : "Sign in to start monitoring.";
-        _loginPanel.Visibility = ViewModel.LoggedIn ? Visibility.Collapsed : Visibility.Visible;
+        if (!ViewModel.HasLoadedStatus)
+        {
+            _accountSummaryTextBlock.Text = "Checking sign-in status...";
+            _loginPanel.Visibility = Visibility.Collapsed;
+            _accountActionsPanel.Visibility = Visibility.Collapsed;
+            _signedInActionsPanel.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            _accountSummaryTextBlock.Text = ViewModel.LoggedIn
+                ? $"Signed in as {ViewModel.AccountSummary}"
+                : "Sign in to start monitoring.";
+            _loginPanel.Visibility = ViewModel.LoggedIn ? Visibility.Collapsed : Visibility.Visible;
+            _accountActionsPanel.Visibility = ViewModel.LoggedIn ? Visibility.Visible : Visibility.Collapsed;
+            _signedInActionsPanel.Visibility = ViewModel.LoggedIn ? Visibility.Visible : Visibility.Collapsed;
+        }
+
         var loginEnabled = !ViewModel.IsBusy;
         _emailTextBox.IsEnabled = loginEnabled;
         _passwordBox.IsEnabled = loginEnabled;
         _deviceNameTextBox.IsEnabled = loginEnabled;
         if (_signInButton is not null) _signInButton.IsEnabled = loginEnabled;
-        _accountActionsPanel.Visibility = ViewModel.LoggedIn ? Visibility.Visible : Visibility.Collapsed;
-        _signedInActionsPanel.Visibility = ViewModel.LoggedIn ? Visibility.Visible : Visibility.Collapsed;
 
         _errorTextBlock.Text = ViewModel.ErrorText ?? "";
         _errorTextBlock.Visibility = string.IsNullOrWhiteSpace(ViewModel.ErrorText)
@@ -595,6 +606,7 @@ public sealed partial class MainWindow : Window
     private string BuildPrimaryStatusText() =>
         ViewModel.MonitorState switch
         {
+            "loading" => "Loading status...",
             "running" => "Monitoring active",
             "starting" => "Starting monitoring",
             "signed_out" => "Logged out",
@@ -662,6 +674,7 @@ public sealed partial class MainWindow : Window
 
         return ViewModel.MonitorState switch
         {
+            "loading" => "Checking your sign-in status...",
             "running" => "Virtue is actively monitoring this device.",
             "starting" => "Virtue is bringing the background monitor online.",
             "signed_out" => "Monitoring resumes after you sign in again.",

--- a/client/windows/src/resident_monitor.rs
+++ b/client/windows/src/resident_monitor.rs
@@ -276,6 +276,13 @@ fn run_monitor_loop(shutdown: Arc<AtomicBool>, command_rx: Receiver<MonitorComma
         }
     };
 
+    if let Ok(resp) = bus.request::<StatusRequest, StatusResponse>(StatusRequest) {
+        update_snapshot(|s| {
+            s.logged_in = resp.status.is_authenticated;
+            s.pending_request_count = resp.status.pending_request_count;
+        });
+    }
+
     if let Err(err) = (|| -> anyhow::Result<()> {
         bus.send(ProcessStarted)?;
         store_state(&state_path, &bus.iter()?)?;
@@ -364,6 +371,7 @@ fn handle_command(bus: &mut EventBus, state_path: &Path, command: MonitorCommand
             let _ = store_state(state_path, &bus.iter()?);
             let result = request_result.and_then(|r| {
                 if r.success {
+                    note_login_state(true);
                     Ok(r.device_id.unwrap_or_default())
                 } else {
                     Err(CoreError::CommandFailed(
@@ -378,6 +386,7 @@ fn handle_command(bus: &mut EventBus, state_path: &Path, command: MonitorCommand
             let _ = store_state(state_path, &bus.iter()?);
             let result = request_result.and_then(|r| {
                 if r.success {
+                    note_login_state(false);
                     Ok(())
                 } else {
                     Err(CoreError::CommandFailed(


### PR DESCRIPTION
## Summary

On launch (and after every login/logout), the Windows app briefly showed the signed-out UI (login form, "Sign in to start monitoring.") for ~5-10 seconds even though the device was actually logged in. Fixes #501.

Two distinct bugs, both fixed:

1. **Rust daemon**: `MonitorStatusSnapshot.logged_in` defaulted to `false` and was only refreshed once per loop tick, *after* a `Ping` that fans out to `UploadModule::handle_ping` — which makes real network calls (each with a 5s timeout) when already authenticated. Right after login the network stack is often not ready, so these calls stall near their timeout, and the fast, synchronous, in-memory `StatusRequest` answer was stuck queued behind the slow `Ping` in the loop ordering. Fixed by priming the snapshot from a `StatusRequest` immediately after the event bus is built, before the first `Ping` ever runs. Also wired up the previously dead-code `note_login_state()` helper into `AppLogin`/`AppLogout` so fresh logins/logouts update the snapshot the instant the command completes, instead of waiting for the next tick.
2. **C# view model**: even a fast/correct status still has to be fetched once, and until that first fetch completes `SessionViewModel` defaulted `_loggedIn = false`, which the UI rendered identically to a confirmed signed-out state. Added a real `HasLoadedStatus` / `"loading"` monitor state so the UI shows a neutral loading state instead, as defense in depth for any remaining race.

## Changes

**Type of change:** Bug fix
**Components:** Windows

- `client/windows/src/resident_monitor.rs` — prime status snapshot before first `Ping`; wire up `note_login_state()` in `AppLogin`/`AppLogout`
- `client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs` — add `HasLoadedStatus`, `"loading"` monitor state, gate `LoggedInText`/`AccountSummary`/`TrayTooltip` on it
- `client/windows/Virtue.WindowsApp/MainWindow.xaml.cs` — render a neutral "Checking sign-in status..." state instead of the login form until status has loaded
- `client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs` — new test asserting the pre-refresh state is `"loading"`, not signed-out

## Testing

- Remote smoke build on a Windows 11 VM (`client/windows/scripts/remote-windows-build.sh --mode smoke`): `cargo build`/`clippy` clean for `virtue-core` and `virtue-windows`, `dotnet build`/`test` — 30/30 tests passing (including the new loading-state test), full `Virtue.WindowsApp` build succeeded.
- Built and installed the MSIX package on the same VM, logged in with a real test account, then force-killed and relaunched the app process to reproduce the daemon-restart scenario from the bug report. Rapid-fire screenshots across the relaunch show the app going straight from no-window to "Starting monitoring" / "Signed in as ..." on the very first rendered frame — no "Logged out" flash at any point — then settling normally to "Monitoring active".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ResTYy4rZXHviL7QBZYKLE