### PR TITLE
Extend boot/gap alert thresholds (#511)

### DIFF
--- a/client/core/src/module/lifecycle.rs
+++ b/client/core/src/module/lifecycle.rs
@@ -33,10 +33,13 @@ pub(crate) const HIGH_RISK_LIFECYCLE_ALERT: f32 = 0.8;
 // A single stall can be a blip (heavy capture/classify cycle, a slow poll) —
 // alerting on one is twitchy, so we sum the time lost to over-threshold gaps
 // inside a sliding window and only alert when that sustained gap budget is
-// exceeded.
+// exceeded. Each bucket has its own budget: startup gets the most headroom
+// since a legitimate boot can take longer than a plain mid-session stall.
 const PER_GAP_THRESHOLD_MS: i64 = 10_000; // a gap must exceed 10s to count
 const GAP_WINDOW_MS: i64 = 10 * 60 * 1_000; // 10-min sliding window
-const GAP_BUDGET_MS: i64 = 60_000; // alert when counted gap time >= 60s in window
+const GAP_BUDGET_MS: i64 = 2 * 60 * 1_000; // UnexpectedGap (mid-session): alert at >= 2 min in window
+const STARTUP_GAP_BUDGET_MS: i64 = 4 * 60 * 1_000; // UnexpectedStart: alert at >= 4 min, to tolerate longer boots
+const STOP_GAP_BUDGET_MS: i64 = 60_000; // UnexpectedStop: alert at >= 1 min, unchanged
 const GAP_ALERT_COOLDOWN_MS: i64 = 5 * 60 * 1_000; // <= one alert per 5 min
 
 const SUSPEND_MIN_MS: i64 = 5_000; // boot-vs-monotonic divergence worth logging
@@ -72,7 +75,7 @@ impl GapTracker {
     /// whether the budget is newly crossed (respecting the cooldown). Gaps
     /// are intentionally NOT cleared on alert — chronic stalls keep
     /// re-alerting each cooldown, while one-off bursts age out of the window.
-    fn crossed_budget(&mut self, now_ms: i64) -> bool {
+    fn crossed_budget(&mut self, now_ms: i64, budget_ms: i64) -> bool {
         let window_start = now_ms - GAP_WINDOW_MS;
         self.gaps.retain(|(ts, _)| *ts >= window_start);
         let total: i64 = self.gaps.iter().map(|(_, gap)| *gap).sum();
@@ -82,7 +85,7 @@ impl GapTracker {
         let cooldown_ok =
             self.last_alert_ms == 0 || now_ms - self.last_alert_ms >= GAP_ALERT_COOLDOWN_MS;
 
-        if total >= GAP_BUDGET_MS && cooldown_ok {
+        if total >= budget_ms && cooldown_ok {
             self.last_alert_ms = now_ms;
             true
         } else {
@@ -191,7 +194,11 @@ impl LifecycleModule {
 
         if delta_mono > PER_GAP_THRESHOLD_MS {
             self.state.unexpected_gap.record(utc_ms, delta_mono);
-            if self.state.unexpected_gap.crossed_budget(utc_ms) {
+            if self
+                .state
+                .unexpected_gap
+                .crossed_budget(utc_ms, GAP_BUDGET_MS)
+            {
                 let _ = emitter.send(Upload {
                     risk: HIGH_RISK_LIFECYCLE_ALERT,
                     kind: UploadKind::LifecycleAlert {
@@ -296,7 +303,11 @@ impl LifecycleModule {
 
         if gap > PER_GAP_THRESHOLD_MS {
             self.state.unexpected_start.record(utc_ms, gap);
-            if self.state.unexpected_start.crossed_budget(utc_ms) {
+            if self
+                .state
+                .unexpected_start
+                .crossed_budget(utc_ms, STARTUP_GAP_BUDGET_MS)
+            {
                 let _ = emitter.send(Upload {
                     risk: HIGH_RISK_LIFECYCLE_ALERT,
                     kind: UploadKind::LifecycleAlert {
@@ -324,7 +335,11 @@ impl LifecycleModule {
 
         if gap > PER_GAP_THRESHOLD_MS {
             self.state.unexpected_stop.record(logout_ms, gap);
-            if self.state.unexpected_stop.crossed_budget(logout_ms) {
+            if self
+                .state
+                .unexpected_stop
+                .crossed_budget(logout_ms, STOP_GAP_BUDGET_MS)
+            {
                 let _ = emitter.send(Upload {
                     risk: HIGH_RISK_LIFECYCLE_ALERT,
                     kind: UploadKind::LifecycleAlert {
@@ -511,7 +526,7 @@ mod tests {
         t.clear_captured();
 
         // A single 30s gap: over the 10s per-gap threshold (recorded) but
-        // under the 60s sliding-window budget, so no alert fires.
+        // under the 120s sliding-window budget, so no alert fires.
         t.platform.set_boot_clock_ms(31_000);
         t.platform.set_monotonic_clock_ms(31_000);
         t.emit(31, Ping);
@@ -533,13 +548,13 @@ mod tests {
         t.emit(1, Ping);
         t.clear_captured();
 
-        // Three 25s gaps: 25 -> 50 (both under the 60s budget), then 75 >= 60 alerts.
-        t.platform.set_boot_clock_ms(26_000);
-        t.platform.set_monotonic_clock_ms(26_000);
-        t.emit(26, Ping);
-        t.platform.set_boot_clock_ms(51_000);
-        t.platform.set_monotonic_clock_ms(51_000);
-        t.emit(51, Ping);
+        // Three 45s gaps: 45 -> 90 (both under the 120s budget), then 135 >= 120 alerts.
+        t.platform.set_boot_clock_ms(46_000);
+        t.platform.set_monotonic_clock_ms(46_000);
+        t.emit(46, Ping);
+        t.platform.set_boot_clock_ms(91_000);
+        t.platform.set_monotonic_clock_ms(91_000);
+        t.emit(91, Ping);
         t.assert_not_like(crate::like!(Upload {
             kind: UploadKind::LifecycleAlert {
                 reason: AlertReason::UnexpectedGap
@@ -548,9 +563,9 @@ mod tests {
         }));
         t.clear_captured();
 
-        t.platform.set_boot_clock_ms(76_000);
-        t.platform.set_monotonic_clock_ms(76_000);
-        t.emit(76, Ping);
+        t.platform.set_boot_clock_ms(136_000);
+        t.platform.set_monotonic_clock_ms(136_000);
+        t.emit(136, Ping);
         t.assert_like(crate::like!(Upload {
             kind: UploadKind::LifecycleAlert {
                 reason: AlertReason::UnexpectedGap
@@ -585,10 +600,10 @@ mod tests {
         t.platform.set_monotonic_clock_ms(1_000);
         t.emit(1, Ping);
 
-        // First gap of 70s crosses budget and alerts.
-        t.platform.set_boot_clock_ms(71_000);
-        t.platform.set_monotonic_clock_ms(71_000);
-        t.emit(71, Ping);
+        // First gap of 130s crosses the 120s budget directly and alerts.
+        t.platform.set_boot_clock_ms(131_000);
+        t.platform.set_monotonic_clock_ms(131_000);
+        t.emit(131, Ping);
         t.assert_like(crate::like!(Upload {
             kind: UploadKind::LifecycleAlert {
                 reason: AlertReason::UnexpectedGap
@@ -597,10 +612,10 @@ mod tests {
         }));
         t.clear_captured();
 
-        // 40s later (< 5-min cooldown): another 70s gap crosses budget again but is suppressed.
-        t.platform.set_boot_clock_ms(181_000);
-        t.platform.set_monotonic_clock_ms(181_000);
-        t.emit(181, Ping);
+        // 40s later (< 5-min cooldown): another gap crosses budget again but is suppressed.
+        t.platform.set_boot_clock_ms(171_000);
+        t.platform.set_monotonic_clock_ms(171_000);
+        t.emit(171, Ping);
         t.assert_not_like(crate::like!(Upload {
             kind: UploadKind::LifecycleAlert {
                 reason: AlertReason::UnexpectedGap
@@ -698,10 +713,30 @@ mod tests {
         b.add(LifecycleModule::new(Box::new(b.platform())));
         let mut t = b.build();
         t.platform.set_last_login(Some(100));
-        t.platform.set_boot_clock_ms(61_000);
-        t.platform.set_monotonic_clock_ms(61_000);
-        t.emit(61, Ping);
+        t.platform.set_boot_clock_ms(241_000);
+        t.platform.set_monotonic_clock_ms(241_000);
+        t.emit(241, Ping);
         t.assert_like(crate::like!(Upload {
+            kind: UploadKind::LifecycleAlert {
+                reason: AlertReason::UnexpectedStart
+            },
+            ..
+        }));
+    }
+
+    #[test]
+    fn seventy_five_second_boot_does_not_trigger_unexpected_start() {
+        let mut b = EventTester::builder();
+        b.add(LifecycleModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        // Regression test for the reported Mac boot that took 75s and
+        // incorrectly alerted under the old 60s startup budget. Under the
+        // new 240s budget, it must stay silent.
+        t.platform.set_last_login(Some(100));
+        t.platform.set_boot_clock_ms(75_100);
+        t.platform.set_monotonic_clock_ms(75_100);
+        t.emit(75, Ping);
+        t.assert_not_like(crate::like!(Upload {
             kind: UploadKind::LifecycleAlert {
                 reason: AlertReason::UnexpectedStart
             },

--- a/client/core/src/testing/event_tester.rs
+++ b/client/core/src/testing/event_tester.rs
@@ -489,10 +489,10 @@ mod tests {
         t.clear_captured();
 
         // A big awake gap (monotonic keeps pace with boot — no suspend) crosses
-        // the sliding-window budget on the next ping.
-        t.platform.set_boot_clock_ms(101_000);
-        t.platform.set_monotonic_clock_ms(101_000);
-        t.emit(101, Ping);
+        // the sliding-window budget (120s) on the next ping.
+        t.platform.set_boot_clock_ms(121_000);
+        t.platform.set_monotonic_clock_ms(121_000);
+        t.emit(121, Ping);
         t.assert_like(crate::like!(Upload {
             kind: UploadKind::LifecycleAlert {
                 reason: AlertReason::UnexpectedGap

--- a/client/core/tampering.md
+++ b/client/core/tampering.md
@@ -47,10 +47,13 @@ their own.
   last recorded one is the reboot signal. Any math spanning a reboot anchors
   on UTC + the login/logout hooks instead.
 - Each of the three gap buckets (`UnexpectedGap`/`UnexpectedStart`/
-  `UnexpectedStop`) uses a shared sliding-window budget: gaps are summed over
-  a 10-minute window, and an alert only fires once the summed gap time
-  crosses a budget (60s), with a 5-minute cooldown between repeat alerts per
-  bucket. A single stall shouldn't alert on its own.
+  `UnexpectedStop`) uses the same sliding-window mechanism — gaps are summed
+  over a 10-minute window, and an alert only fires once the summed gap time
+  crosses that bucket's budget, with a 5-minute cooldown between repeat
+  alerts per bucket — but each bucket has its own budget: `UnexpectedGap`
+  (mid-session) is 2 min, `UnexpectedStart` is 4 min (to tolerate longer
+  boots), and `UnexpectedStop` is unchanged at 1 min. A single stall
+  shouldn't alert on its own.
 - A reconstructed (unclean-shutdown) logout timestamp is a _floor_, not
   exact — it sits at or before the true end, so the computed
   `UnexpectedStop` gap can only shrink, never be invented. A simultaneous

--- a/client/core/tests/scenarios.rs
+++ b/client/core/tests/scenarios.rs
@@ -122,11 +122,11 @@ fn unexpected_gap_batches_alert_without_email() {
     // First loop establishes a baseline heartbeat sample.
     scenario.at_t(0).loop_iteration();
     // Suppress a second screenshot so the only new upload traffic is the alert itself.
-    scenario.set_last_screenshot_at_ms(Some(61_000));
+    scenario.set_last_screenshot_at_ms(Some(121_000));
     let hashes_before = scenario.api.state().hash_uploads.len();
-    // A single 61s gap exceeds the sliding-window budget (60s) in one shot, so the
+    // A single 121s gap exceeds the sliding-window budget (120s) in one shot, so the
     // UnexpectedGap alert fires — but it's high-risk, not immediate.
-    scenario.at_t(61_000).loop_iteration();
+    scenario.at_t(121_000).loop_iteration();
     let state = scenario.api.state();
     assert!(
         state.notify_calls.is_empty(),
@@ -274,9 +274,9 @@ fn logout_clears_pending_state() {
 fn unexpected_start_after_long_gap_since_login_emits_alert() {
     let mut scenario = Scenario::authenticated();
     scenario.platform.set_last_login(Some(0));
-    scenario.platform.set_boot_clock_ms(130_000);
-    scenario.platform.set_monotonic_clock_ms(130_000);
-    scenario.at_t(130_000).loop_iteration();
+    scenario.platform.set_boot_clock_ms(241_000);
+    scenario.platform.set_monotonic_clock_ms(241_000);
+    scenario.at_t(241_000).loop_iteration();
     // UnexpectedStart is high-risk but batched (no immediate email).
     let state = scenario.api.state();
     assert!(

--- a/landing/src/content/help/developer/lifecycle.md
+++ b/landing/src/content/help/developer/lifecycle.md
@@ -115,13 +115,15 @@ the edge checks anchor on UTC + the login/logout hooks instead.
 
 A single slow loop iteration briefly stalling `Ping` shouldn't alert on its
 own, so each bucket's gaps are recorded into a window and summed — the alert
-fires on sustained gap _budget_, not any one gap.
+fires on sustained gap _budget_, not any one gap. The budget is
+bucket-specific: 2 min for the mid-session `UnexpectedGap` bucket, 4 min for
+`UnexpectedStart` (to tolerate longer boots), and 1 min for `UnexpectedStop`.
 
 ```mermaid
 flowchart TD
     G([Gap recorded]) --> Prune[Prune entries outside GAP_WINDOW_MS]
     Prune --> Sum[Sum remaining gap time]
-    Sum --> Budget{total ≥ GAP_BUDGET_MS?}
+    Sum --> Budget{total ≥ bucket's budget?}
     Budget -->|no| Done1([done, gaps kept for next time])
     Budget -->|yes| Cooldown{Cooldown elapsed\nor never alerted?}
     Cooldown -->|no| Done2([suppressed, gaps kept])
@@ -178,7 +180,9 @@ Defined at the top of `lifecycle.rs`:
 | --------------------------- | ------ | -------------------------------------------------------------- |
 | `PER_GAP_THRESHOLD_MS`      | 10s    | Minimum size for a single gap to be recorded                   |
 | `GAP_WINDOW_MS`             | 10 min | Sliding window gaps are summed over                            |
-| `GAP_BUDGET_MS`             | 60s    | Total gap time in the window that triggers an alert            |
+| `GAP_BUDGET_MS`             | 2 min  | Mid-session gap budget (`UnexpectedGap`)                       |
+| `STARTUP_GAP_BUDGET_MS`     | 4 min  | Startup gap budget (`UnexpectedStart`)                         |
+| `STOP_GAP_BUDGET_MS`        | 1 min  | Shutdown gap budget (`UnexpectedStop`), unchanged              |
 | `GAP_ALERT_COOLDOWN_MS`     | 5 min  | Minimum time between repeat alerts, per bucket                 |
 | `SUSPEND_MIN_MS`            | 5s     | Minimum boot-vs-monotonic divergence worth logging             |
 | `LOGIN_POLL_INTERVAL_MS`    | 5 min  | Coarse cadence for the (possibly expensive) login/logout hooks |


### PR DESCRIPTION
## Summary

A Mac boot that took 1 min 15 sec incorrectly triggered a high-risk `UnexpectedStart` alert. All three lifecycle gap buckets (`UnexpectedGap`/`UnexpectedStart`/`UnexpectedStop`) shared a single 60s sliding-window budget in `client/core/src/module/lifecycle.rs`. This PR gives each bucket its own budget: startup gets more headroom (4 min) since boots can legitimately take longer than a mid-session stall, and the mid-session budget is loosened too (2 min). Shutdown stays at 1 min per explicit direction — the issue only calls out startup and the "normal" gap, not shutdown.

Fixes #511.

## Changes

Type of change: Bug fix

Components: Core

- Split `GAP_BUDGET_MS` (60s) into three constants: `GAP_BUDGET_MS` (2 min, mid-session `UnexpectedGap`), `STARTUP_GAP_BUDGET_MS` (4 min, `UnexpectedStart`), `STOP_GAP_BUDGET_MS` (1 min, `UnexpectedStop`, unchanged)
- `GapTracker::crossed_budget` now takes the budget as a parameter instead of reading a shared constant
- Updated unit/scenario tests whose gap sizes were tuned to the old shared 60s budget; added a regression test asserting a 75s boot does not trigger `UnexpectedStart` under the new 240s budget
- Updated `client/core/tampering.md` and `landing/src/content/help/developer/lifecycle.md` to describe the per-bucket budgets

No `web/` changes needed — confirmed via grep that the web app only does generic rendering of `lifecycle`/`lifecycle_alert` log kinds and contains no gap-budget logic of its own.

## Testing

- `cargo test -p virtue-core --features testing` — all 121 unit tests + 17 scenario tests pass
- `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fmc2DQbv3Ag4kE8kNzoQyh