### PR TITLE
ios: install tracing subscriber, migrate daemon-loop diagnostic (6/6)

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -3889,6 +3889,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tract-onnx",
  "virtue-text-detection",
  "webp",

--- a/client/android/rust/Cargo.lock
+++ b/client/android/rust/Cargo.lock
@@ -2904,7 +2904,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3212,6 +3224,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "tract-onnx",
  "virtue-text-detection",
  "webp",

--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -40,5 +40,6 @@ sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1", features = ["time"] }
 tract-onnx = "0.21"
+tracing = "0.1"
 virtue-text-detection = { path = "../text-detection" }
 webp = "0.3"

--- a/client/core/src/events/bus.rs
+++ b/client/core/src/events/bus.rs
@@ -51,8 +51,15 @@ macro_rules! dispatch_event {
 
 pub fn log_error(msg: &str, err: Option<&dyn std::fmt::Display>) {
     match err {
-        Some(e) => eprintln!("[core error] {msg}: {e}"),
-        None => eprintln!("[core error] {msg}"),
+        Some(e) => tracing::error!(error = %e, "{msg}"),
+        None => tracing::error!("{msg}"),
+    }
+}
+
+pub fn log_warning(msg: &str, err: Option<&dyn std::fmt::Display>) {
+    match err {
+        Some(e) => tracing::warn!(error = %e, "{msg}"),
+        None => tracing::warn!("{msg}"),
     }
 }
 
@@ -280,13 +287,21 @@ impl EventBus {
     /// every observer is collected and returned.
     pub fn iter(&mut self) -> CoreResult<StateType> {
         while let Ok(event) = self.rx.try_recv() {
-            if cfg!(debug_assertions) {
-                println!("Event: {:?}", &*event);
-            }
             // Upcast the boxed event to `&dyn Any` ONCE, dereferencing to the
             // inner `dyn AnyDebugEvent` first. Upcasting the box directly would
             // yield a `&dyn Any` of the box, so no `type_id`/downcast would match.
             let event_any: &dyn Any = &*event;
+
+            // `Ping` fires on every tick regardless of activity and carries no
+            // state of its own, so even DEBUG-level dispatch logging is too
+            // noisy to be useful by default — it alone goes to TRACE. Every
+            // other event type logs at DEBUG; the runtime filter (not a
+            // compile-time flag) decides whether it's actually emitted.
+            if event_any.is::<super::Ping>() {
+                tracing::trace!(event = ?event, "event");
+            } else {
+                tracing::debug!(event = ?event, "event");
+            }
 
             // Subscription-based handlers (closure subscriptions).
             if let Some(handlers) = self.handlers.get(&event_any.type_id()) {

--- a/client/core/src/ipc_bridge.rs
+++ b/client/core/src/ipc_bridge.rs
@@ -29,7 +29,7 @@ impl IpcBridge {
                                 }
                             }
                             Err(e) => {
-                                eprintln!("daemon: ipc accept error: {e}");
+                                tracing::error!(error = %e, "daemon: ipc accept error");
                                 break;
                             }
                         }
@@ -41,9 +41,10 @@ impl IpcBridge {
                 })
             }
             Err(e) => {
-                eprintln!(
-                    "daemon: failed to bind IPC listener at {}: {e}",
-                    path.display()
+                tracing::error!(
+                    error = %e,
+                    path = %path.display(),
+                    "daemon: failed to bind IPC listener"
                 );
                 None
             }

--- a/client/core/src/lib.rs
+++ b/client/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod events;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod ipc_bridge;
+pub mod logging;
 pub mod model;
 pub mod module;
 pub mod platform;

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -1,0 +1,125 @@
+//! Rotation/retention conventions shared by every platform that installs a
+//! `tracing` subscriber. `core` never installs a subscriber itself (see
+//! `client/CLAUDE.md`'s cross-component contracts) — only the host process
+//! knows its own process model — but the naming/retention knobs are pure
+//! logic worth centralizing rather than reimplementing per platform.
+
+/// Default `EnvFilter` directive per build type — the fallback when no
+/// runtime override (`RUST_LOG`, where supported) is present.
+pub fn default_filter_directive(debug_build: bool) -> &'static str {
+    if debug_build {
+        "info,virtue_core=debug"
+    } else {
+        "info"
+    }
+}
+
+/// Rolling-file naming/retention knobs shared by every platform with a file
+/// sink (everything except Linux, which stays on stdout -> journald).
+pub struct FileLogPolicy {
+    pub file_name_prefix: &'static str,
+    pub max_retained_files: usize,
+}
+
+pub const DEFAULT_FILE_LOG_POLICY: FileLogPolicy = FileLogPolicy {
+    file_name_prefix: "virtue",
+    max_retained_files: 14,
+};
+
+/// Deletes all but the newest `max_retained_files` files in `dir` whose name
+/// starts with `policy.file_name_prefix`, sorted by modified time. Call once
+/// at subscriber-install time on platforms using a file sink —
+/// `tracing_appender` itself does not prune old files.
+pub fn prune_old_logs(dir: &std::path::Path, policy: &FileLogPolicy) -> std::io::Result<()> {
+    let mut files: Vec<(std::time::SystemTime, std::path::PathBuf)> = std::fs::read_dir(dir)?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(policy.file_name_prefix))
+        })
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, entry.path()))
+        })
+        .collect();
+
+    if files.len() <= policy.max_retained_files {
+        return Ok(());
+    }
+
+    // Newest first, so the retained prefix is the newest `max_retained_files`.
+    files.sort_by(|a, b| b.0.cmp(&a.0));
+    for (_, path) in files.into_iter().skip(policy.max_retained_files) {
+        let _ = std::fs::remove_file(path);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_filter_directive_differs_by_build_type() {
+        assert_eq!(default_filter_directive(true), "info,virtue_core=debug");
+        assert_eq!(default_filter_directive(false), "info");
+    }
+
+    #[test]
+    fn prune_old_logs_keeps_only_newest_files() {
+        let dir = std::env::temp_dir().join(format!(
+            "virtue-logging-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let policy = FileLogPolicy {
+            file_name_prefix: "virtue",
+            max_retained_files: 2,
+        };
+
+        // Create 4 matching files plus one non-matching file, with distinct
+        // mtimes (some filesystems have coarse mtime resolution, so bump the
+        // clock explicitly rather than relying on real elapsed time).
+        let names = [
+            "virtue.2024-01-01",
+            "virtue.2024-01-02",
+            "virtue.2024-01-03",
+            "virtue.2024-01-04",
+        ];
+        for (i, name) in names.iter().enumerate() {
+            let path = dir.join(name);
+            std::fs::write(&path, b"x").unwrap();
+            let mtime = std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(1_700_000_000 + i as u64 * 3600);
+            let file = std::fs::File::open(&path).unwrap();
+            file.set_modified(mtime).unwrap();
+        }
+        std::fs::write(dir.join("other.log"), b"x").unwrap();
+
+        prune_old_logs(&dir, &policy).unwrap();
+
+        let remaining: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+
+        assert!(remaining.contains(&"virtue.2024-01-03".to_string()));
+        assert!(remaining.contains(&"virtue.2024-01-04".to_string()));
+        assert!(!remaining.contains(&"virtue.2024-01-01".to_string()));
+        assert!(!remaining.contains(&"virtue.2024-01-02".to_string()));
+        assert!(
+            remaining.contains(&"other.log".to_string()),
+            "non-matching files are untouched"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -4,14 +4,13 @@
 //! knows its own process model — but the naming/retention knobs are pure
 //! logic worth centralizing rather than reimplementing per platform.
 
-/// Default `EnvFilter` directive per build type — the fallback when no
-/// runtime override (`RUST_LOG`, where supported) is present.
-pub fn default_filter_directive(debug_build: bool) -> &'static str {
-    if debug_build {
-        "info,virtue_core=debug"
-    } else {
-        "info"
-    }
+/// Default `EnvFilter` directive — the fallback when no runtime override
+/// (`RUST_LOG`, where supported) is present. Always debug-level for
+/// `virtue_core` so release builds retain the same diagnostic detail as
+/// debug builds; `debug_build` is accepted for call-site symmetry with
+/// platforms that also gate their own crate's directive on it.
+pub fn default_filter_directive(_debug_build: bool) -> &'static str {
+    "info,virtue_core=debug"
 }
 
 /// Rolling-file naming/retention knobs shared by every platform with a file
@@ -62,9 +61,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_filter_directive_differs_by_build_type() {
+    fn default_filter_directive_is_debug_regardless_of_build_type() {
         assert_eq!(default_filter_directive(true), "info,virtue_core=debug");
-        assert_eq!(default_filter_directive(false), "info");
+        assert_eq!(default_filter_directive(false), "info,virtue_core=debug");
     }
 
     #[test]

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -50,7 +50,7 @@ pub fn prune_old_logs(dir: &std::path::Path, policy: &FileLogPolicy) -> std::io:
     }
 
     // Newest first, so the retained prefix is the newest `max_retained_files`.
-    files.sort_by(|a, b| b.0.cmp(&a.0));
+    files.sort_by_key(|f| std::cmp::Reverse(f.0));
     for (_, path) in files.into_iter().skip(policy.max_retained_files) {
         let _ = std::fs::remove_file(path);
     }

--- a/client/core/src/logging.rs
+++ b/client/core/src/logging.rs
@@ -98,7 +98,9 @@ mod tests {
             std::fs::write(&path, b"x").unwrap();
             let mtime = std::time::SystemTime::UNIX_EPOCH
                 + std::time::Duration::from_secs(1_700_000_000 + i as u64 * 3600);
-            let file = std::fs::File::open(&path).unwrap();
+            // `File::open` is read-only, which lacks the write-attributes
+            // permission `set_modified` needs on Windows.
+            let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
             file.set_modified(mtime).unwrap();
         }
         std::fs::write(dir.join("other.log"), b"x").unwrap();

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -72,7 +72,7 @@ pub enum AlertReason {
     UserStop,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum UploadKind {
     Screenshot {
@@ -106,6 +106,38 @@ pub enum UploadKind {
         details: Option<String>,
     },
     Heartbeat,
+}
+
+/// Hand-written so the captured screenshot bytes never reach a log line
+/// verbatim — every other field prints exactly as `#[derive(Debug)]` would.
+impl std::fmt::Debug for UploadKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UploadKind::Screenshot {
+                image,
+                content_type,
+                skin_detection,
+                nsfw_detection,
+            } => write!(
+                f,
+                "Screenshot {{ image: <{} bytes>, content_type: {content_type:?}, skin_detection: {skin_detection:?}, nsfw_detection: {nsfw_detection:?} }}",
+                image.len()
+            ),
+            UploadKind::Lifecycle { kind } => write!(f, "Lifecycle {{ kind: {kind:?} }}"),
+            UploadKind::LifecycleAlert { reason } => {
+                write!(f, "LifecycleAlert {{ reason: {reason:?} }}")
+            }
+            UploadKind::ScreenshotSkipped { reason } => {
+                write!(f, "ScreenshotSkipped {{ reason: {reason:?} }}")
+            }
+            UploadKind::Alert { message } => write!(f, "Alert {{ message: {message:?} }}"),
+            UploadKind::CaptureFailed => write!(f, "CaptureFailed"),
+            UploadKind::Dev { title, details } => {
+                write!(f, "Dev {{ title: {title:?}, details: {details:?} }}")
+            }
+            UploadKind::Heartbeat => write!(f, "Heartbeat"),
+        }
+    }
 }
 
 /// A single piece of `ServiceStatus` reported by one module in response to a

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -94,8 +94,9 @@ impl ScreenshotModule {
                 // a load failure is an unresolved Git LFS pointer baked in instead of the real
                 // ONNX (see build.rs guard). Without a classifier every screenshot risk is 0,
                 // so make that loud rather than silent.
-                eprintln!(
-                    "[screenshot] NSFW classifier disabled, all screenshot risk will be 0: {err}"
+                tracing::error!(
+                    error = %err,
+                    "NSFW classifier disabled, all screenshot risk will be 0"
                 );
                 None
             }
@@ -107,7 +108,7 @@ impl ScreenshotModule {
         let ocr = match ScreenshotOCR::new(Default::default()) {
             Ok(ocr) => Some(Arc::new(ocr)),
             Err(err) => {
-                eprintln!("[screenshot] OCR disabled, text will not be redacted: {err}");
+                tracing::warn!(error = %err, "OCR disabled, text will not be redacted");
                 None
             }
         };
@@ -256,7 +257,7 @@ fn run_capture(
     let scores = classifier.and_then(|c| match c.classify(&screenshot.bytes) {
         Ok(scores) => Some(scores),
         Err(err) => {
-            eprintln!("[screenshot] classify failed, recording risk 0: {err}");
+            tracing::warn!(error = %err, "classify failed, recording risk 0");
             None
         }
     });
@@ -298,13 +299,13 @@ fn redact_if_ocr(ocr: Option<&ScreenshotOCR>, mut shot: crate::Screenshot) -> cr
     match engine.detect(&shot.bytes) {
         Ok(result) if !result.regions.is_empty() => {
             if let Err(err) = redact_text_regions(&mut shot, &result.regions) {
-                eprintln!("[screenshot] text redaction failed, uploading unredacted: {err}");
+                tracing::warn!(error = %err, "text redaction failed, uploading unredacted");
             }
             shot
         }
         Ok(_) => shot,
         Err(err) => {
-            eprintln!("[screenshot] OCR failed, uploading unredacted: {err}");
+            tracing::warn!(error = %err, "OCR failed, uploading unredacted");
             shot
         }
     }

--- a/client/core/src/module/screenshot/fingerprint.rs
+++ b/client/core/src/module/screenshot/fingerprint.rs
@@ -47,11 +47,25 @@ const MIN_STRONG_CELLS: usize = 6;
 /// A grid fingerprint of a captured frame: the grid dimensions plus the row-major grayscale
 /// cells. Dimensions are stored so two fingerprints can only be compared when they describe the
 /// same-shaped grid (i.e. the same screen resolution).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fingerprint {
     pub width: u16,
     pub height: u16,
     pub cells: Vec<u8>,
+}
+
+/// Hand-written so the raw grayscale grid — a coarse but real reconstruction
+/// of on-screen content — never reaches a log line verbatim.
+impl std::fmt::Debug for Fingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Fingerprint {{ width: {}, height: {}, cells: <{} bytes> }}",
+            self.width,
+            self.height,
+            self.cells.len()
+        )
+    }
 }
 
 /// Grid cell counts (width, height) for an image of the given pixel dimensions.

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -12,7 +12,7 @@ use crate::api::ApiTransport;
 use crate::crypto::{CryptoEngine, compute_event_hash, encode_batch_event};
 use crate::error::{CoreError, CoreResult};
 use crate::events::Ping;
-use crate::events::bus::{Emitter, EventBus, Observer, StateType, log_error};
+use crate::events::bus::{Emitter, EventBus, Observer, StateType, log_error, log_warning};
 use crate::model::PartialStatus;
 use crate::module::auth::{Login, Logout, LogoutRequested};
 use crate::module::config::ConfigChanged;
@@ -305,7 +305,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 let encoded = match encode_batch_event(&event) {
                     Ok(bytes) => bytes,
                     Err(err) => {
-                        log_error(
+                        log_warning(
                             "encode_batch_event failed, keeping event for retry",
                             Some(&err),
                         );
@@ -328,7 +328,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                     }
                     Err(err) => {
                         had_failure = true;
-                        log_error("hash upload failed, will retry", Some(&err));
+                        log_warning("hash upload failed, will retry", Some(&err));
                         Some(event)
                     }
                 }
@@ -418,7 +418,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 true
             }
             Err(err) if err.is_not_found() || err.is_unauthorized() => {
-                log_error(
+                log_warning(
                     "settings refresh before batch: device deregistered or unauth, logging out",
                     Some(&err),
                 );
@@ -426,7 +426,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 false
             }
             Err(err) => {
-                log_error(
+                log_warning(
                     "settings refresh before batch failed; using last known settings",
                     Some(&err),
                 );
@@ -482,8 +482,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         )?;
         match self.upload_batch(&batch) {
             Ok(_) => {
-                #[cfg(debug_assertions)]
-                eprintln!("[upload] batch ok: {count} events, start_ms={start_time_ms}");
+                tracing::info!(count, start_time_ms, "batch upload ok");
                 self.state.pending_batch_events.drain(..count);
                 if self.state.post_login_proof_batches_remaining > 0 {
                     self.state.post_login_proof_batches_remaining -= 1;
@@ -493,7 +492,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 Ok(())
             }
             Err(err) if err.is_not_found() || err.is_unauthorized() => {
-                log_error(
+                log_warning(
                     "batch upload: device deregistered or unauth, logging out",
                     Some(&err),
                 );
@@ -501,7 +500,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 Ok(())
             }
             Err(err) => {
-                log_error("batch upload deferred", Some(&err));
+                log_warning("batch upload deferred", Some(&err));
                 self.batch_backoff.record_failure(now_ms);
                 Ok(())
             }

--- a/client/ios/rust/Cargo.toml
+++ b/client/ios/rust/Cargo.toml
@@ -17,3 +17,6 @@ once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -19,6 +19,11 @@ use virtue_core::{
 };
 
 static CORE: OnceCell<IosCore> = OnceCell::new();
+// Kept alive for the process lifetime; dropping it would silently stop the
+// background thread that flushes buffered log lines. A dedicated `OnceCell`
+// (rather than piggybacking on `CORE`, which has no room to hold a guard)
+// still only ever runs its init closure once per process.
+static LOG_GUARD: OnceCell<tracing_appender::non_blocking::WorkerGuard> = OnceCell::new();
 
 const DEFAULT_BASE_API_URL: &str = virtue_core::DEFAULT_API_BASE_URL;
 const DEFAULT_CAPTURE_INTERVAL_SECONDS: u64 = virtue_core::DEFAULT_CAPTURE_INTERVAL_SECONDS;
@@ -132,6 +137,41 @@ impl LifecycleHooks for IosPlatformHooks {
 
 impl PlatformHooks for IosPlatformHooks {}
 
+/// Installs the process-wide `tracing` subscriber on first call, writing
+/// daily-rotated plain-text logs to `<data_dir>/logs/virtue.log`. Subsequent
+/// calls are no-ops. No runtime override (no shell env vars on mobile) — the
+/// compiled-in default filter for the build type is used directly.
+fn init_logging(data_dir: &Path) {
+    LOG_GUARD.get_or_init(|| {
+        let log_dir = data_dir.join("logs");
+        if let Err(err) = fs::create_dir_all(&log_dir) {
+            eprintln!("failed to create logs dir {}: {err}", log_dir.display());
+        }
+        if let Err(err) = virtue_core::logging::prune_old_logs(
+            &log_dir,
+            &virtue_core::logging::DEFAULT_FILE_LOG_POLICY,
+        ) {
+            eprintln!("failed to prune old logs: {err}");
+        }
+
+        let file_appender = tracing_appender::rolling::daily(
+            &log_dir,
+            virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix,
+        );
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new(
+                virtue_core::logging::default_filter_directive(cfg!(debug_assertions)),
+            ))
+            .with_writer(non_blocking)
+            .with_ansi(false)
+            .init();
+
+        guard
+    });
+}
+
 #[no_mangle]
 pub extern "C" fn virtue_ios_default_capture_interval_seconds() -> u64 {
     DEFAULT_CAPTURE_INTERVAL_SECONDS
@@ -172,6 +212,8 @@ pub extern "C" fn virtue_ios_native_init(
         )?;
 
         if CORE.get().is_none() {
+            init_logging(Path::new(&data_dir));
+
             CORE.set(IosCore {
                 state_dir: PathBuf::from(data_dir),
                 runtime_config_file,
@@ -406,7 +448,7 @@ fn run_daemon_loop(core: &IosCore) -> Result<()> {
             store_state(&state_path, &state)?;
             Ok(())
         })() {
-            eprintln!("ios-daemon: {err}");
+            tracing::error!(error = %err, "ios-daemon");
         }
         sleep_interruptible(&core.stop, LOOP_INTERVAL);
     }
@@ -556,5 +598,29 @@ fn into_c_result(result: Result<()>) -> *mut c_char {
         Err(err) => CString::new(err.to_string())
             .map(CString::into_raw)
             .unwrap_or(std::ptr::null_mut()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_logging_is_idempotent_across_repeated_calls() {
+        // `virtue_ios_native_init` can legitimately be called more than once per
+        // process, and its one-time-setup block guards on `CORE.get().is_none()`
+        // before calling `init_logging`. `init_logging` itself must also tolerate
+        // more than one call without panicking, since nothing prevents it being
+        // reached twice before `CORE` is set on a slow init path.
+        let dir =
+            std::env::temp_dir().join(format!("virtue-ios-logging-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        init_logging(&dir);
+        init_logging(&dir);
+
+        assert!(LOG_GUARD.get().is_some(), "logging should be initialized");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## Summary
- Stacked on #521 (android), same shape. `ios/rust` is a standalone crate with its own `[workspace]`, so `tracing`/`tracing-subscriber`/`tracing-appender` are added directly to its own `Cargo.toml`.
- Adds `init_logging()`, guarded by its own `OnceCell` (mirrors Android's approach), called from inside `virtue_ios_native_init`'s one-time-setup block alongside the existing `CORE` `OnceCell` guard. Writes daily-rotated plain-text logs to `<data_dir>/logs/virtue.log`. No runtime `RUST_LOG` override in v1, same reasoning as Android.
- Migrates the single daemon-loop `eprintln!` (`lib.rs`) to `tracing::error!` — previously essentially zero diagnostic output existed on this platform.
- Adds a unit test asserting `init_logging` tolerates being called twice without panicking.

## Changes
Type of change: Feature
Components: iOS

## Testing
This crate has no Apple-only dependencies, so it builds, clippys, and tests directly on this host:
- `cargo test`: 1/1 test passes (`init_logging_is_idempotent_across_repeated_calls`).
- `cargo clippy --all-targets -- -D warnings`: clean aside from one pre-existing unrelated dead-code warning (`ERROR_RETRY_INTERVAL`, present before this PR).

Final PR in the GitHub #508 tracing migration stack: core (#517) → linux (#518) → mac (#519) → windows (#520) → android (#521) → **ios**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115qaKQq43TFxDNsSh5afbY