### PR TITLE
mac: install tracing subscriber with daily-rotated file (3/6)

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -3889,6 +3889,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tract-onnx",
  "virtue-text-detection",
  "webp",

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -676,6 +676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2019,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3132,6 +3159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +3278,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3370,6 +3412,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3574,6 +3625,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3655,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3855,6 +3949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3932,6 +4032,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
  "virtue-core",
 ]

--- a/client/android/rust/Cargo.lock
+++ b/client/android/rust/Cargo.lock
@@ -2904,7 +2904,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3212,6 +3224,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tract-onnx",
  "virtue-text-detection",
  "webp",

--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -40,5 +40,6 @@ sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1", features = ["time"] }
 tract-onnx = "0.21"
+tracing = "0.1"
 virtue-text-detection = { path = "../text-detection" }
 webp = "0.3"

--- a/client/core/src/events/bus.rs
+++ b/client/core/src/events/bus.rs
@@ -51,8 +51,15 @@ macro_rules! dispatch_event {
 
 pub fn log_error(msg: &str, err: Option<&dyn std::fmt::Display>) {
     match err {
-        Some(e) => eprintln!("[core error] {msg}: {e}"),
-        None => eprintln!("[core error] {msg}"),
+        Some(e) => tracing::error!(error = %e, "{msg}"),
+        None => tracing::error!("{msg}"),
+    }
+}
+
+pub fn log_warning(msg: &str, err: Option<&dyn std::fmt::Display>) {
+    match err {
+        Some(e) => tracing::warn!(error = %e, "{msg}"),
+        None => tracing::warn!("{msg}"),
     }
 }
 
@@ -280,13 +287,21 @@ impl EventBus {
     /// every observer is collected and returned.
     pub fn iter(&mut self) -> CoreResult<StateType> {
         while let Ok(event) = self.rx.try_recv() {
-            if cfg!(debug_assertions) {
-                println!("Event: {:?}", &*event);
-            }
             // Upcast the boxed event to `&dyn Any` ONCE, dereferencing to the
             // inner `dyn AnyDebugEvent` first. Upcasting the box directly would
             // yield a `&dyn Any` of the box, so no `type_id`/downcast would match.
             let event_any: &dyn Any = &*event;
+
+            // `Ping` fires on every tick regardless of activity and carries no
+            // state of its own, so even DEBUG-level dispatch logging is too
+            // noisy to be useful by default — it alone goes to TRACE. Every
+            // other event type logs at DEBUG; the runtime filter (not a
+            // compile-time flag) decides whether it's actually emitted.
+            if event_any.is::<super::Ping>() {
+                tracing::trace!(event = ?event, "event");
+            } else {
+                tracing::debug!(event = ?event, "event");
+            }
 
             // Subscription-based handlers (closure subscriptions).
             if let Some(handlers) = self.handlers.get(&event_any.type_id()) {

--- a/client/core/src/ipc_bridge.rs
+++ b/client/core/src/ipc_bridge.rs
@@ -29,7 +29,7 @@ impl IpcBridge {
                                 }
                             }
                             Err(e) => {
-                                eprintln!("daemon: ipc accept error: {e}");
+                                tracing::error!(error = %e, "daemon: ipc accept error");
                                 break;
                             }
                         }
@@ -41,9 +41,10 @@ impl IpcBridge {
                 })
             }
             Err(e) => {
-                eprintln!(
-                    "daemon: failed to bind IPC listener at {}: {e}",
-                    path.display()
+                tracing::error!(
+                    error = %e,
+                    path = %path.display(),
+                    "daemon: failed to bind IPC listener"
                 );
                 None
             }

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod events;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod ipc_bridge;
+pub mod logging;
 pub mod model;
 pub mod module;
 pub mod platform;

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -1,0 +1,125 @@
+//! Rotation/retention conventions shared by every platform that installs a
+//! `tracing` subscriber. `core` never installs a subscriber itself (see
+//! `client/CLAUDE.md`'s cross-component contracts) — only the host process
+//! knows its own process model — but the naming/retention knobs are pure
+//! logic worth centralizing rather than reimplementing per platform.
+
+/// Default `EnvFilter` directive per build type — the fallback when no
+/// runtime override (`RUST_LOG`, where supported) is present.
+pub fn default_filter_directive(debug_build: bool) -> &'static str {
+    if debug_build {
+        "info,virtue_core=debug"
+    } else {
+        "info"
+    }
+}
+
+/// Rolling-file naming/retention knobs shared by every platform with a file
+/// sink (everything except Linux, which stays on stdout -> journald).
+pub struct FileLogPolicy {
+    pub file_name_prefix: &'static str,
+    pub max_retained_files: usize,
+}
+
+pub const DEFAULT_FILE_LOG_POLICY: FileLogPolicy = FileLogPolicy {
+    file_name_prefix: "virtue",
+    max_retained_files: 14,
+};
+
+/// Deletes all but the newest `max_retained_files` files in `dir` whose name
+/// starts with `policy.file_name_prefix`, sorted by modified time. Call once
+/// at subscriber-install time on platforms using a file sink —
+/// `tracing_appender` itself does not prune old files.
+pub fn prune_old_logs(dir: &std::path::Path, policy: &FileLogPolicy) -> std::io::Result<()> {
+    let mut files: Vec<(std::time::SystemTime, std::path::PathBuf)> = std::fs::read_dir(dir)?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(policy.file_name_prefix))
+        })
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, entry.path()))
+        })
+        .collect();
+
+    if files.len() <= policy.max_retained_files {
+        return Ok(());
+    }
+
+    // Newest first, so the retained prefix is the newest `max_retained_files`.
+    files.sort_by(|a, b| b.0.cmp(&a.0));
+    for (_, path) in files.into_iter().skip(policy.max_retained_files) {
+        let _ = std::fs::remove_file(path);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_filter_directive_differs_by_build_type() {
+        assert_eq!(default_filter_directive(true), "info,virtue_core=debug");
+        assert_eq!(default_filter_directive(false), "info");
+    }
+
+    #[test]
+    fn prune_old_logs_keeps_only_newest_files() {
+        let dir = std::env::temp_dir().join(format!(
+            "virtue-logging-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let policy = FileLogPolicy {
+            file_name_prefix: "virtue",
+            max_retained_files: 2,
+        };
+
+        // Create 4 matching files plus one non-matching file, with distinct
+        // mtimes (some filesystems have coarse mtime resolution, so bump the
+        // clock explicitly rather than relying on real elapsed time).
+        let names = [
+            "virtue.2024-01-01",
+            "virtue.2024-01-02",
+            "virtue.2024-01-03",
+            "virtue.2024-01-04",
+        ];
+        for (i, name) in names.iter().enumerate() {
+            let path = dir.join(name);
+            std::fs::write(&path, b"x").unwrap();
+            let mtime = std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(1_700_000_000 + i as u64 * 3600);
+            let file = std::fs::File::open(&path).unwrap();
+            file.set_modified(mtime).unwrap();
+        }
+        std::fs::write(dir.join("other.log"), b"x").unwrap();
+
+        prune_old_logs(&dir, &policy).unwrap();
+
+        let remaining: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+
+        assert!(remaining.contains(&"virtue.2024-01-03".to_string()));
+        assert!(remaining.contains(&"virtue.2024-01-04".to_string()));
+        assert!(!remaining.contains(&"virtue.2024-01-01".to_string()));
+        assert!(!remaining.contains(&"virtue.2024-01-02".to_string()));
+        assert!(
+            remaining.contains(&"other.log".to_string()),
+            "non-matching files are untouched"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -4,14 +4,13 @@
 //! knows its own process model — but the naming/retention knobs are pure
 //! logic worth centralizing rather than reimplementing per platform.
 
-/// Default `EnvFilter` directive per build type — the fallback when no
-/// runtime override (`RUST_LOG`, where supported) is present.
-pub fn default_filter_directive(debug_build: bool) -> &'static str {
-    if debug_build {
-        "info,virtue_core=debug"
-    } else {
-        "info"
-    }
+/// Default `EnvFilter` directive — the fallback when no runtime override
+/// (`RUST_LOG`, where supported) is present. Always debug-level for
+/// `virtue_core` so release builds retain the same diagnostic detail as
+/// debug builds; `debug_build` is accepted for call-site symmetry with
+/// platforms that also gate their own crate's directive on it.
+pub fn default_filter_directive(_debug_build: bool) -> &'static str {
+    "info,virtue_core=debug"
 }
 
 /// Rolling-file naming/retention knobs shared by every platform with a file
@@ -62,9 +61,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_filter_directive_differs_by_build_type() {
+    fn default_filter_directive_is_debug_regardless_of_build_type() {
         assert_eq!(default_filter_directive(true), "info,virtue_core=debug");
-        assert_eq!(default_filter_directive(false), "info");
+        assert_eq!(default_filter_directive(false), "info,virtue_core=debug");
     }
 
     #[test]

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -50,7 +50,7 @@ pub fn prune_old_logs(dir: &std::path::Path, policy: &FileLogPolicy) -> std::io:
     }
 
     // Newest first, so the retained prefix is the newest `max_retained_files`.
-    files.sort_by(|a, b| b.0.cmp(&a.0));
+    files.sort_by_key(|f| std::cmp::Reverse(f.0));
     for (_, path) in files.into_iter().skip(policy.max_retained_files) {
         let _ = std::fs::remove_file(path);
     }

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -98,7 +98,9 @@ mod tests {
             std::fs::write(&path, b"x").unwrap();
             let mtime = std::time::SystemTime::UNIX_EPOCH
                 + std::time::Duration::from_secs(1_700_000_000 + i as u64 * 3600);
-            let file = std::fs::File::open(&path).unwrap();
+            // `File::open` is read-only, which lacks the write-attributes
+            // permission `set_modified` needs on Windows.
+            let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
             file.set_modified(mtime).unwrap();
         }
         std::fs::write(dir.join("other.log"), b"x").unwrap();

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -72,7 +72,7 @@ pub enum AlertReason {
     UserStop,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum UploadKind {
     Screenshot {
@@ -106,6 +106,38 @@ pub enum UploadKind {
         details: Option<String>,
     },
     Heartbeat,
+}
+
+/// Hand-written so the captured screenshot bytes never reach a log line
+/// verbatim — every other field prints exactly as `#[derive(Debug)]` would.
+impl std::fmt::Debug for UploadKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UploadKind::Screenshot {
+                image,
+                content_type,
+                skin_detection,
+                nsfw_detection,
+            } => write!(
+                f,
+                "Screenshot {{ image: <{} bytes>, content_type: {content_type:?}, skin_detection: {skin_detection:?}, nsfw_detection: {nsfw_detection:?} }}",
+                image.len()
+            ),
+            UploadKind::Lifecycle { kind } => write!(f, "Lifecycle {{ kind: {kind:?} }}"),
+            UploadKind::LifecycleAlert { reason } => {
+                write!(f, "LifecycleAlert {{ reason: {reason:?} }}")
+            }
+            UploadKind::ScreenshotSkipped { reason } => {
+                write!(f, "ScreenshotSkipped {{ reason: {reason:?} }}")
+            }
+            UploadKind::Alert { message } => write!(f, "Alert {{ message: {message:?} }}"),
+            UploadKind::CaptureFailed => write!(f, "CaptureFailed"),
+            UploadKind::Dev { title, details } => {
+                write!(f, "Dev {{ title: {title:?}, details: {details:?} }}")
+            }
+            UploadKind::Heartbeat => write!(f, "Heartbeat"),
+        }
+    }
 }
 
 /// A single piece of `ServiceStatus` reported by one module in response to a

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -94,8 +94,9 @@ impl ScreenshotModule {
                 // a load failure is an unresolved Git LFS pointer baked in instead of the real
                 // ONNX (see build.rs guard). Without a classifier every screenshot risk is 0,
                 // so make that loud rather than silent.
-                eprintln!(
-                    "[screenshot] NSFW classifier disabled, all screenshot risk will be 0: {err}"
+                tracing::error!(
+                    error = %err,
+                    "NSFW classifier disabled, all screenshot risk will be 0"
                 );
                 None
             }
@@ -107,7 +108,7 @@ impl ScreenshotModule {
         let ocr = match ScreenshotOCR::new(Default::default()) {
             Ok(ocr) => Some(Arc::new(ocr)),
             Err(err) => {
-                eprintln!("[screenshot] OCR disabled, text will not be redacted: {err}");
+                tracing::warn!(error = %err, "OCR disabled, text will not be redacted");
                 None
             }
         };
@@ -256,7 +257,7 @@ fn run_capture(
     let scores = classifier.and_then(|c| match c.classify(&screenshot.bytes) {
         Ok(scores) => Some(scores),
         Err(err) => {
-            eprintln!("[screenshot] classify failed, recording risk 0: {err}");
+            tracing::warn!(error = %err, "classify failed, recording risk 0");
             None
         }
     });
@@ -298,13 +299,13 @@ fn redact_if_ocr(ocr: Option<&ScreenshotOCR>, mut shot: crate::Screenshot) -> cr
     match engine.detect(&shot.bytes) {
         Ok(result) if !result.regions.is_empty() => {
             if let Err(err) = redact_text_regions(&mut shot, &result.regions) {
-                eprintln!("[screenshot] text redaction failed, uploading unredacted: {err}");
+                tracing::warn!(error = %err, "text redaction failed, uploading unredacted");
             }
             shot
         }
         Ok(_) => shot,
         Err(err) => {
-            eprintln!("[screenshot] OCR failed, uploading unredacted: {err}");
+            tracing::warn!(error = %err, "OCR failed, uploading unredacted");
             shot
         }
     }

--- a/client/core/src/module/screenshot/fingerprint.rs
+++ b/client/core/src/module/screenshot/fingerprint.rs
@@ -47,11 +47,25 @@ const MIN_STRONG_CELLS: usize = 6;
 /// A grid fingerprint of a captured frame: the grid dimensions plus the row-major grayscale
 /// cells. Dimensions are stored so two fingerprints can only be compared when they describe the
 /// same-shaped grid (i.e. the same screen resolution).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fingerprint {
     pub width: u16,
     pub height: u16,
     pub cells: Vec<u8>,
+}
+
+/// Hand-written so the raw grayscale grid — a coarse but real reconstruction
+/// of on-screen content — never reaches a log line verbatim.
+impl std::fmt::Debug for Fingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Fingerprint {{ width: {}, height: {}, cells: <{} bytes> }}",
+            self.width,
+            self.height,
+            self.cells.len()
+        )
+    }
 }
 
 /// Grid cell counts (width, height) for an image of the given pixel dimensions.

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -12,7 +12,7 @@ use crate::api::ApiTransport;
 use crate::crypto::{CryptoEngine, compute_event_hash, encode_batch_event};
 use crate::error::{CoreError, CoreResult};
 use crate::events::Ping;
-use crate::events::bus::{Emitter, EventBus, Observer, StateType, log_error};
+use crate::events::bus::{Emitter, EventBus, Observer, StateType, log_error, log_warning};
 use crate::model::PartialStatus;
 use crate::module::auth::{Login, Logout, LogoutRequested};
 use crate::module::config::ConfigChanged;
@@ -305,7 +305,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 let encoded = match encode_batch_event(&event) {
                     Ok(bytes) => bytes,
                     Err(err) => {
-                        log_error(
+                        log_warning(
                             "encode_batch_event failed, keeping event for retry",
                             Some(&err),
                         );
@@ -328,7 +328,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                     }
                     Err(err) => {
                         had_failure = true;
-                        log_error("hash upload failed, will retry", Some(&err));
+                        log_warning("hash upload failed, will retry", Some(&err));
                         Some(event)
                     }
                 }
@@ -418,7 +418,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 true
             }
             Err(err) if err.is_not_found() || err.is_unauthorized() => {
-                log_error(
+                log_warning(
                     "settings refresh before batch: device deregistered or unauth, logging out",
                     Some(&err),
                 );
@@ -426,7 +426,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 false
             }
             Err(err) => {
-                log_error(
+                log_warning(
                     "settings refresh before batch failed; using last known settings",
                     Some(&err),
                 );
@@ -482,8 +482,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         )?;
         match self.upload_batch(&batch) {
             Ok(_) => {
-                #[cfg(debug_assertions)]
-                eprintln!("[upload] batch ok: {count} events, start_ms={start_time_ms}");
+                tracing::info!(count, start_time_ms, "batch upload ok");
                 self.state.pending_batch_events.drain(..count);
                 if self.state.post_login_proof_batches_remaining > 0 {
                     self.state.post_login_proof_batches_remaining -= 1;
@@ -493,7 +492,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 Ok(())
             }
             Err(err) if err.is_not_found() || err.is_unauthorized() => {
-                log_error(
+                log_warning(
                     "batch upload: device deregistered or unauth, logging out",
                     Some(&err),
                 );
@@ -501,7 +500,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 Ok(())
             }
             Err(err) => {
-                log_error("batch upload deferred", Some(&err));
+                log_warning("batch upload deferred", Some(&err));
                 self.batch_backoff.record_failure(now_ms);
                 Ok(())
             }

--- a/client/mac/Cargo.toml
+++ b/client/mac/Cargo.toml
@@ -25,4 +25,7 @@ objc2-core-graphics = { version = "0.3.2", default-features = false, features = 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/client/mac/src/daemon.rs
+++ b/client/mac/src/daemon.rs
@@ -23,6 +23,48 @@ const ITER_INTERVAL: Duration = Duration::from_secs(1);
 /// part of the core alerting model.
 const LOCAL_SUSPEND_MIN_MS: i64 = 5_000;
 
+/// Installs the process-wide `tracing` subscriber, writing daily-rotated
+/// plain-text logs to `paths.logs_dir` (`~/Library/Logs/virtue.log`). The
+/// returned guard must be kept alive for the life of the process — dropping
+/// it stops the background writer thread that flushes buffered log lines.
+///
+/// A launchd stdout/stderr redirect (see `launch_agent.rs`) remains as a
+/// fallback safety net for output emitted before this installs, or panics
+/// that bypass `tracing` entirely.
+pub fn init_logging(paths: &ClientPaths) -> tracing_appender::non_blocking::WorkerGuard {
+    if let Err(err) = std::fs::create_dir_all(&paths.logs_dir) {
+        eprintln!(
+            "failed to create logs dir {}: {err}",
+            paths.logs_dir.display()
+        );
+    }
+    if let Err(err) = virtue_core::logging::prune_old_logs(
+        &paths.logs_dir,
+        &virtue_core::logging::DEFAULT_FILE_LOG_POLICY,
+    ) {
+        eprintln!("failed to prune old logs: {err}");
+    }
+
+    let file_appender = tracing_appender::rolling::daily(
+        &paths.logs_dir,
+        virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix,
+    );
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::new(virtue_core::logging::default_filter_directive(cfg!(
+            debug_assertions
+        )))
+    });
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .init();
+
+    guard
+}
+
 pub fn run_daemon(paths: &ClientPaths) -> Result<()> {
     let paths = paths.clone();
 
@@ -30,7 +72,7 @@ pub fn run_daemon(paths: &ClientPaths) -> Result<()> {
         .map_err(anyhow::Error::from)
         .and_then(|runtime| runtime.block_on(run_daemon_service_loop(&paths)));
     if let Err(err) = result {
-        eprintln!("daemon: {err:#}");
+        tracing::error!(error = %format!("{err:#}"), "daemon: fatal error, exiting");
         std::process::exit(1);
     }
     std::process::exit(0);
@@ -99,19 +141,19 @@ async fn run_daemon_service_loop(paths: &ClientPaths) -> Result<()> {
                     suppress_capture_state_until = None;
                 }
                 if let Err(e) = store_state(&state_path, &state) {
-                    eprintln!("daemon: failed to store state: {e}");
+                    tracing::error!(error = %e, "daemon: failed to store state");
                 }
             }
             Err(err) => {
                 let error_text = err.to_string();
                 if suppress_capture_state_until.is_none_or(|until| Instant::now() >= until) {
                     if is_permission_missing_error(&error_text) {
-                        eprintln!("daemon: capture permission missing: {error_text}");
+                        tracing::warn!("daemon: capture permission missing: {error_text}");
                     } else {
-                        eprintln!("daemon: capture blocked: {error_text}");
+                        tracing::warn!("daemon: capture blocked: {error_text}");
                     }
                 }
-                eprintln!("daemon: {error_text}");
+                tracing::warn!("daemon: {error_text}");
             }
         }
 

--- a/client/mac/src/launch_agent.rs
+++ b/client/mac/src/launch_agent.rs
@@ -237,17 +237,21 @@ fn wait_for_loaded_state(
 
 fn render_plist(exe_path: &Path, paths: &ClientPaths) -> String {
     let exe = xml_escape(&exe_path.display().to_string());
+    // `tracing-appender` owns `virtue.<date>` in this same directory; these
+    // launchd-redirected files are only a fallback safety net for output
+    // emitted before `tracing` initializes, or panics that bypass it, so they
+    // use distinct names to avoid colliding with the rotated log files.
     let stdout_path = xml_escape(
         &paths
             .logs_dir
-            .join("virtue-daemon.log")
+            .join("virtue-daemon-launchd.log")
             .display()
             .to_string(),
     );
     let stderr_path = xml_escape(
         &paths
             .logs_dir
-            .join("virtue-daemon.error.log")
+            .join("virtue-daemon-launchd.error.log")
             .display()
             .to_string(),
     );

--- a/client/mac/src/main.rs
+++ b/client/mac/src/main.rs
@@ -42,6 +42,7 @@ fn run() -> Result<()> {
     let paths = ClientPaths::discover()?;
     paths.ensure_dirs()?;
     apply_runtime_env(&paths);
+    let _log_guard = daemon::init_logging(&paths);
 
     match cli.command {
         Commands::Daemon => daemon::run_daemon(&paths),


### PR DESCRIPTION
## Summary
- Stacked on #518 (linux). Installs a rotating plain-text file subscriber (`tracing-appender`, daily rotation, `~/Library/Logs/virtue.log`) once at the top of `main.rs`'s `run()` — covering both the `daemon` and `status` subcommands from a single init point, so `daemon.rs`'s `run_daemon()` doesn't re-install it.
- `daemon.rs`: adds `init_logging()`, pruning old logs via `core::logging::prune_old_logs`; migrates daemon-loop diagnostics (state-store failures → ERROR, capture-permission/blocked → WARN) from `eprintln!` to `tracing`.
- `launch_agent.rs`: repoints the launchd plist's `StandardOutPath`/`StandardErrorPath` to `virtue-daemon-launchd.{log,error.log}` so they don't collide with `tracing-appender`'s own `virtue.log` — kept as a fallback safety net for output emitted before `tracing` initializes, or panics that bypass it, per the confirmed product decision to keep this redirect alongside the new file.

## Changes
Type of change: Feature
Components: Core (macOS client)

## Testing
Not verified by a local build/test/clippy run — `objc2` requires a real Apple toolchain and SDK, unavailable in this environment. The `client/Cargo.lock` update was verified additive-only (no version bumps) by observing Cargo's resolve step complete before the (expected) `objc2` compile error on a non-Apple host. **Needs macOS CI / `AGENTS.md` verification before merge** (`cargo build/clippy/test -p virtue-mac`, `./mac/scripts/build-dmg.sh`).

Part of the GitHub #508 tracing migration stack: core (#517) → linux (#518) → **mac** → windows → android → ios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115qaKQq43TFxDNsSh5afbY