### PR TITLE
Fix landing dev-port links in plain-HTTP dev mode

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -189,6 +189,7 @@ else
     export VITE_API_URL="http://localhost:${API_PORT}"
     export VITE_API_PROXY_TARGET="http://localhost:${API_PORT}"
     export VITE_LANDING_URL="http://localhost:${LANDING_PORT}"
+    export PUBLIC_APP_URL="http://localhost:${WEB_PORT}"
     [ "$DONATE" = 1 ] && export PUBLIC_DONATE_API_URL="http://localhost:${DONATE_PORT}"
     printf '\n  Landing : http://localhost:%s\n' "$LANDING_PORT"
     printf '  Web     : http://localhost:%s\n' "$WEB_PORT"


### PR DESCRIPTION
## Summary

In plain-HTTP dev mode (`./scripts/launch.sh --donate`, no domain arg), the landing site's links to the web app (Header "Sign in", homepage "Get started", `/about` signup link, help-page signup links) always pointed at `http://localhost:5173` regardless of the actual, dynamically-picked `WEB_PORT`. This was a regression introduced in commit 833c9c0.

The root cause: `scripts/launch.sh` only exported `PUBLIC_APP_URL` inside the domain (`[ -n "$DOMAIN" ]`) branch. The plain-HTTP `else` branch never set it, so `landing/src/lib/app-url.ts` fell back to its hardcoded default.

Fixes #524.

## Changes

Bug fix. Component: Landing (dev tooling — `scripts/launch.sh`).

Added `export PUBLIC_APP_URL="http://localhost:${WEB_PORT}"` in the no-domain branch of `scripts/launch.sh`, mirroring the domain branch's existing `export PUBLIC_APP_URL="https://app.${DOMAIN}.localhost"`.

## Testing

- Ran `./scripts/launch.sh --donate` (no domain arg) and confirmed the landing site's Header "Sign in" link, homepage "Get started" link, `/about` signup link, and help-page signup links all point at `http://localhost:<WEB_PORT>` matching the printed web port, instead of the hardcoded `:5173`.
- Confirmed the domain-mode path (`./scripts/launch.sh --donate somedomain`) is unaffected — its `PUBLIC_APP_URL` export is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cTXSytqdSJjvedAo2AQh5