### PR TITLE
Fix custom donation amount silently blocking decimal submissions

### DIFF
--- a/landing/src/components/DonateForm.tsx
+++ b/landing/src/components/DonateForm.tsx
@@ -4,6 +4,10 @@ import { DONATE_API_URL, STRIPE_PORTAL_URL } from '../lib/donate-url';
 
 const PRESET_AMOUNTS = [5, 10, 25, 50, 100];
 
+function formatAmount(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
 export function DonateForm() {
   const [amount, setAmount] = useState<number>(25);
   const [customAmount, setCustomAmount] = useState<string>('');
@@ -12,7 +16,10 @@ export function DonateForm() {
   const [error, setError] = useState<string | null>(null);
 
   // The custom input, when filled, overrides the selected preset.
-  const effectiveAmount = customAmount.trim() !== '' ? Number(customAmount) : amount;
+  const rawAmount = customAmount.trim() !== '' ? Number(customAmount) : amount;
+  const effectiveAmount = Number.isFinite(rawAmount)
+    ? Math.round(rawAmount * 100) / 100
+    : rawAmount;
   const amountIsValid = Number.isFinite(effectiveAmount) && effectiveAmount >= 1;
 
   function selectPreset(value: number) {
@@ -91,7 +98,7 @@ export function DonateForm() {
             <input
               type="number"
               min="1"
-              step="1"
+              step="0.01"
               inputMode="decimal"
               placeholder="Other"
               value={customAmount}
@@ -107,8 +114,8 @@ export function DonateForm() {
         {submitting
           ? 'Redirecting to checkout…'
           : recurring
-            ? `Donate $${amountIsValid ? effectiveAmount : ''} monthly`
-            : `Donate $${amountIsValid ? effectiveAmount : ''}`}
+            ? `Donate $${amountIsValid ? formatAmount(effectiveAmount) : ''} monthly`
+            : `Donate $${amountIsValid ? formatAmount(effectiveAmount) : ''}`}
       </Button>
 
       <p class="donate-secure-note">


### PR DESCRIPTION
## Summary

- Custom donation amounts with cents (e.g. 17.50) silently failed to submit — the `<input type="number" step="1">` triggered native HTML5 constraint validation that blocked `onSubmit` with zero visible feedback, even though the component's own JS logic (`effectiveAmount`, `amountIsValid`) already accepted and displayed decimals.
- Fixes #525.

## Changes

<!-- Type of change: Bug fix -->
<!-- Components: Landing -->

- `landing/src/components/DonateForm.tsx`:
  - Changed the custom amount input's `step` from `1` to `0.01` so native validation stops rejecting cent-level values.
  - `effectiveAmount` now rounds to cents (`Math.round(rawAmount * 100) / 100`) to avoid floating-point artifacts leaking into the request body or display.
  - Added a `formatAmount` helper so the button label shows `$17.50` for decimal amounts while whole-dollar amounts still render without trailing zeros (`$25`, not `$25.00`).
- No backend changes needed — `api-donate/src/routes/checkout.ts` already accepts decimal dollar amounts and converts to cents correctly.

## Testing

- `astro check` in `landing/` — 0 errors.
- Manually verified against the local `landing` dev server (headless Firefox):
  - Entering `17.50` shows "Donate $17.50 monthly" and successfully submits (POST to `/checkout` fires, no longer silently blocked).
  - Entering `0.50` correctly keeps the button disabled (min-amount check still holds).
  - Entering `1` still renders `$1` (no trailing `.00`) and works.
  - Preset amount buttons ($5/$10/$25/$50/$100) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTnJfV3GSB34g8DqjSBXm7