### PR TITLE
Fix missing log labels, heartbeat restore, dev tooling

### DIFF
--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -36,7 +36,7 @@ impl From<&str> for Redacted<String> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum LifecycleKind {
     /// A suspend interval detected retrospectively via boot-vs-monotonic
     /// clock divergence.
@@ -89,6 +89,7 @@ pub enum UploadKind {
         nsfw_detection: Option<f32>,
     },
     Lifecycle {
+        #[serde(flatten)]
         kind: LifecycleKind,
     },
     LifecycleAlert {
@@ -290,4 +291,47 @@ pub struct ServiceStatus {
 pub struct LoopOutcome {
     pub ran_at_ms: i64,
     pub status: ServiceStatus,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // `LifecycleKind` must serialize as a bare `"kind"`-tagged object flattened
+    // into `UploadKind::Lifecycle`'s `data` — this is exactly the wire shape
+    // the web viewer's `getLogCategory`/`getLogMessage` assume, and previously
+    // silently drifted from it when the variants gained fields (see #526).
+    #[test]
+    fn lifecycle_kind_serializes_to_flattened_tagged_shape() {
+        assert_eq!(
+            serde_json::to_value(LifecycleKind::SuspendDetected {
+                duration_ms: 60_033
+            })
+            .unwrap(),
+            json!({ "kind": "suspend_detected", "duration_ms": 60_033 })
+        );
+        assert_eq!(
+            serde_json::to_value(LifecycleKind::SystemLogin { utc_ms: 123 }).unwrap(),
+            json!({ "kind": "system_login", "utc_ms": 123 })
+        );
+        assert_eq!(
+            serde_json::to_value(LifecycleKind::SystemLogout { utc_ms: 456 }).unwrap(),
+            json!({ "kind": "system_logout", "utc_ms": 456 })
+        );
+    }
+
+    #[test]
+    fn upload_kind_lifecycle_flattens_kind_into_data() {
+        let upload = UploadKind::Lifecycle {
+            kind: LifecycleKind::SystemLogin { utc_ms: 789 },
+        };
+        assert_eq!(
+            serde_json::to_value(upload).unwrap(),
+            json!({
+                "type": "lifecycle",
+                "data": { "kind": "system_login", "utc_ms": 789 }
+            })
+        );
+    }
 }

--- a/client/core/src/module/heartbeat.rs
+++ b/client/core/src/module/heartbeat.rs
@@ -15,6 +15,8 @@ pub(crate) const HEARTBEAT_INTERVAL_MS: i64 = 24 * 60 * 60 * 1_000;
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct HeartbeatObserverState {
     pub last_heartbeat_ms: i64,
+    #[serde(default)]
+    pub authenticated: bool,
 }
 
 pub struct HeartbeatModule {
@@ -45,6 +47,7 @@ impl Observer for HeartbeatModule {
     fn init(&mut self, _bus: &mut EventBus, state: StateType) -> CoreResult<()> {
         if !state.is_null() {
             self.state = serde_json::from_value(state)?;
+            self.authenticated = self.state.authenticated;
         }
         Ok(())
     }
@@ -53,10 +56,12 @@ impl Observer for HeartbeatModule {
         crate::dispatch_event!(event, {
             _: Login => {
                 self.authenticated = true;
+                self.state.authenticated = true;
                 Ok(())
             },
             _: Logout => {
                 self.authenticated = false;
+                self.state.authenticated = false;
                 Ok(())
             },
             _: Ping => {
@@ -219,6 +224,30 @@ mod tests {
         // After another 24h: should fire
         t2.clear_captured();
         t2.emit(DAY_SECS + DAY_SECS + 20.0, Ping);
+        t2.assert_like(crate::like!(Upload {
+            kind: UploadKind::Heartbeat,
+            ..
+        }));
+    }
+
+    #[test]
+    fn authenticated_flag_persists_across_restart_without_relogin() {
+        let mut b = EventTester::builder();
+        b.add(HeartbeatModule::new(Box::new(b.platform())));
+        let mut t = b.build();
+        t.emit(DAY_SECS - 2.0, login_event());
+        t.emit(DAY_SECS, Ping); // heartbeat fires
+
+        let saved = t.bus.save().unwrap();
+
+        // Simulate daemon restart while still logged in: no Login event this time.
+        let mut b2 = EventTester::builder();
+        b2.add(HeartbeatModule::new(Box::new(b2.platform())));
+        b2.with_state(saved);
+        let mut t2 = b2.build();
+        t2.clear_captured();
+
+        t2.emit(DAY_SECS + DAY_SECS, Ping);
         t2.assert_like(crate::like!(Upload {
             kind: UploadKind::Heartbeat,
             ..

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -71,6 +71,18 @@ run() {
           done &
 }
 
+# Local D1 state persists across dev sessions, but this script picks a fresh
+# random API port every run, which gets baked into R2_URL (local batch urls
+# route through the api worker's own /r2 proxy, not a real R2 domain). Without
+# this, batches uploaded in a previous session point at a dead port. Rewrite
+# their stored urls to the current R2_URL so old local batches keep resolving.
+rewrite_local_batch_urls() {
+    local new_r2_url="$1"
+    (cd "$ROOT/api" && bun run wrangler d1 execute staging-app-db --local --env staging \
+        --command "UPDATE batches SET url = '${new_r2_url}/' || substr(url, instr(url, '/r2/') + 4) WHERE url LIKE '%/r2/%';" \
+        > /dev/null 2>&1) || true
+}
+
 # Start the donations worker (and Stripe webhook forwarder). $1 is the landing
 # URL the worker should use for CORS and Stripe redirect URLs.
 start_donate() {
@@ -178,6 +190,7 @@ if [ -n "$DOMAIN" ]; then
         wait 2>/dev/null || true
     }
 
+    rewrite_local_batch_urls "https://app.${DOMAIN}.localhost/r2"
     run "api"     "31" "api"     bun run dev -- --port "$API_PORT" \
         --var "APP_URL:https://app.${DOMAIN}.localhost" \
         --var "R2_URL:https://app.${DOMAIN}.localhost/r2" \
@@ -196,6 +209,7 @@ else
     [ "$DONATE" = 1 ] && printf '  Donate  : http://localhost:%s\n' "$DONATE_PORT"
     printf '\n'
 
+    rewrite_local_batch_urls "http://localhost:${API_PORT}/r2"
     run "api"     "31" "api"     bun run dev -- --port "$API_PORT" \
         --var "APP_URL:http://localhost:${WEB_PORT}" \
         --var "R2_URL:http://localhost:${API_PORT}/r2" \

--- a/scripts/seed-dev-user.mjs
+++ b/scripts/seed-dev-user.mjs
@@ -16,8 +16,10 @@ const ROOT = join(__dirname, '..');
 const EMAIL = 'dev@dev.com';
 const PASSWORD = 'devpassword';
 
-// Fixed UUID and salt so the seed is deterministic across runs.
-const USER_ID_HEX = '0123456789abcdef0123456789abcdef';
+// Fixed UUID and salt so the seed is deterministic across runs. Must have a
+// valid v4 version nibble (4) and variant nibble (8/9/a/b) — z.uuid() rejects
+// ids that don't, which breaks the access_keys validation on batch upload.
+const USER_ID_HEX = '0123456789ab4def8123456789abcdef';
 const PASSWORD_SALT = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
 // Fixed IKM for deterministic HPKE key pair derivation across runs.

--- a/web/src/pages/Logs/LogsList.tsx
+++ b/web/src/pages/Logs/LogsList.tsx
@@ -8,8 +8,8 @@ import {
   getLogCategory,
   getLogMessage,
   LogDetailDialog,
+  LogIcon,
 } from './shared';
-import { LogIcon } from './log-icons';
 import { getRiskLevel } from '@virtueinitiative/shared-web/risk';
 
 const ITEM_HEIGHT = 68;

--- a/web/src/pages/Logs/index.tsx
+++ b/web/src/pages/Logs/index.tsx
@@ -6,15 +6,7 @@ import { LogsIcon } from '../../components/icons';
 import { LogsGallery } from './LogsGallery';
 import { LogsList } from './LogsList';
 import { getRiskRating, type RiskRating } from '@virtueinitiative/shared-web/risk';
-import { FeedLog, formatDayLabel, getLogCategory, LOG_TYPES } from './shared';
-
-const LOG_CATEGORIES = [
-  ...new Set(
-    LOG_TYPES.map((type) =>
-      getLogCategory({ type, data: {}, id: '', device_id: '', ts: 0, created_at: 0 }),
-    ),
-  ),
-];
+import { FeedLog, formatDayLabel, getLogCategory, LOG_CATEGORIES } from './shared';
 import './style.css';
 import { useUrlState } from '../../hooks/useUrlState';
 import { Button, Dialog, DialogHeader, Field, Select } from '@virtueinitiative/shared-web';
@@ -198,8 +190,7 @@ export function Logs({ userId: routeUserId }: { userId?: string }) {
     () =>
       (logs ?? []).filter((item) => {
         if (item.ts < weekStart || item.ts > weekEnd) return false;
-        if (typeFilter !== null && getLogCategory({ ...item, data: {} }) !== typeFilter)
-          return false;
+        if (typeFilter !== null && getLogCategory(item) !== typeFilter) return false;
         if (riskFilter !== 'all') {
           const rating = getRiskRating(item.risk);
           if (riskFilter === 'high' && rating !== 'high') return false;

--- a/web/src/pages/Logs/log-icons.test.tsx
+++ b/web/src/pages/Logs/log-icons.test.tsx
@@ -1,8 +1,14 @@
 import { render } from '@testing-library/preact';
 import { describe, expect, it } from 'vitest';
 import { DataLog } from '../../utils/api/api';
-import { LogIcon } from './log-icons';
-import { getLogCategory, getLogHelpAnchor, getLogHelpUrl, LOG_TYPES } from './shared';
+import {
+  getLogCategory,
+  getLogHelpAnchor,
+  getLogHelpUrl,
+  getLogMessage,
+  LOG_TYPES,
+  LogIcon,
+} from './shared';
 
 function log(type: string, data: Record<string, unknown> = {}): DataLog {
   return { id: 'x', device_id: 'd', ts: 0, created_at: 0, type, data };
@@ -19,6 +25,25 @@ describe('getLogCategory — titles', () => {
     );
     expect(getLogCategory(log('capture_failed'))).toBe('Capture Failed');
     expect(getLogCategory(log('screenshot_skipped'))).toBe('Screenshot Skipped');
+    expect(getLogCategory(log('heartbeat'))).toBe('Heartbeat');
+  });
+});
+
+describe('getLogMessage', () => {
+  it('builds device-specific messages per log kind', () => {
+    expect(getLogMessage(log('heartbeat'), 'Bob’s PC')).toBe('Heartbeat received from Bob’s PC');
+    expect(getLogMessage(log('lifecycle', { kind: 'system_login' }), 'Bob’s PC')).toBe(
+      'Bob’s PC was logged into or started up',
+    );
+    expect(getLogMessage(log('lifecycle', { kind: 'system_logout' }), 'Bob’s PC')).toBe(
+      'Bob’s PC was logged out of or shut down',
+    );
+    expect(
+      getLogMessage(
+        log('lifecycle', { kind: 'suspend_detected', duration_ms: 90_000 }),
+        'Bob’s PC',
+      ),
+    ).toContain('2 min');
   });
 });
 
@@ -45,6 +70,24 @@ describe('LogIcon', () => {
   it('renders an SVG (not emoji text) for every log type', () => {
     for (const type of LOG_TYPES) {
       const { container, unmount } = render(<LogIcon log={log(type)} />);
+      expect(container.querySelector('svg')).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it('renders an SVG for every lifecycle kind and lifecycle_alert reason', () => {
+    const samples: DataLog[] = [
+      log('lifecycle', { kind: 'system_login' }),
+      log('lifecycle', { kind: 'system_logout' }),
+      log('lifecycle', { kind: 'suspend_detected' }),
+      log('lifecycle_alert', { reason: 'unexpected_gap' }),
+      log('lifecycle_alert', { reason: 'unexpected_stop' }),
+      log('lifecycle_alert', { reason: 'unexpected_start' }),
+      log('lifecycle_alert', { reason: 'user_stop' }),
+      log('heartbeat'),
+    ];
+    for (const sample of samples) {
+      const { container, unmount } = render(<LogIcon log={sample} />);
       expect(container.querySelector('svg')).toBeTruthy();
       unmount();
     }

--- a/web/src/pages/Logs/log-icons.tsx
+++ b/web/src/pages/Logs/log-icons.tsx
@@ -1,5 +1,4 @@
 import { ComponentChildren } from 'preact';
-import { DataLog } from '../../utils/api/api';
 
 // Hand-inlined Heroicons (outline) — same convention as the rest of the web app
 // (see MenuIcon/ExpandIcon in ./index.tsx). Size is controlled by the parent via
@@ -24,7 +23,7 @@ function Icon({ children }: { children: ComponentChildren }) {
 
 const cap = { strokeLinecap: 'round', strokeLinejoin: 'round' } as const;
 
-function CameraIcon() {
+export function CameraIcon() {
   return (
     <Icon>
       <path
@@ -39,7 +38,7 @@ function CameraIcon() {
   );
 }
 
-function DocumentDuplicateIcon() {
+export function DocumentDuplicateIcon() {
   return (
     <Icon>
       <path
@@ -50,7 +49,7 @@ function DocumentDuplicateIcon() {
   );
 }
 
-function MoonIcon() {
+export function MoonIcon() {
   return (
     <Icon>
       <path
@@ -61,7 +60,7 @@ function MoonIcon() {
   );
 }
 
-function SignInIcon() {
+export function SignInIcon() {
   return (
     <Icon>
       <path
@@ -72,7 +71,7 @@ function SignInIcon() {
   );
 }
 
-function SignOutIcon() {
+export function SignOutIcon() {
   return (
     <Icon>
       <path
@@ -83,7 +82,7 @@ function SignOutIcon() {
   );
 }
 
-function ActivityIcon() {
+export function ActivityIcon() {
   return (
     <Icon>
       <path
@@ -94,7 +93,7 @@ function ActivityIcon() {
   );
 }
 
-function ClockIcon() {
+export function ClockIcon() {
   return (
     <Icon>
       <path {...cap} d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
@@ -102,7 +101,7 @@ function ClockIcon() {
   );
 }
 
-function ExclamationTriangleIcon() {
+export function ExclamationTriangleIcon() {
   return (
     <Icon>
       <path
@@ -113,7 +112,7 @@ function ExclamationTriangleIcon() {
   );
 }
 
-function ExclamationCircleIcon() {
+export function ExclamationCircleIcon() {
   return (
     <Icon>
       <path
@@ -124,7 +123,7 @@ function ExclamationCircleIcon() {
   );
 }
 
-function BellAlertIcon() {
+export function BellAlertIcon() {
   return (
     <Icon>
       <path
@@ -135,7 +134,7 @@ function BellAlertIcon() {
   );
 }
 
-function WrenchScrewdriverIcon() {
+export function WrenchScrewdriverIcon() {
   return (
     <Icon>
       <path
@@ -155,31 +154,4 @@ export function InformationCircleIcon() {
       />
     </Icon>
   );
-}
-
-/** Picks the right Heroicon for a log entry based on its type and kind/reason. */
-export function LogIcon({ log }: { log: DataLog }) {
-  const kind = log.data?.kind as string | undefined;
-  switch (log.type) {
-    case 'screenshot':
-      return <CameraIcon />;
-    case 'screenshot_skipped':
-      return <DocumentDuplicateIcon />;
-    case 'lifecycle':
-      if (kind === 'system_login') return <SignInIcon />;
-      if (kind === 'system_logout') return <SignOutIcon />;
-      if (kind === 'suspend_detected') return <MoonIcon />;
-      return <ActivityIcon />;
-    case 'lifecycle_alert':
-      if ((log.data?.reason as string | undefined) === 'unexpected_gap') return <ClockIcon />;
-      return <ExclamationTriangleIcon />;
-    case 'alert':
-      return <BellAlertIcon />;
-    case 'capture_failed':
-      return <ExclamationCircleIcon />;
-    case 'dev':
-      return <WrenchScrewdriverIcon />;
-    default:
-      return <ActivityIcon />;
-  }
 }

--- a/web/src/pages/Logs/logs.test.tsx
+++ b/web/src/pages/Logs/logs.test.tsx
@@ -1,9 +1,52 @@
 import { screen, waitFor } from '@testing-library/preact';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderWithClient } from '../../test-utils';
 import { TEST_DEVICES } from '../../mocks/fixtures';
+import type { FeedLog } from './types';
 import { Logs } from './index';
+import { LOG_CATEGORIES } from './shared';
+
+const SAMPLE_LOGS: FeedLog[] = [
+  {
+    id: 'log-login',
+    device_id: TEST_DEVICES[0].id,
+    ts: Date.now(),
+    created_at: Date.now(),
+    type: 'lifecycle',
+    data: { kind: 'system_login', utc_ms: Date.now() },
+    batch_status: 'verified',
+    source: 'batch',
+  },
+];
+
+vi.mock('../../utils/cache/client', () => ({
+  cacheClient: {
+    setSession: vi.fn(),
+    cacheQuery: (
+      _query: unknown,
+      cb: (update: {
+        logs: FeedLog[];
+        replace: boolean;
+        done: boolean;
+        processed: number;
+        total: number;
+      }) => void,
+    ) => {
+      // Real cache client delivers updates over a BroadcastChannel/worker, so the
+      // callback always fires asynchronously — mirror that here, since calling it
+      // synchronously would race the effect's own `setLogResult(initial)` call.
+      Promise.resolve().then(() => {
+        cb({ logs: SAMPLE_LOGS, replace: true, done: true, processed: 1, total: 1 });
+      });
+    },
+    refetch: vi.fn(),
+    clearCache: vi.fn().mockResolvedValue(undefined),
+    deleteDeviceData: vi.fn().mockResolvedValue(undefined),
+    getEventImage: vi.fn().mockResolvedValue(null),
+    getDeviceBatchEndTimes: vi.fn().mockResolvedValue([]),
+  },
+}));
 
 // NOTE: The SQLite/OPFS cache worker is not available in the happy-dom test environment.
 // The component handles a null cacheClient gracefully (cacheQuery is a no-op), so
@@ -72,6 +115,49 @@ describe('Logs — view switching', () => {
     await waitFor(() => {
       expect(screen.getByRole('link', { name: /list/i })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /gallery/i })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Logs — type filter', () => {
+  it('offers kind/reason-specific categories, not just generic types', async () => {
+    renderWithClient(<Logs />);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'System Login' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Suspend Detected' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Heartbeat' })).toBeInTheDocument();
+    });
+    expect(LOG_CATEGORIES).toContain('System Login');
+  });
+
+  it('matches a lifecycle log against its specific kind category, not the generic type', async () => {
+    // NOTE: LogsList virtualizes rows via @tanstack/react-virtual, which doesn't paint
+    // items in happy-dom (no real layout/ResizeObserver signal), so we can't assert on
+    // rendered row text here. Instead we assert on the "No logs found." empty state,
+    // which the list only shows when the *filtered* item count is truly zero — a
+    // faithful proxy for whether the type filter matched.
+    const user = userEvent.setup();
+    renderWithClient(<Logs />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('No logs found.')).not.toBeInTheDocument();
+    });
+
+    const typeSelect = screen
+      .getByRole('option', { name: 'System Login' })
+      .closest('select') as HTMLSelectElement;
+
+    // Regression for the `{ ...item, data: {} }` bug: stripping `data` made every
+    // lifecycle log resolve to the generic "Activity" category, so a specific-kind
+    // filter like "System Login" would never match and the log would disappear.
+    await user.selectOptions(typeSelect, 'System Login');
+    await waitFor(() => {
+      expect(screen.queryByText('No logs found.')).not.toBeInTheDocument();
+    });
+
+    await user.selectOptions(typeSelect, 'Suspend Detected');
+    await waitFor(() => {
+      expect(screen.getByText('No logs found.')).toBeInTheDocument();
     });
   });
 });

--- a/web/src/pages/Logs/shared.tsx
+++ b/web/src/pages/Logs/shared.tsx
@@ -1,10 +1,24 @@
+import type { JSX } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { DataLog } from '../../utils/api/api';
 import { formatDate, formatTime } from '../../utils/time';
 import { Button, Dialog, DialogHeader } from '@virtueinitiative/shared-web';
 import { describeRiskLevel, getRiskLevel } from '@virtueinitiative/shared-web/risk';
 import { LANDING_URL } from '../../utils/landing-url';
-import { InformationCircleIcon, LogIcon } from './log-icons';
+import {
+  ActivityIcon,
+  BellAlertIcon,
+  CameraIcon,
+  ClockIcon,
+  DocumentDuplicateIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+  MoonIcon,
+  SignInIcon,
+  SignOutIcon,
+  WrenchScrewdriverIcon,
+} from './log-icons';
 
 import { loadEventImage } from '../../utils/api/event-image';
 import { type FeedLog, getLogImage, toUint8Array } from './types';
@@ -20,34 +34,169 @@ function getLogMetadata(log: DataLog) {
     );
 }
 
-export function getLogCategory(log: DataLog): string {
+type LogCaseKey =
+  | 'screenshot'
+  | 'screenshot_skipped'
+  | 'system_login'
+  | 'system_logout'
+  | 'suspend_detected'
+  | 'lifecycle_other'
+  | 'unexpected_gap'
+  | 'unexpected_stop'
+  | 'unexpected_start'
+  | 'user_stop'
+  | 'lifecycle_alert_other'
+  | 'alert'
+  | 'capture_failed'
+  | 'dev'
+  | 'heartbeat'
+  | 'unknown';
+
+/** The only place in the module that branches on a log's `type`/`kind`/`reason`. */
+function getLogCaseKey(log: DataLog): LogCaseKey {
   const kind = log.data?.kind as string | undefined;
   const reason = log.data?.reason as string | undefined;
   switch (log.type) {
     case 'screenshot':
-      return 'Screenshot';
+      return 'screenshot';
     case 'screenshot_skipped':
-      return 'Screenshot Skipped';
+      return 'screenshot_skipped';
     case 'lifecycle':
-      if (kind === 'system_login') return 'System Login';
-      if (kind === 'system_logout') return 'System Logout';
-      if (kind === 'suspend_detected') return 'Suspend Detected';
-      return 'Activity';
+      if (kind === 'system_login') return 'system_login';
+      if (kind === 'system_logout') return 'system_logout';
+      if (kind === 'suspend_detected') return 'suspend_detected';
+      return 'lifecycle_other';
     case 'lifecycle_alert':
-      if (reason === 'unexpected_gap') return 'Unexpected Gap';
-      if (reason === 'unexpected_stop') return 'Process Stopped Unexpectedly';
-      if (reason === 'unexpected_start') return 'Unexpected Restart';
-      if (reason === 'user_stop') return 'Monitoring Stopped by User';
-      return 'Alert';
+      if (reason === 'unexpected_gap') return 'unexpected_gap';
+      if (reason === 'unexpected_stop') return 'unexpected_stop';
+      if (reason === 'unexpected_start') return 'unexpected_start';
+      if (reason === 'user_stop') return 'user_stop';
+      return 'lifecycle_alert_other';
     case 'alert':
-      return 'Alert';
+      return 'alert';
     case 'capture_failed':
-      return 'Capture Failed';
+      return 'capture_failed';
     case 'dev':
-      return 'Developer';
+      return 'dev';
+    case 'heartbeat':
+      return 'heartbeat';
     default:
-      return (log.type ?? '').replace(/_/g, ' ');
+      return 'unknown';
   }
+}
+
+const LOG_KIND_TABLE: Record<
+  Exclude<LogCaseKey, 'unknown'>,
+  {
+    category: string;
+    icon: () => JSX.Element;
+    message: (deviceName: string, data: Record<string, unknown>) => string;
+  }
+> = {
+  screenshot: {
+    category: 'Screenshot',
+    icon: CameraIcon,
+    message: (d) => `Screenshot captured on ${d}`,
+  },
+  screenshot_skipped: {
+    category: 'Screenshot Skipped',
+    icon: DocumentDuplicateIcon,
+    message: (d, data) => {
+      const reason = data.reason as string | undefined;
+      if (reason === 'static_screen') return `Duplicate screenshot skipped on ${d}`;
+      if (reason === 'locked_or_screensaver') return `Screen locked, screenshot skipped on ${d}`;
+      return `Screenshot skipped on ${d}`;
+    },
+  },
+  system_login: {
+    category: 'System Login',
+    icon: SignInIcon,
+    message: (d) => `${d} was logged into or started up`,
+  },
+  system_logout: {
+    category: 'System Logout',
+    icon: SignOutIcon,
+    message: (d) => `${d} was logged out of or shut down`,
+  },
+  suspend_detected: {
+    category: 'Suspend Detected',
+    icon: MoonIcon,
+    message: (d, data) => {
+      const durationMs = typeof data.duration_ms === 'number' ? data.duration_ms : undefined;
+      if (durationMs === undefined) return `${d} was asleep for a while`;
+      const minutes = Math.round(durationMs / 60_000);
+      const durationLabel = minutes >= 1 ? `${minutes} min` : `${Math.round(durationMs / 1000)}s`;
+      return `${d} was asleep for ${durationLabel}`;
+    },
+  },
+  lifecycle_other: {
+    category: 'Activity',
+    icon: ActivityIcon,
+    message: (d) => `Lifecycle event on ${d}`,
+  },
+  unexpected_gap: {
+    category: 'Unexpected Gap',
+    icon: ClockIcon,
+    message: (d) => `Monitoring gap detected on ${d}`,
+  },
+  unexpected_stop: {
+    category: 'Process Stopped Unexpectedly',
+    icon: ExclamationTriangleIcon,
+    message: (d) => `Process stopped unexpectedly on ${d}`,
+  },
+  unexpected_start: {
+    category: 'Unexpected Restart',
+    icon: ExclamationTriangleIcon,
+    message: (d) => `Unexpected restart detected on ${d}`,
+  },
+  user_stop: {
+    category: 'Monitoring Stopped by User',
+    icon: ExclamationTriangleIcon,
+    message: (d) => `Monitoring stopped by user on ${d}`,
+  },
+  lifecycle_alert_other: {
+    category: 'Alert',
+    icon: ExclamationTriangleIcon,
+    message: (d) => `Alert on ${d}`,
+  },
+  alert: {
+    category: 'Alert',
+    icon: BellAlertIcon,
+    message: (d, data) => (data.message as string | undefined) ?? `Alert on ${d}`,
+  },
+  capture_failed: {
+    category: 'Capture Failed',
+    icon: ExclamationCircleIcon,
+    message: (d) => `Capture failed repeatedly on ${d}`,
+  },
+  dev: {
+    category: 'Developer',
+    icon: WrenchScrewdriverIcon,
+    message: (d, data) => {
+      const title = data.title as string | undefined;
+      const details = data.details as string | undefined;
+      return title ? (details ? `${title}: ${details}` : title) : `Developer log on ${d}`;
+    },
+  },
+  heartbeat: {
+    category: 'Heartbeat',
+    icon: ActivityIcon,
+    message: (d) => `Heartbeat received from ${d}`,
+  },
+};
+
+export const LOG_CATEGORIES = [...new Set(Object.values(LOG_KIND_TABLE).map((v) => v.category))];
+
+export function getLogCategory(log: DataLog): string {
+  const key = getLogCaseKey(log);
+  if (key === 'unknown') return (log.type ?? '').replace(/_/g, ' ');
+  return LOG_KIND_TABLE[key].category;
+}
+
+export function LogIcon({ log }: { log: DataLog }) {
+  const key = getLogCaseKey(log);
+  const IconComp = key === 'unknown' ? ActivityIcon : LOG_KIND_TABLE[key].icon;
+  return <IconComp />;
 }
 
 /** Base URL of the help page documenting every log type. */
@@ -68,52 +217,9 @@ export function getLogHelpUrl(log: DataLog): string {
 }
 
 export function getLogMessage(log: DataLog, deviceName: string): string {
-  const d = log.data;
-  switch (log.type) {
-    case 'lifecycle': {
-      const kind = d.kind as string | undefined;
-      if (kind === 'system_login') return `${deviceName} was logged into or started up`;
-      if (kind === 'system_logout') return `${deviceName} was logged out of or shut down`;
-      if (kind === 'suspend_detected') {
-        const durationMs = typeof d.duration_ms === 'number' ? d.duration_ms : undefined;
-        if (durationMs === undefined) return `${deviceName} was asleep for a while`;
-        const minutes = Math.round(durationMs / 60_000);
-        const durationLabel = minutes >= 1 ? `${minutes} min` : `${Math.round(durationMs / 1000)}s`;
-        return `${deviceName} was asleep for ${durationLabel}`;
-      }
-      return `Lifecycle event on ${deviceName}`;
-    }
-    case 'lifecycle_alert': {
-      const reason = d.reason as string | undefined;
-      if (reason === 'user_stop') return `Monitoring stopped by user on ${deviceName}`;
-      if (reason === 'unexpected_start') return `Unexpected restart detected on ${deviceName}`;
-      if (reason === 'unexpected_gap') return `Monitoring gap detected on ${deviceName}`;
-      if (reason === 'unexpected_stop') return `Process stopped unexpectedly on ${deviceName}`;
-      return `Alert on ${deviceName}`;
-    }
-    case 'screenshot':
-      return `Screenshot captured on ${deviceName}`;
-    case 'screenshot_skipped': {
-      const reason = d.reason as string | undefined;
-      if (reason === 'static_screen') return `Duplicate screenshot skipped on ${deviceName}`;
-      if (reason === 'locked_or_screensaver')
-        return `Screen locked, screenshot skipped on ${deviceName}`;
-      return `Screenshot skipped on ${deviceName}`;
-    }
-    case 'alert': {
-      const message = d.message as string | undefined;
-      return message ?? `Alert on ${deviceName}`;
-    }
-    case 'capture_failed':
-      return `Capture failed repeatedly on ${deviceName}`;
-    case 'dev': {
-      const title = d.title as string | undefined;
-      const details = d.details as string | undefined;
-      return title ? (details ? `${title}: ${details}` : title) : `Developer log on ${deviceName}`;
-    }
-    default:
-      return `Event on ${deviceName}`;
-  }
+  const key = getLogCaseKey(log);
+  if (key === 'unknown') return `Event on ${deviceName}`;
+  return LOG_KIND_TABLE[key].message(deviceName, log.data);
 }
 
 export const LOG_TYPES = [
@@ -124,6 +230,7 @@ export const LOG_TYPES = [
   'alert',
   'capture_failed',
   'dev',
+  'heartbeat',
 ] as const;
 
 const _dayLabelFmt = new Intl.DateTimeFormat(undefined, {


### PR DESCRIPTION
## Summary

- Fixes lifecycle logs showing generic labels ("Activity"/"Alert") instead of specific ones ("System Login", "Suspend Detected", etc.) by flattening `LifecycleKind`'s serde tag into the wire format the web viewer expects.
- Fixes heartbeats silently stopping after any daemon restart while already logged in — `HeartbeatModule::init` wasn't restoring the `authenticated` flag from saved state, unlike `UploadModule`.
- Fixes two local dev-only issues: `launch.sh` now rewrites stale batch urls in local D1 (they went stale because the random dev API port changes every run), and `seed-dev-user.mjs` now seeds a valid v4 UUID instead of one that failed `z.uuid()` validation on batch upload.

## Changes

<!-- Type of change: Bug fix -->
<!-- Components: Core, Web -->

- `client/core/src/model.rs`: `#[serde(tag = "kind")]` on `LifecycleKind`, `#[serde(flatten)]` on `UploadKind::Lifecycle.kind`; added serialization tests.
- `web/src/pages/Logs/shared.tsx` + `log-icons.tsx`/`.test.tsx` + `logs.test.tsx` + `index.tsx`/`LogsList.tsx`: consolidated type/kind/reason branching into a single `getLogCaseKey` used by both label and icon lookups.
- `client/core/src/module/heartbeat.rs`: persist `authenticated` on `HeartbeatObserverState`, restore it in `init`; added regression test.
- `scripts/launch.sh`: rewrite locally-stored batch urls to the current session's `R2_URL` on startup.
- `scripts/seed-dev-user.mjs`: use a valid v4 UUID for the seeded dev user id.

## Testing

- [x] `cargo test -p virtue-core` and `cargo test -p virtue-core --features testing --test scenarios` — 126 + 17 passed
- [x] `cargo test -p virtue-linux` — 32 passed
- [x] `cargo clippy -p virtue-core --all-targets -- -D warnings` / `cargo clippy -p virtue-linux --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `npm test -- --run` (web) — 102 passed
- [x] `npm run typecheck` / `npm run format:check` / `npm run build` (web) — clean
- [x] Manually reproduced the stale-batch-url dev issue against local D1 state and verified `launch.sh`'s rewrite fixes it
- [x] Manually re-seeded the dev user locally and confirmed the new UUID passes `z.uuid()`
- [x] (Human) Manually tested the web labels, see below

<img width="445" height="291" alt="image" src="https://github.com/user-attachments/assets/843f3322-072c-4b99-b3c0-b46b56e633e0" />
<img width="389" height="196" alt="image" src="https://github.com/user-attachments/assets/1437ccf2-4f26-4d43-a3f2-c20e27f14f42" />
