### PR TITLE
Sign Android release APKs

### DIFF
--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -93,6 +93,28 @@ jobs:
         run: ./gradlew --no-daemon :app:lintDebug :app:assembleDebug
         working-directory: client/android
 
+      - name: Decode Android signing keystore
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [[ -z "${ANDROID_KEYSTORE_BASE64}" ]]; then
+            echo "ANDROID_KEYSTORE_BASE64 secret is not set; release APK cannot be signed" >&2
+            exit 1
+          fi
+          keystore_path="${RUNNER_TEMP}/virtue-release.jks"
+          printf '%s' "${ANDROID_KEYSTORE_BASE64}" | base64 --decode > "${keystore_path}"
+          {
+            echo "ANDROID_KEYSTORE_PATH=${keystore_path}"
+            echo "ANDROID_KEYSTORE_PASSWORD=${ANDROID_KEYSTORE_PASSWORD}"
+            echo "ANDROID_KEY_ALIAS=${ANDROID_KEY_ALIAS}"
+            echo "ANDROID_KEY_PASSWORD=${ANDROID_KEY_PASSWORD}"
+          } >> "$GITHUB_ENV"
+
       - name: Android build (release)
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
         run: ./gradlew --no-daemon :app:assembleRelease

--- a/client/android/app/build.gradle.kts
+++ b/client/android/app/build.gradle.kts
@@ -70,6 +70,17 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            System.getenv("ANDROID_KEYSTORE_PATH")?.let { keystorePath ->
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -77,6 +88,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 


### PR DESCRIPTION
Fix release Android APKs being published completely unsigned.

## Type of change
- Bug fix

## Components changed
- Android

## Description
`assembleRelease` had no `signingConfig`, so the CI-built release APK had no v1/v2/v3 signature at all — `META-INF/MANIFEST.MF` was missing and there was no APK Signing Block. This made every published release APK (e.g. `virtue-android-0.0.8-dev-2026-07-18-80382aa.apk`) fail to install with `INSTALL_PARSE_FAILED_NO_CERTIFICATES: Failed to collect certificates from base.apk: Attempt to get length of null array`.

Changes:
- `client/android/app/build.gradle.kts`: added a `release` `signingConfig` that reads the keystore path and credentials from `ANDROID_KEYSTORE_PATH` / `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEY_ALIAS` / `ANDROID_KEY_PASSWORD` env vars, and applied it to the `release` build type.
- `.github/workflows/client-android.yml`: added a "Decode Android signing keystore" step (gated the same as the release build) that decodes a new `ANDROID_KEYSTORE_BASE64` secret to a file and exports the signing env vars via `$GITHUB_ENV`, failing loudly if the secret is missing rather than silently shipping an unsigned APK.

A new dedicated release keystore was generated and the 4 required secrets (`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`) have already been added to the repo's GitHub Actions secrets.

## Testing
Verified the generated keystore opens correctly with `keytool -list`. Have not yet observed a full CI run producing a signed APK — the next push to `staging` or `main` will be the real end-to-end check; recommend confirming the resulting release APK installs cleanly via `adb install` before closing this out.

## Impact
No behavior change for debug builds. Release builds now require the 4 keystore secrets to be present in CI or the build fails fast (previously it succeeded silently while producing an unusable artifact). This is the app's permanent signing identity going forward — it must be reused for all future releases.

## Additional Information
🤖 Generated with [Claude Code](https://claude.com/claude-code)