### PR TITLE
Auth routes cleanup: merge endpoints, close enumeration leaks, prefix tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,18 @@
 
 See `AGENTS.md` for how to run checks and tests for each component.
 
+## Local dev
+
+`./scripts/setup.sh` — one-time: installs deps, copies `.dev.vars`, runs local D1 migrations, installs/trusts Caddy.
+
+`./scripts/launch.sh [--donate] [domain]` — starts `api`, `web`, and `landing` dev servers together (interleaved colored logs), each on a random free port:
+
+- No `domain` arg: plain `http://localhost:<port>` for each service (ports differ per run — see the script's own startup banner). This is enough for most manual testing; browsers treat `http://localhost` as a secure context, so the API's `Secure` session cookie still gets set and sent.
+- With a `domain` arg (e.g. `./scripts/launch.sh myfeature`): registers `https://app.<domain>.localhost`, `https://<domain>.localhost`, etc. via the local Caddy instance (requires `setup.sh` to have run), mimicking the production URL structure.
+- `--donate` also starts `api-donate` and forwards Stripe webhooks to it if the `stripe` CLI is available.
+
+`EMAIL_DELIVERY_MODE=log` in `api/.dev.vars` means outgoing emails aren't sent — they're printed to the `[api]`-prefixed dev-server log (subject/text/html/metadata), including the token-bearing links. That's the way to find a signup/email-change/password-reset link during local testing.
+
 ## Cross-component contracts
 
 These five things are implemented independently in both Rust (`client/core/`) and TypeScript (`web/`) and **must stay bit-for-bit compatible**. If you change one side, you must change the other to match.

--- a/api/API.md
+++ b/api/API.md
@@ -11,7 +11,7 @@ Base URL examples:
 - `DateTime`: millisecond Unix timestamp
 - `Base64`: base64-encoded binary
 - `SHA256`: lowercase hex-encoded SHA-256 digest
-- `RefreshToken`: opaque web-session string. Set as the HTTPOnly `refresh_token` cookie by `POST /login`, `POST /signup`, and `POST /email-verification/validate`, and also returned in the `POST /login` body.
+- `RefreshToken`: opaque web-session string, prefixed by purpose (e.g. `wst_...`). Set as the HTTPOnly `refresh_token` cookie by `POST /login`, `POST /signup`, and `POST /email-verification/validate`.
 - `HashServerToken`: EdDSA JWT (`Ed25519`) with `type: "hash-server"` and `sub = device id`; minted by `POST /d/device`, `GET /d/device`, and `POST /d/batch`
 - `DeviceRefreshToken`: opaque string returned by `POST /d/device`
 - `ServerToken`: EdDSA JWT (`Ed25519`) with `type: "server"` and `sub = device id`
@@ -46,7 +46,7 @@ Base URL examples:
   },
   "name": "Name" | undefined,
   "pub_key": Base64 | undefined,
-  "priv_key": Base64 | undefined
+  "encrypted_priv_key": Base64 | undefined
 }
 ```
 
@@ -111,16 +111,6 @@ Response `200`:
 }
 ```
 
-### `GET /current-hash-params`
-
-Returns the current client password-derivation settings.
-
-Response `200`:
-
-```js
-HashParams;
-```
-
 ### `GET /.well-known/jwks.json`
 
 Returns the public signing key in JWKS form for remote JWT verification.
@@ -144,10 +134,19 @@ Response `200`:
 
 ### `GET /user/login-material?email=user@example.com`
 
-Returns a login salt and the current hash params. The response shape is the same for existing and
-non-existing users.
+Returns the current client password-derivation settings, and — when `email` is provided — a login
+salt for that email. The response shape is the same for existing and non-existing users (a decoy
+salt is returned for unknown emails, for enumeration resistance).
 
-Response `200`:
+Response `200` (no `email`):
+
+```js
+{
+  "params": HashParams
+}
+```
+
+Response `200` (with `email`):
 
 ```js
 {
@@ -178,7 +177,10 @@ Notes:
 - Stores a short-lived pending signup token (`email_tokens` row with `purpose='signup'` and `user_id=NULL`).
 - Sends a verification email with a link to `/finish-signup?token=...`.
 - Does **not** create a user account.
-- Returns `409` if an account already exists for the email.
+- Never returns a distinct status for an already-registered email (enumeration-safe). If an
+  account already exists, no token is issued; instead a notice email is sent to the existing
+  account telling them someone tried to sign up with their address. The response is always
+  `{ "ok": true }`.
 
 ### `POST /signup`
 
@@ -190,7 +192,7 @@ Request:
   "password_auth": Base64,
   "password_salt": Base64,
   "pub_key": Base64,
-  "priv_key": Base64,
+  "encrypted_priv_key": Base64,
   "name": "Name" | undefined,
   "email_digest_minutes_utc": Number | undefined,
   "partner_invite_token": "opaque-string" | undefined
@@ -216,6 +218,9 @@ Notes:
 - Creates the account using `email` from the pending record + crypto material from the body.
 - Account is created with `email_verified = true`. Sets the `refresh_token` cookie (auto-login on signup).
 - The signup token is consumed on success.
+- If an account was created for this email in the window between `/signup-request` and `/signup`
+  (a token-redemption race), the token is consumed and the same generic `400` used for
+  expired/invalid tokens is returned — no distinct error, no new account created.
 - `partner_invite_token` is accepted for forwarding to the client and should be applied by the client through `POST /partner/accept` after signup.
 
 ### `POST /login`
@@ -234,12 +239,11 @@ Response `200`:
 
 ```js
 {
-  "ok": true,
-  "refresh_token": RefreshToken
+  "ok": true
 }
 ```
 
-Also sets the `refresh_token` cookie. If the credentials are valid but the account email is
+Also sets the `refresh_token` cookie (the only way this token is delivered). If the credentials are valid but the account email is
 unverified, returns `403` with:
 
 ```js
@@ -272,6 +276,9 @@ Notes:
 
 - Applies a pending `email_change` token; returns `400` for any other or expired token.
 - Also creates a web session and sets the `refresh_token` cookie (auto-login on verification).
+- If the target email was claimed by another account in the window between `PATCH /user` and
+  redemption (a race), the token is consumed, a notice is sent to the real owner, and the same
+  generic `400` is returned — no distinct error, no session created.
 
 ### `POST /logout`
 
@@ -301,7 +308,7 @@ Request:
   "name": "New Name" | undefined,
   "email_frequency": "none" | "alerts-only" | "daily" | "weekly" | undefined,
   "pub_key": Base64 | undefined,
-  "priv_key": Base64 | undefined
+  "encrypted_priv_key": Base64 | undefined
 }
 ```
 
@@ -320,13 +327,21 @@ Notes:
 - When `email` is changed, the user email is **not** updated immediately.
 - A pending `email_change` token is sent to the new address.
 - Submitting that token to `POST /email-verification/validate` applies the email update.
+- If the requested email is already in use by another account, no distinct error is returned —
+  the response looks identical to the success case (`email_verification_required: true`), but no
+  working verification token is issued for the requester. Instead, a notice is sent to the actual
+  owner of that email.
+- Name/settings/key-material fields are applied unconditionally, regardless of whether the email
+  change itself succeeds.
 
 ### `DELETE /user`
 
 Requires an authenticated web session (the `refresh_token` cookie, or `Bearer <RefreshToken>`).
 
-Permanently deletes the account and all of its stored batches. `confirm_email` must match the
-account email or the request returns `400`.
+Permanently deletes the account; D1 rows owned by the account (devices, batches, sessions, email
+tokens) cascade-delete along with it. `confirm_email` must match the account email or the request
+returns `400`. R2 batch blobs are **not** deleted inline — they age out independently via a bucket
+lifecycle rule, same as the general 30-day batch retention policy.
 
 Request:
 
@@ -379,7 +394,7 @@ Request:
   "password_auth": Base64,
   "password_salt": Base64,
   "pub_key": Base64,
-  "priv_key": Base64
+  "encrypted_priv_key": Base64
 }
 ```
 

--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -119,13 +119,13 @@ export async function findUserByEmail(db: D1Database, email: string) {
     email_bounced_at: number | null;
     settings: string;
     pub_key: ArrayBuffer | null;
-    priv_key: ArrayBuffer | null;
+    encrypted_priv_key: ArrayBuffer | null;
   }>(
     db
       .prepare(
         `SELECT id, email, password_hash, password_salt, password_params_version,
                 name, email_verified, email_bounced_at, settings,
-                pub_key, priv_key
+                pub_key, encrypted_priv_key
          FROM users
          WHERE email = ?`,
       )
@@ -145,12 +145,12 @@ export async function findUserById(db: D1Database, userId: string) {
     email_bounced_at: number | null;
     settings: string;
     pub_key: ArrayBuffer | null;
-    priv_key: ArrayBuffer | null;
+    encrypted_priv_key: ArrayBuffer | null;
   }>(
     db
       .prepare(
         `SELECT id, email, name, email_verified, email_bounced_at, settings,
-                pub_key, priv_key
+                pub_key, encrypted_priv_key
          FROM users
          WHERE id = ?`,
       )
@@ -211,7 +211,7 @@ export async function createUser(
     passwordSalt: ArrayBuffer;
     passwordParamsVersion: string;
     pub_key: ArrayBuffer;
-    priv_key: ArrayBuffer;
+    encrypted_priv_key: ArrayBuffer;
     name?: string;
   },
 ) {
@@ -220,7 +220,7 @@ export async function createUser(
       `INSERT INTO users (
         id, email, password_hash, password_salt, password_params_version,
         name, email_verified, settings,
-        pub_key, priv_key, created_at
+        pub_key, encrypted_priv_key, created_at
       ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?)`,
     )
     .bind(
@@ -232,7 +232,7 @@ export async function createUser(
       input.name ?? null,
       JSON.stringify({ email_frequency: 'daily', timezone: 'UTC' }),
       input.pub_key,
-      input.priv_key,
+      input.encrypted_priv_key,
       Date.now(),
     )
     .run();
@@ -251,7 +251,7 @@ export async function updateUser(
     email_bounced_at?: number | null;
     settings?: { email_frequency?: string; timezone?: string };
     pub_key?: ArrayBuffer;
-    priv_key?: ArrayBuffer;
+    encrypted_priv_key?: ArrayBuffer;
   },
 ) {
   const updates: string[] = [];
@@ -308,9 +308,9 @@ export async function updateUser(
     params.push(fields.pub_key);
   }
 
-  if (fields.priv_key !== undefined) {
-    updates.push('priv_key = ?');
-    params.push(fields.priv_key);
+  if (fields.encrypted_priv_key !== undefined) {
+    updates.push('encrypted_priv_key = ?');
+    params.push(fields.encrypted_priv_key);
   }
 
   if (updates.length === 0) {
@@ -995,11 +995,18 @@ export async function findEmailTokenByHash(db: D1Database, tokenHash: string, pu
   }>(purpose ? prepared.bind(tokenHash, purpose) : prepared.bind(tokenHash), ['id', 'user_id']);
 }
 
-export async function consumeEmailToken(db: D1Database, tokenId: string, consumedAt: number) {
-  return db
+export async function consumeEmailToken(
+  db: D1Database,
+  token: { id: string; user_id: string | null; purpose: string },
+  consumedAt: number,
+) {
+  await db
     .prepare('UPDATE email_tokens SET consumed_at = ? WHERE id = ? AND consumed_at IS NULL')
-    .bind(consumedAt, uuidToBytes(tokenId))
+    .bind(consumedAt, uuidToBytes(token.id))
     .run();
+  if (token.user_id) {
+    await invalidateEmailTokens(db, token.user_id, token.purpose);
+  }
 }
 
 export async function createSessionRecord(

--- a/api/src/lib/email-domain.ts
+++ b/api/src/lib/email-domain.ts
@@ -23,6 +23,8 @@ export const emailKinds = [
   'tamper_alert',
   'daily_digest',
   'weekly_digest',
+  'account_exists_notice',
+  'email_in_use_notice',
 ] as const;
 
 export type EmailKind = (typeof emailKinds)[number];

--- a/api/src/lib/email/templates.ts
+++ b/api/src/lib/email/templates.ts
@@ -277,6 +277,90 @@ export function renderPasswordResetTemplate(input: {
   };
 }
 
+export function renderAccountExistsTemplate(input: {
+  appName: string;
+  recipientName?: string | null;
+  loginUrl: string;
+  forgotPasswordUrl: string;
+  appUrl: string;
+}) {
+  const appName = normalizeAppName(input.appName);
+  const greeting = input.recipientName ? `Hi ${input.recipientName},` : 'Hi,';
+  const footer = withFooter({
+    appName,
+    appUrl: input.appUrl,
+    headline: 'Someone tried to sign up with your email',
+    textLines: [
+      greeting,
+      '',
+      `Someone just tried to create a new ${appName} account using this email address, but you already have one.`,
+      '',
+      `If this was you, log in instead: ${input.loginUrl}`,
+      `Forgot your password? Reset it here: ${input.forgotPasswordUrl}`,
+      '',
+      'If you did not expect this, you can safely ignore this email.',
+    ],
+    htmlSections: [
+      paragraph(greeting),
+      paragraph(
+        `Someone just tried to create a new ${appName} account using this email address, but you already have one.`,
+      ),
+      actionButton(input.loginUrl, 'Log in'),
+      `<p style="${inlineStyle({
+        margin: '0 0 16px 0',
+        color: EMAIL_COLORS.textMuted,
+        'font-size': '13px',
+        'line-height': '1.5',
+      })}">Forgot your password? ${themedLink(input.forgotPasswordUrl, 'Reset it here')}.</p>`,
+      paragraph('If you did not expect this, you can safely ignore this email.'),
+    ],
+  });
+
+  return {
+    subject: `Someone tried to sign up for ${appName.replace('The', '').trim()} with your email`,
+    text: footer.text,
+    html: footer.html,
+  };
+}
+
+export function renderEmailInUseTemplate(input: {
+  appName: string;
+  recipientName?: string | null;
+  forgotPasswordUrl: string;
+  appUrl: string;
+}) {
+  const appName = normalizeAppName(input.appName);
+  const greeting = input.recipientName ? `Hi ${input.recipientName},` : 'Hi,';
+  const footer = withFooter({
+    appName,
+    appUrl: input.appUrl,
+    headline: 'This email is already associated with an account',
+    textLines: [
+      greeting,
+      '',
+      `Someone tried to change a ${appName} account's email address to this one, but it's already associated with your account.`,
+      '',
+      `If you forgot your password, you can reset it here: ${input.forgotPasswordUrl}`,
+      '',
+      'If you did not expect this, you can safely ignore this email.',
+    ],
+    htmlSections: [
+      paragraph(greeting),
+      paragraph(
+        `Someone tried to change a ${appName} account's email address to this one, but it's already associated with your account.`,
+      ),
+      actionButton(input.forgotPasswordUrl, 'Reset password'),
+      paragraph('If you did not expect this, you can safely ignore this email.'),
+    ],
+  });
+
+  return {
+    subject: `This email is already in use on ${appName.replace('The', '').trim()}`,
+    text: footer.text,
+    html: footer.html,
+  };
+}
+
 export function renderPartnerInviteTemplate(input: {
   ownerName?: string | null;
   ownerEmail: string;

--- a/api/src/lib/tokens.ts
+++ b/api/src/lib/tokens.ts
@@ -1,9 +1,32 @@
 import { createHash, randomBytes } from 'node:crypto';
 
-export function generateOpaqueToken() {
-  return randomBytes(24).toString('base64url');
+export type TokenPurpose =
+  | 'web_session'
+  | 'device_session'
+  | 'signup'
+  | 'email_change'
+  | 'password_reset'
+  | 'partner_invite';
+
+const TOKEN_PREFIXES: Record<TokenPurpose, string> = {
+  web_session: 'wst_',
+  device_session: 'dst_',
+  signup: 'sut_',
+  email_change: 'ect_',
+  password_reset: 'prt_',
+  partner_invite: 'pit_',
+};
+
+export function generateOpaqueToken(purpose: TokenPurpose) {
+  return `${TOKEN_PREFIXES[purpose]}${randomBytes(24).toString('base64url')}`;
 }
 
 export function hashOpaqueToken(token: string) {
   return createHash('sha256').update(token).digest('hex');
+}
+
+export function assertTokenPurpose(token: string, purpose: TokenPurpose) {
+  if (!token.startsWith(TOKEN_PREFIXES[purpose])) {
+    throw new Error(`Invalid token purpose: expected ${purpose}`);
+  }
 }

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { getCookie } from 'hono/cookie';
 import { Env, Variables } from '../types/bindings';
 import { JWTType, verifyJWT } from '../lib/jwt';
 import { findSessionByRefreshTokenHash } from '../lib/db';
-import { hashOpaqueToken } from '../lib/tokens';
+import { assertTokenPurpose, hashOpaqueToken } from '../lib/tokens';
 
 export function authenticate(type: JWTType | JWTType[]) {
   const allowed = Array.isArray(type) ? type : [type];
@@ -48,6 +48,12 @@ export function authenticateWebSession() {
       return c.json({ error: 'Unauthorized' }, 401);
     }
 
+    try {
+      assertTokenPurpose(refreshToken, 'web_session');
+    } catch {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
     const session = await findSessionByRefreshTokenHash(
       c.env.DB,
       hashOpaqueToken(refreshToken),
@@ -74,6 +80,12 @@ export function authenticateDeviceSession() {
     }
 
     const token = authHeader.slice(7);
+    try {
+      assertTokenPurpose(token, 'device_session');
+    } catch {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
     const session = await findSessionByRefreshTokenHash(c.env.DB, hashOpaqueToken(token), 'device');
 
     if (!session || !session.device_id || session.expires_at < Date.now()) {

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Context, Hono } from 'hono';
 import { getCookie, deleteCookie, setCookie } from 'hono/cookie';
 import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
 import { authenticateWebSession } from '../middleware/auth';
 import { validateZ } from '../middleware/validation';
 import {
@@ -13,11 +14,12 @@ import {
   findUserByEmail,
   findUserById,
   invalidateEmailTokens,
-  listBatchUrlsForUser,
   updateUser,
   consumeEmailToken,
 } from '../lib/db';
 import {
+  renderAccountExistsTemplate,
+  renderEmailInUseTemplate,
   renderEmailVerificationTemplate,
   renderPasswordResetTemplate,
 } from '../lib/email/templates';
@@ -45,9 +47,8 @@ import {
   generatePasswordSalt,
   hashPasswordAuth,
 } from '../lib/password';
-import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
+import { assertTokenPurpose, generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
-import { deleteObject } from '../lib/r2';
 import { verifyUserCredentials } from '../lib/credentials';
 
 const auth = new Hono<{ Bindings: Env; Variables: Variables }>();
@@ -64,47 +65,55 @@ function buildHashParamsResponse() {
   };
 }
 
-function decodeRequiredBase64(value: string, field: string) {
-  const decoded = decodeBase64(value);
-  if (new Uint8Array(decoded).byteLength === 0) {
-    throw new Error(`${field} must not be empty`);
-  }
-  return decoded;
+// Base64 decode + byte-length validation, layered on top of the wire-level
+// `z.base64()` string schemas in shared-web/types.ts (which stay strings since
+// web serializes these fields as JSON).
+function base64Bytes(length: number, label: string) {
+  return z.base64().transform((value, ctx) => {
+    const decoded = decodeBase64(value);
+    if (new Uint8Array(decoded).byteLength !== length) {
+      ctx.addIssue({ code: 'custom', message: `${label} must be ${length} bytes` });
+      return z.NEVER;
+    }
+    return decoded;
+  });
 }
 
-function decodePasswordSalt(value: string) {
-  const decoded = decodeRequiredBase64(value, 'password_salt');
-  if (new Uint8Array(decoded).byteLength !== CURRENT_HASH_PARAMS.salt_length) {
-    throw new Error(`password_salt must be ${CURRENT_HASH_PARAMS.salt_length} bytes`);
-  }
-  return decoded;
+function base64NonEmpty(label: string) {
+  return z.base64().transform((value, ctx) => {
+    const decoded = decodeBase64(value);
+    if (new Uint8Array(decoded).byteLength === 0) {
+      ctx.addIssue({ code: 'custom', message: `${label} must not be empty` });
+      return z.NEVER;
+    }
+    return decoded;
+  });
 }
 
-function decodePasswordAuth(value: string) {
-  const decoded = decodeRequiredBase64(value, 'password_auth');
-  if (new Uint8Array(decoded).byteLength !== 32) {
-    throw new Error('password_auth must be 32 bytes');
-  }
-  return decoded;
-}
+const keyMaterialSchema = z.object({
+  password_auth: base64Bytes(32, 'password_auth'),
+  password_salt: base64Bytes(CURRENT_HASH_PARAMS.salt_length, 'password_salt'),
+  pub_key: base64Bytes(32, 'pub_key'),
+  encrypted_priv_key: base64NonEmpty('encrypted_priv_key'),
+});
 
-function decodePublicKey(value: string) {
-  const decoded = decodeRequiredBase64(value, 'pub_key');
-  if (new Uint8Array(decoded).byteLength !== 32) {
-    throw new Error('pub_key must be 32 bytes');
-  }
-  return decoded;
-}
+const updateKeyMaterialSchema = z.object({
+  pub_key: base64Bytes(32, 'pub_key').optional(),
+  encrypted_priv_key: base64NonEmpty('encrypted_priv_key').optional(),
+});
 
-function badRequest(c: Context<{ Bindings: Env; Variables: Variables }>, message: string) {
-  return c.json({ error: 'Bad Request', details: { errors: [message] } }, 400);
+function invalidRequestData(
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  error: z.ZodError,
+) {
+  return c.json({ error: 'Invalid request data', details: z.treeifyError(error) }, 400);
 }
 
 async function createSession(
   c: Context<{ Bindings: Env; Variables: Variables }>,
   userId: string,
 ): Promise<string> {
-  const refreshToken = generateOpaqueToken();
+  const refreshToken = generateOpaqueToken('web_session');
   const now = Date.now();
 
   await createSessionRecord(c.env.DB, {
@@ -133,7 +142,7 @@ async function issueEmailToken(
   ttlMs: number,
 ) {
   await invalidateEmailTokens(db, user.id, purpose);
-  const token = generateOpaqueToken();
+  const token = generateOpaqueToken(purpose);
   const now = Date.now();
 
   await createEmailToken(db, {
@@ -205,6 +214,58 @@ async function sendSignupConfirmationEmail(
   });
 }
 
+async function sendAccountExistsEmail(
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  user: { id: string; email: string; name?: string | null },
+) {
+  const loginUrl = `${c.env.APP_URL}/login`;
+  const forgotPasswordUrl = `${c.env.APP_URL}/forgot-password`;
+  const email = renderAccountExistsTemplate({
+    appName: c.env.APP_NAME,
+    appUrl: c.env.APP_URL,
+    recipientName: user.name,
+    loginUrl,
+    forgotPasswordUrl,
+  });
+
+  await sendEmail({
+    env: c.env,
+    db: c.env.DB,
+    kind: 'account_exists_notice',
+    recipient: user.email,
+    subject: email.subject,
+    text: email.text,
+    html: email.html,
+    related_user_id: user.id,
+    metadata: { purpose: 'account_exists', loginUrl, forgotPasswordUrl },
+  });
+}
+
+async function sendEmailInUseNotice(
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  user: { id: string; email: string; name?: string | null },
+) {
+  const forgotPasswordUrl = `${c.env.APP_URL}/forgot-password`;
+  const email = renderEmailInUseTemplate({
+    appName: c.env.APP_NAME,
+    appUrl: c.env.APP_URL,
+    recipientName: user.name,
+    forgotPasswordUrl,
+  });
+
+  await sendEmail({
+    env: c.env,
+    db: c.env.DB,
+    kind: 'email_in_use_notice',
+    recipient: user.email,
+    subject: email.subject,
+    text: email.text,
+    html: email.html,
+    related_user_id: user.id,
+    metadata: { purpose: 'email_in_use', forgotPasswordUrl },
+  });
+}
+
 async function sendPasswordResetEmail(
   c: Context<{ Bindings: Env; Variables: Variables }>,
   user: { id: string; email: string; name?: string | null },
@@ -234,8 +295,14 @@ async function sendPasswordResetEmail(
 async function getValidTokenRecord(
   db: D1Database,
   rawToken: string,
-  purpose?: 'email_change' | 'password_reset' | 'signup',
+  purpose: 'email_change' | 'password_reset' | 'signup',
 ) {
+  try {
+    assertTokenPurpose(rawToken, purpose);
+  } catch {
+    return null;
+  }
+
   const token = await findEmailTokenByHash(db, hashOpaqueToken(rawToken), purpose);
   if (!token || token.consumed_at || token.expires_at < Date.now()) {
     return null;
@@ -246,10 +313,13 @@ async function getValidTokenRecord(
   return token;
 }
 
-auth.get('/current-hash-params', async (c) => c.json(buildHashParamsResponse()));
-
 auth.get('/user/login-material', validateZ('query', loginMaterialQuerySchema), async (c) => {
   const { email } = c.req.valid('query');
+
+  if (!email) {
+    return c.json({ params: buildHashParamsResponse() });
+  }
+
   const user = await findUserByEmail(c.env.DB, email.trim().toLowerCase());
 
   return c.json({
@@ -264,10 +334,11 @@ auth.post('/signup-request', validateZ('json', signupRequestSchema), async (c) =
   const existingUser = await findUserByEmail(c.env.DB, normalizedEmail);
 
   if (existingUser) {
-    return c.json({ error: 'An account already exists for that email' }, 409);
+    await sendAccountExistsEmail(c, existingUser);
+    return c.json({ ok: true });
   }
 
-  const token = generateOpaqueToken();
+  const token = generateOpaqueToken('signup');
   const now = Date.now();
 
   await createEmailToken(c.env.DB, {
@@ -288,7 +359,7 @@ auth.post('/signup-request', validateZ('json', signupRequestSchema), async (c) =
 });
 
 auth.post('/signup', validateZ('json', signupSchema), async (c) => {
-  const { verification_token, password_auth, password_salt, pub_key, priv_key, name } =
+  const { verification_token, password_auth, password_salt, pub_key, encrypted_priv_key, name } =
     c.req.valid('json');
 
   const record = await getValidTokenRecord(c.env.DB, verification_token, 'signup');
@@ -300,39 +371,39 @@ auth.post('/signup', validateZ('json', signupSchema), async (c) => {
   const existingUser = await findUserByEmail(c.env.DB, normalizedEmail);
 
   if (existingUser) {
-    return c.json({ error: 'An account already exists for that email' }, 409);
+    // Someone else already claimed this email between /signup-request and now.
+    // /signup-request already notified the account owner, so just burn the
+    // token and report the same generic failure — no fresh leak here.
+    await consumeEmailToken(c.env.DB, record, Date.now());
+    return c.json({ error: 'Invalid or expired verification token' }, 400);
   }
 
-  let decodedPasswordAuth: ArrayBuffer;
-  let decodedPasswordSalt: ArrayBuffer;
-  let decodedPublicKey: ArrayBuffer;
-  let decodedPrivateKey: ArrayBuffer;
-
-  try {
-    decodedPasswordAuth = decodePasswordAuth(password_auth);
-    decodedPasswordSalt = decodePasswordSalt(password_salt);
-    decodedPublicKey = decodePublicKey(pub_key);
-    decodedPrivateKey = decodeRequiredBase64(priv_key, 'priv_key');
-  } catch (error) {
-    return badRequest(c, error instanceof Error ? error.message : 'Invalid signup payload');
+  const decoded = keyMaterialSchema.safeParse({
+    password_auth,
+    password_salt,
+    pub_key,
+    encrypted_priv_key,
+  });
+  if (!decoded.success) {
+    return invalidRequestData(c, decoded.error);
   }
 
   const userId = uuidv4();
-  const passwordHash = await hashPasswordAuth(decodedPasswordAuth);
+  const passwordHash = await hashPasswordAuth(decoded.data.password_auth);
 
   await createUser(c.env.DB, {
     id: userId,
     email: normalizedEmail,
     passwordHash,
-    passwordSalt: decodedPasswordSalt,
+    passwordSalt: decoded.data.password_salt,
     passwordParamsVersion: HASH_PARAMS_VERSION,
-    pub_key: decodedPublicKey,
-    priv_key: decodedPrivateKey,
+    pub_key: decoded.data.pub_key,
+    encrypted_priv_key: decoded.data.encrypted_priv_key,
     name,
   });
 
   await updateUser(c.env.DB, userId, { email_verified: true });
-  await consumeEmailToken(c.env.DB, record.id, Date.now());
+  await consumeEmailToken(c.env.DB, record, Date.now());
 
   await createSession(c, userId);
 
@@ -367,14 +438,19 @@ auth.post('/login', validateZ('json', loginSchema), async (c) => {
     await updateUser(c.env.DB, user.id, { settings: { timezone } });
   }
 
-  const refresh_token = await createSession(c, user.id);
-  return c.json({ ok: true, refresh_token });
+  await createSession(c, user.id);
+  return c.json({ ok: true });
 });
 
 auth.post('/logout', async (c) => {
   const refreshToken = getCookie(c, 'refresh_token');
   if (refreshToken) {
-    await deleteSessionByRefreshTokenHash(c.env.DB, hashOpaqueToken(refreshToken), 'web');
+    try {
+      assertTokenPurpose(refreshToken, 'web_session');
+      await deleteSessionByRefreshTokenHash(c.env.DB, hashOpaqueToken(refreshToken), 'web');
+    } catch {
+      // Malformed or foreign-purpose token — nothing to delete.
+    }
   }
   deleteCookie(c, 'refresh_token', { path: '/' });
   return c.body(null, 204);
@@ -395,13 +471,15 @@ auth.get('/user', authenticateWebSession(), async (c) => {
     settings: user.settings,
     ...(user.name ? { name: user.name } : {}),
     ...(user.pub_key ? { pub_key: encodeBase64(user.pub_key) } : {}),
-    ...(user.priv_key ? { priv_key: encodeBase64(user.priv_key) } : {}),
+    ...(user.encrypted_priv_key
+      ? { encrypted_priv_key: encodeBase64(user.encrypted_priv_key) }
+      : {}),
   });
 });
 
 auth.patch('/user', authenticateWebSession(), validateZ('json', updateUserSchema), async (c) => {
   const userId = c.get('sub');
-  const { email, name, settings, pub_key, priv_key } = c.req.valid('json');
+  const { email, name, settings, pub_key, encrypted_priv_key } = c.req.valid('json');
   const normalizedEmail = email?.trim().toLowerCase();
   const user = await findUserById(c.env.DB, userId);
 
@@ -409,47 +487,43 @@ auth.patch('/user', authenticateWebSession(), validateZ('json', updateUserSchema
     return c.json({ error: 'User account not found' }, 404);
   }
 
-  const emailChanged = Boolean(normalizedEmail && normalizedEmail !== user.email);
-  if (emailChanged) {
-    const existingUser = await findUserByEmail(c.env.DB, normalizedEmail!);
-    if (existingUser && existingUser.id !== userId) {
-      return c.json({ error: 'Email is already in use' }, 409);
-    }
-  }
-
-  let decodedPublicKey: ArrayBuffer | undefined;
-  let decodedPrivateKey: ArrayBuffer | undefined;
-
-  try {
-    decodedPublicKey = pub_key ? decodePublicKey(pub_key) : undefined;
-    decodedPrivateKey = priv_key ? decodeRequiredBase64(priv_key, 'priv_key') : undefined;
-  } catch (error) {
-    return badRequest(c, error instanceof Error ? error.message : 'Invalid user update payload');
+  const decoded = updateKeyMaterialSchema.safeParse({ pub_key, encrypted_priv_key });
+  if (!decoded.success) {
+    return invalidRequestData(c, decoded.error);
   }
 
   await updateUser(c.env.DB, userId, {
     name,
     settings,
-    pub_key: decodedPublicKey,
-    priv_key: decodedPrivateKey,
+    pub_key: decoded.data.pub_key,
+    encrypted_priv_key: decoded.data.encrypted_priv_key,
   });
 
+  const emailChanged = Boolean(normalizedEmail && normalizedEmail !== user.email);
   if (emailChanged) {
-    const verificationToken = await issueEmailToken(
-      c.env.DB,
-      { id: userId, email: normalizedEmail! },
-      'email_change',
-      EMAIL_VERIFICATION_TTL_MS,
-    );
-    await sendVerificationEmail(
-      c,
-      {
-        id: userId,
-        email: normalizedEmail!,
-        name: name ?? user.name,
-      },
-      verificationToken,
-    );
+    const existingUser = await findUserByEmail(c.env.DB, normalizedEmail!);
+    if (existingUser && existingUser.id !== userId) {
+      // Don't issue a real verification token — just let the actual owner
+      // know, and tell the requester the same thing a successful request
+      // would say (mirrors POST /password-reset's generic 204 pattern).
+      await sendEmailInUseNotice(c, existingUser);
+    } else {
+      const verificationToken = await issueEmailToken(
+        c.env.DB,
+        { id: userId, email: normalizedEmail! },
+        'email_change',
+        EMAIL_VERIFICATION_TTL_MS,
+      );
+      await sendVerificationEmail(
+        c,
+        {
+          id: userId,
+          email: normalizedEmail!,
+          name: name ?? user.name,
+        },
+        verificationToken,
+      );
+    }
   }
 
   return c.json<UpdateUserResponse>({
@@ -476,16 +550,9 @@ auth.delete('/user', authenticateWebSession(), validateZ('json', deleteUserSchem
     return c.json({ error: 'Confirmation email does not match your account email' }, 400);
   }
 
-  const batchUrls = await listBatchUrlsForUser(c.env.DB, userId);
+  // R2 batch blobs age out via a bucket lifecycle rule independent of D1 row
+  // lifetime, so there's nothing to clean up here beyond the cascading D1 delete.
   await deleteUserById(c.env.DB, userId);
-
-  const r2Prefix = `${c.env.R2_URL}/`;
-  await Promise.all(
-    batchUrls
-      .map((batch) => batch.url)
-      .filter((url) => url.startsWith(r2Prefix))
-      .map((url) => deleteObject(c.env, url.slice(r2Prefix.length))),
-  );
 
   deleteCookie(c, 'refresh_token', { path: '/' });
   return c.body(null, 204);
@@ -493,9 +560,9 @@ auth.delete('/user', authenticateWebSession(), validateZ('json', deleteUserSchem
 
 auth.post('/email-verification/validate', validateZ('json', verifyEmailSchema), async (c) => {
   const { token } = c.req.valid('json');
-  const record = await getValidTokenRecord(c.env.DB, token);
+  const record = await getValidTokenRecord(c.env.DB, token, 'email_change');
 
-  if (!record || !record.user_id || record.purpose !== 'email_change') {
+  if (!record || !record.user_id) {
     return c.json({ error: 'Invalid or expired token' }, 400);
   }
 
@@ -503,7 +570,9 @@ auth.post('/email-verification/validate', validateZ('json', verifyEmailSchema), 
 
   const existingUser = await findUserByEmail(c.env.DB, record.email);
   if (existingUser && existingUser.id !== userId) {
-    return c.json({ error: 'Email is already in use' }, 409);
+    await consumeEmailToken(c.env.DB, record, Date.now());
+    await sendEmailInUseNotice(c, existingUser);
+    return c.json({ error: 'Invalid or expired token' }, 400);
   }
 
   await updateUser(c.env.DB, userId, {
@@ -511,8 +580,7 @@ auth.post('/email-verification/validate', validateZ('json', verifyEmailSchema), 
     email_verified: true,
     email_bounced_at: null,
   });
-  await consumeEmailToken(c.env.DB, record.id, Date.now());
-  await invalidateEmailTokens(c.env.DB, userId, 'email_change');
+  await consumeEmailToken(c.env.DB, record, Date.now());
 
   await createSession(c, userId);
 
@@ -554,7 +622,7 @@ auth.post('/password-reset/validate', validateZ('json', passwordResetValidateSch
 });
 
 auth.post('/password-reset/finalize', validateZ('json', passwordResetSchema), async (c) => {
-  const { token, password_auth, password_salt, pub_key, priv_key } = c.req.valid('json');
+  const { token, password_auth, password_salt, pub_key, encrypted_priv_key } = c.req.valid('json');
   const record = await getValidTokenRecord(c.env.DB, token, 'password_reset');
 
   if (!record || !record.user_id) {
@@ -566,29 +634,24 @@ auth.post('/password-reset/finalize', validateZ('json', passwordResetSchema), as
     return c.json({ error: 'Invalid or expired token' }, 400);
   }
 
-  let decodedPasswordAuth: ArrayBuffer;
-  let decodedPasswordSalt: ArrayBuffer;
-  let decodedPublicKey: ArrayBuffer;
-  let decodedPrivateKey: ArrayBuffer;
-
-  try {
-    decodedPasswordAuth = decodePasswordAuth(password_auth);
-    decodedPasswordSalt = decodePasswordSalt(password_salt);
-    decodedPublicKey = decodePublicKey(pub_key);
-    decodedPrivateKey = decodeRequiredBase64(priv_key, 'priv_key');
-  } catch (error) {
-    return badRequest(c, error instanceof Error ? error.message : 'Invalid password reset payload');
+  const decoded = keyMaterialSchema.safeParse({
+    password_auth,
+    password_salt,
+    pub_key,
+    encrypted_priv_key,
+  });
+  if (!decoded.success) {
+    return invalidRequestData(c, decoded.error);
   }
 
   await updateUser(c.env.DB, record.user_id, {
-    password_hash: await hashPasswordAuth(decodedPasswordAuth),
-    password_salt: decodedPasswordSalt,
+    password_hash: await hashPasswordAuth(decoded.data.password_auth),
+    password_salt: decoded.data.password_salt,
     password_params_version: HASH_PARAMS_VERSION,
-    pub_key: decodedPublicKey,
-    priv_key: decodedPrivateKey,
+    pub_key: decoded.data.pub_key,
+    encrypted_priv_key: decoded.data.encrypted_priv_key,
   });
-  await consumeEmailToken(c.env.DB, record.id, Date.now());
-  await invalidateEmailTokens(c.env.DB, record.user_id, 'password_reset');
+  await consumeEmailToken(c.env.DB, record, Date.now());
 
   return c.json({ ok: true });
 });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -65,9 +65,9 @@ function buildHashParamsResponse() {
   };
 }
 
-// Base64 decode + byte-length validation, layered on top of the wire-level
-// `z.base64()` string schemas in shared-web/types.ts (which stay strings since
-// web serializes these fields as JSON).
+// Decodes a base64 field and rejects it unless it's exactly `length` bytes,
+// replacing the old hand-rolled decode+length checks with a Zod schema so
+// failures get the same aggregated error shape as the rest of the API.
 function base64Bytes(length: number, label: string) {
   return z.base64().transform((value, ctx) => {
     const decoded = decodeBase64(value);

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -71,7 +71,7 @@ async function createDeviceSession(
   c: Context<{ Bindings: Env; Variables: Variables }>,
   deviceId: string,
 ) {
-  const refreshToken = generateOpaqueToken();
+  const refreshToken = generateOpaqueToken('device_session');
   const now = Date.now();
 
   await createSessionRecord(c.env.DB, {

--- a/api/src/routes/partners.ts
+++ b/api/src/routes/partners.ts
@@ -30,7 +30,7 @@ import {
   type CreatePartnerResponse,
 } from '../../../shared-web/types';
 import { sendEmail } from '../lib/email';
-import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
+import { assertTokenPurpose, generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
 
 const partners = new Hono<{ Bindings: Env; Variables: Variables }>();
@@ -69,7 +69,7 @@ partners.post(
     const id = uuidv4();
     const inviteTokenId = uuidv4();
     const now = Date.now();
-    const inviteToken = generateOpaqueToken();
+    const inviteToken = generateOpaqueToken('partner_invite');
     const inviteTokenHash = hashOpaqueToken(inviteToken);
 
     await createEmailToken(c.env.DB, {
@@ -116,6 +116,13 @@ partners.post(
 
 partners.post('/partner/validate', validateZ('json', inviteTokenSchema), async (c) => {
   const { token } = c.req.valid('json');
+
+  try {
+    assertTokenPurpose(token, 'partner_invite');
+  } catch {
+    return c.json({ error: 'Invalid or expired invite' }, 400);
+  }
+
   const invite = await findPartnerByInviteTokenHash(c.env.DB, hashOpaqueToken(token));
 
   if (
@@ -152,6 +159,13 @@ partners.post(
     const userId = c.get('sub');
     const currentUser = await findUserById(c.env.DB, userId);
     const { token } = c.req.valid('json');
+
+    try {
+      assertTokenPurpose(token, 'partner_invite');
+    } catch {
+      return c.json({ error: 'Invalid or expired invite' }, 400);
+    }
+
     const invite = await findPartnerByInviteTokenHash(c.env.DB, hashOpaqueToken(token));
 
     if (!currentUser || !invite) {
@@ -195,7 +209,11 @@ partners.post(
       updated_at: Date.now(),
     });
     if (invite.invite_token_id) {
-      await consumeEmailToken(c.env.DB, invite.invite_token_id, Date.now());
+      await consumeEmailToken(
+        c.env.DB,
+        { id: invite.invite_token_id, user_id: null, purpose: 'partner_invite' },
+        Date.now(),
+      );
     }
 
     const owner = await findUserById(c.env.DB, invite.watching_user_id);

--- a/api/src/schema/migrations/0010_rename_priv_key.sql
+++ b/api/src/schema/migrations/0010_rename_priv_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN priv_key TO encrypted_priv_key;

--- a/api/test/auth-routes.test.ts
+++ b/api/test/auth-routes.test.ts
@@ -614,8 +614,8 @@ describe('Auth routes', () => {
     expect(unprefixedRes.status).toBe(401);
 
     const { id: deviceRefreshToken } = await (async () => {
-      const { cookie } = await signupAndGetCookie('device-owner@example.com', 'pw');
-      const device = await createDeviceForUser(cookie, 'Laptop', 'linux');
+      await signupAndGetCookie('device-owner@example.com', 'pw');
+      const device = await createDeviceForUser('device-owner@example.com', 'pw', 'Laptop', 'linux');
       return { id: device.refresh_token };
     })();
 

--- a/api/test/auth-routes.test.ts
+++ b/api/test/auth-routes.test.ts
@@ -21,12 +21,17 @@ import { CURRENT_HASH_PARAMS, verifyPasswordAuth } from '../src/lib/password';
 beforeEach(clearDB);
 
 describe('Auth routes', () => {
-  it('returns the current hash params and login material in an enumeration-safe shape', async () => {
+  it('returns current hash params with no email, and login material in an enumeration-safe shape with one', async () => {
     await signupAndGetCookie('alice@example.com', 'correct horse');
 
-    const paramsRes = await SELF.fetch(`${BASE}/current-hash-params`);
+    const paramsRes = await SELF.fetch(`${BASE}/user/login-material`);
     expect(paramsRes.status).toBe(200);
-    expect(await paramsRes.json()).toMatchObject({
+    const paramsBody = (await paramsRes.json()) as {
+      password_salt?: string;
+      params: { salt_length: number };
+    };
+    expect(paramsBody.password_salt).toBeUndefined();
+    expect(paramsBody.params).toMatchObject({
       version: CURRENT_HASH_PARAMS.version,
       algorithm: CURRENT_HASH_PARAMS.algorithm,
       memory_cost_kib: CURRENT_HASH_PARAMS.memory_cost_kib,
@@ -99,7 +104,7 @@ describe('Auth routes', () => {
         password_auth,
         password_salt,
         pub_key,
-        priv_key,
+        encrypted_priv_key: priv_key,
         name: 'Alice',
       }),
     });
@@ -116,7 +121,7 @@ describe('Auth routes', () => {
     });
 
     const storedUser = await env.DB.prepare(
-      'SELECT id, email_verified, password_hash, password_salt, pub_key, priv_key FROM users WHERE email = ?',
+      'SELECT id, email_verified, password_hash, password_salt, pub_key, encrypted_priv_key FROM users WHERE email = ?',
     )
       .bind('alice@example.com')
       .first<{
@@ -125,7 +130,7 @@ describe('Auth routes', () => {
         password_hash: string;
         password_salt: ArrayBuffer;
         pub_key: ArrayBuffer;
-        priv_key: ArrayBuffer;
+        encrypted_priv_key: ArrayBuffer;
       }>();
     expect(storedUser).toBeTruthy();
     expect(storedUser?.email_verified).toBe(1);
@@ -135,7 +140,7 @@ describe('Auth routes', () => {
     ).toBe(true);
     expect(Buffer.from(storedUser!.password_salt).toString('base64')).toBe(password_salt);
     expect(Buffer.from(storedUser!.pub_key).toString('base64')).toBe(pub_key);
-    expect(Buffer.from(storedUser!.priv_key).toString('base64')).toBe(priv_key);
+    expect(Buffer.from(storedUser!.encrypted_priv_key).toString('base64')).toBe(priv_key);
 
     const consumedToken = await latestEmailToken('signup');
     expect(consumedToken?.consumed_at).not.toBeNull();
@@ -150,21 +155,84 @@ describe('Auth routes', () => {
         password_auth: await passwordAuthFor('pw'),
         password_salt: await passwordSaltFor('nope@example.com'),
         pub_key: await publicKeyFor('nope@example.com'),
-        priv_key: privateKeyFor('nope@example.com'),
+        encrypted_priv_key: privateKeyFor('nope@example.com'),
       }),
     });
     expect(badRes.status).toBe(400);
   });
 
-  it('rejects signup-request for an existing account', async () => {
+  it('signup-request for an existing account looks identical to a fresh request but notifies the owner instead', async () => {
     await signupAndGetCookie('taken@example.com', 'pw');
+
+    const tokenCountBefore = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM email_tokens WHERE purpose = 'signup' AND email = ?",
+    )
+      .bind('taken@example.com')
+      .first<{ count: number }>();
 
     const res = await SELF.fetch(`${BASE}/signup-request`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'taken@example.com' }),
     });
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+
+    const deliveries = await listEmailDeliveries();
+    const notice = deliveries.find((delivery) => delivery.kind === 'account_exists_notice');
+    expect(notice).toMatchObject({
+      recipient_email: 'taken@example.com',
+      status: 'sent',
+    });
+
+    // No new signup token should have been issued for the already-owned email.
+    const tokenCountAfter = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM email_tokens WHERE purpose = 'signup' AND email = ?",
+    )
+      .bind('taken@example.com')
+      .first<{ count: number }>();
+    expect(tokenCountAfter?.count).toBe(tokenCountBefore?.count);
+  });
+
+  it('signup consumes the token and does not leak account existence on a token-redemption race', async () => {
+    const password_auth = await passwordAuthFor('client-derived-auth');
+    const password_salt = await passwordSaltFor('racer@example.com');
+    const pub_key = await publicKeyFor('racer@example.com');
+    const priv_key = privateKeyFor('racer@example.com');
+
+    const requestRes = await SELF.fetch(`${BASE}/signup-request`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'racer@example.com' }),
+    });
+    expect(requestRes.status).toBe(200);
+
+    const deliveries = await listEmailDeliveries();
+    const signupDelivery = deliveries.find(
+      (delivery) =>
+        delivery.kind === 'email_verification' && delivery.recipient_email === 'racer@example.com',
+    );
+    const verificationToken = extractTokenFromDelivery(signupDelivery!, 'signup_token');
+
+    // Someone else claims the email in the window between /signup-request and /signup.
+    await signupAndGetCookie('racer@example.com', 'someone-else');
+
+    const signupRes = await SELF.fetch(`${BASE}/signup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        verification_token: verificationToken,
+        password_auth,
+        password_salt,
+        pub_key,
+        encrypted_priv_key: priv_key,
+      }),
+    });
+    expect(signupRes.status).toBe(400);
+    expect(await signupRes.json()).toEqual({ error: 'Invalid or expired verification token' });
+
+    const consumedToken = await latestEmailToken('signup');
+    expect(consumedToken?.consumed_at).not.toBeNull();
   });
 
   it('logs in with password_auth and sets a refresh cookie', async () => {
@@ -180,10 +248,8 @@ describe('Auth routes', () => {
     });
     expect(loginRes.status).toBe(200);
     expect(loginRes.headers.get('set-cookie')).toContain('refresh_token=');
-    const loginBody = (await loginRes.json()) as { ok: boolean; refresh_token: string };
-    expect(loginBody).toMatchObject({ ok: true });
-    expect(typeof loginBody.refresh_token).toBe('string');
-    expect(loginBody.refresh_token.length).toBeGreaterThan(0);
+    const loginBody = (await loginRes.json()) as { ok: boolean };
+    expect(loginBody).toEqual({ ok: true });
 
     const badLoginRes = await SELF.fetch(`${BASE}/login`, {
       method: 'POST',
@@ -208,7 +274,7 @@ describe('Auth routes', () => {
       body: JSON.stringify({
         name: 'Updated Carol',
         pub_key: nextPubKey,
-        priv_key: nextPrivKey,
+        encrypted_priv_key: nextPrivKey,
       }),
     });
     expect(patchRes.status).toBe(200);
@@ -223,13 +289,13 @@ describe('Auth routes', () => {
       email_verified: boolean;
       settings: { email_frequency: string; timezone: string };
       pub_key: string;
-      priv_key: string;
+      encrypted_priv_key: string;
     };
     expect(body.name).toBe('Updated Carol');
     expect(body.email_verified).toBe(true);
     expect(body.settings).toMatchObject({ email_frequency: 'daily', timezone: 'UTC' });
     expect(body.pub_key).toBe(nextPubKey);
-    expect(body.priv_key).toBe(nextPrivKey);
+    expect(body.encrypted_priv_key).toBe(nextPrivKey);
     await markUserEmailVerified(userId);
     const updateEmailRes = await SELF.fetch(`${BASE}/user`, {
       method: 'PATCH',
@@ -290,6 +356,42 @@ describe('Auth routes', () => {
 
     const latestVerificationToken = await latestEmailToken('email_change');
     expect(latestVerificationToken?.email).toBe('carol-new@example.com');
+  });
+
+  it('PATCH /user email change to an in-use address notifies the owner instead of leaking a 409', async () => {
+    await signupAndGetCookie('owner@example.com', 'pw');
+    const { cookie } = await signupAndGetCookie('requester@example.com', 'pw', 'Requester');
+
+    const patchRes = await SELF.fetch(`${BASE}/user`, {
+      method: 'PATCH',
+      headers: authHeaders(cookie),
+      body: JSON.stringify({ email: 'owner@example.com' }),
+    });
+    expect(patchRes.status).toBe(200);
+    expect(await patchRes.json()).toEqual({
+      ok: true,
+      email_verification_required: true,
+      pending_email: 'owner@example.com',
+    });
+
+    const deliveries = await listEmailDeliveries();
+    const notice = deliveries.find((delivery) => delivery.kind === 'email_in_use_notice');
+    expect(notice).toMatchObject({ recipient_email: 'owner@example.com', status: 'sent' });
+
+    // No email_change token should have been issued for the requester's attempt.
+    const tokenCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM email_tokens WHERE purpose = 'email_change' AND email = ?",
+    )
+      .bind('owner@example.com')
+      .first<{ count: number }>();
+    expect(tokenCount?.count).toBe(0);
+
+    const requesterRes = await SELF.fetch(`${BASE}/user`, {
+      headers: authHeaders(cookie),
+    });
+    expect((await requesterRes.json()) as { email: string }).toMatchObject({
+      email: 'requester@example.com',
+    });
   });
 
   it('verifies email-change tokens and sets a new session cookie', async () => {
@@ -360,7 +462,7 @@ describe('Auth routes', () => {
     void userId;
   });
 
-  it('requires matching email confirmation and permanently deletes the account with cascaded data cleanup', async () => {
+  it('requires matching email confirmation and permanently deletes the account with cascaded D1 cleanup', async () => {
     const { cookie, userId } = await signupAndGetCookie('delete-me@example.com', 'pw', 'Delete Me');
     const device = await createDeviceForUser('delete-me@example.com', 'pw', 'Phone', 'ios');
 
@@ -435,7 +537,9 @@ describe('Auth routes', () => {
         .bind(uuidToBytes(device.id))
         .first<{ count: number }>(),
     ).toMatchObject({ count: 0 });
-    expect(await env.BUCKET.head(batch.url.replace(`${env.R2_URL}/`, ''))).toBeNull();
+    // R2 batch blobs are no longer deleted inline on account deletion — they age
+    // out via the bucket lifecycle rule independent of the D1 row/account lifetime.
+    expect(await env.BUCKET.head(batch.url.replace(`${env.R2_URL}/`, ''))).toBeTruthy();
   });
 
   it('requests and applies password resets with new auth material and keypair bytes', async () => {
@@ -479,20 +583,20 @@ describe('Auth routes', () => {
         password_auth: newPasswordAuth,
         password_salt: newPasswordSalt,
         pub_key: newPubKey,
-        priv_key: newPrivKey,
+        encrypted_priv_key: newPrivKey,
       }),
     });
     expect(resetRes.status).toBe(200);
 
     const storedUser = await env.DB.prepare(
-      'SELECT password_hash, password_salt, pub_key, priv_key FROM users WHERE email = ?',
+      'SELECT password_hash, password_salt, pub_key, encrypted_priv_key FROM users WHERE email = ?',
     )
       .bind('reset@example.com')
       .first<{
         password_hash: string;
         password_salt: ArrayBuffer;
         pub_key: ArrayBuffer;
-        priv_key: ArrayBuffer;
+        encrypted_priv_key: ArrayBuffer;
       }>();
     expect(storedUser).toBeTruthy();
     expect(
@@ -500,6 +604,26 @@ describe('Auth routes', () => {
     ).toBe(true);
     expect(Buffer.from(storedUser!.password_salt).toString('base64')).toBe(newPasswordSalt);
     expect(Buffer.from(storedUser!.pub_key).toString('base64')).toBe(newPubKey);
-    expect(Buffer.from(storedUser!.priv_key).toString('base64')).toBe(newPrivKey);
+    expect(Buffer.from(storedUser!.encrypted_priv_key).toString('base64')).toBe(newPrivKey);
+  });
+
+  it('rejects an unprefixed or wrong-purpose refresh token before touching the session table', async () => {
+    const unprefixedRes = await SELF.fetch(`${BASE}/user`, {
+      headers: authHeaders('not-a-prefixed-token'),
+    });
+    expect(unprefixedRes.status).toBe(401);
+
+    const { id: deviceRefreshToken } = await (async () => {
+      const { cookie } = await signupAndGetCookie('device-owner@example.com', 'pw');
+      const device = await createDeviceForUser(cookie, 'Laptop', 'linux');
+      return { id: device.refresh_token };
+    })();
+
+    // A device_session token (dst_...) presented as a web session (wst_...) must
+    // be rejected on prefix alone, without a session-table lookup.
+    const wrongPurposeRes = await SELF.fetch(`${BASE}/user`, {
+      headers: authHeaders(deviceRefreshToken),
+    });
+    expect(wrongPurposeRes.status).toBe(401);
   });
 });

--- a/api/test/auth.test.ts
+++ b/api/test/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateToken, verifyJWT } from '../src/lib/jwt';
 import { generatePasswordSalt, hashPasswordAuth, verifyPasswordAuth } from '../src/lib/password';
+import { assertTokenPurpose, generateOpaqueToken } from '../src/lib/tokens';
 import {
   TEST_JWT_PRIVATE_KEY,
   TEST_JWT_PUBLIC_KEY,
@@ -47,5 +48,30 @@ describe('JWT tokens', () => {
   it('rejects a token signed with a different public key', async () => {
     const token = await generateToken('server', 'device-123', TEST_JWT_PRIVATE_KEY, 60);
     await expect(verifyJWT(token, TEST_OTHER_JWT_PUBLIC_KEY)).rejects.toThrow();
+  });
+});
+
+describe('Opaque token purpose prefixes', () => {
+  it('prefixes generated tokens by purpose', () => {
+    expect(generateOpaqueToken('web_session')).toMatch(/^wst_/);
+    expect(generateOpaqueToken('device_session')).toMatch(/^dst_/);
+    expect(generateOpaqueToken('signup')).toMatch(/^sut_/);
+    expect(generateOpaqueToken('email_change')).toMatch(/^ect_/);
+    expect(generateOpaqueToken('password_reset')).toMatch(/^prt_/);
+    expect(generateOpaqueToken('partner_invite')).toMatch(/^pit_/);
+  });
+
+  it('accepts a token whose prefix matches the asserted purpose', () => {
+    const token = generateOpaqueToken('web_session');
+    expect(() => assertTokenPurpose(token, 'web_session')).not.toThrow();
+  });
+
+  it('rejects a token whose prefix does not match the asserted purpose', () => {
+    const token = generateOpaqueToken('device_session');
+    expect(() => assertTokenPurpose(token, 'web_session')).toThrow();
+  });
+
+  it('rejects an unprefixed legacy-shaped token', () => {
+    expect(() => assertTokenPurpose('just-some-opaque-string', 'web_session')).toThrow();
   });
 });

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -109,7 +109,7 @@ export async function signupAndGetCookie(
       password_auth,
       password_salt,
       pub_key,
-      priv_key,
+      encrypted_priv_key: priv_key,
       ...(name ? { name } : {}),
     }),
   });

--- a/api/test/setup.ts
+++ b/api/test/setup.ts
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
   email_bounced_at INTEGER,
   settings TEXT NOT NULL DEFAULT '{}',
   pub_key BLOB,
-  priv_key BLOB,
+  encrypted_priv_key BLOB,
   created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -643,6 +643,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,10 +1405,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2256,6 +2266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +2855,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2853,7 +2870,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2965,6 +2981,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,6 +3066,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3091,29 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4206,15 +4266,6 @@ checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
 dependencies = [
  "image",
  "libwebp-sys",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/client/android/rust/Cargo.lock
+++ b/client/android/rust/Cargo.lock
@@ -384,6 +384,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +988,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1833,6 +1844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2354,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2463,6 +2481,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2569,29 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3659,6 +3721,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -31,7 +31,7 @@ hpke = "0.13.0"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 pbkdf2 = "0.12"
 rand_core = { version = "0.9.5", features = ["os_rng"] }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "cookies", "json", "multipart", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "cookies", "json", "multipart", "rustls-tls-native-roots"] }
 rmp-serde = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/client/core/src/api.rs
+++ b/client/core/src/api.rs
@@ -369,23 +369,33 @@ impl ReqwestApiClient {
             return Ok(response);
         }
 
-        let fallback = response
-            .text()
-            .unwrap_or_else(|_| format!("HTTP {} error", status.as_u16()));
-        let message = match serde_json::from_str::<ApiErrorResponse>(&fallback) {
-            Ok(body) => body
-                .details
-                .as_ref()
-                .and_then(format_api_details)
-                .or_else(|| body.error.filter(|s| !s.is_empty()))
-                .unwrap_or(fallback),
-            Err(_) => fallback,
-        };
+        let body = response.text().ok();
+        let message = error_message_from_body(status, body.as_deref());
 
         Err(CoreError::HttpStatus {
             status: status.as_u16(),
             message,
         })
+    }
+}
+
+/// Derives a non-empty error message from a non-2xx response body, falling
+/// back to a status-line-bearing message (e.g. "HTTP 502 Bad Gateway error")
+/// when the body is missing, empty, or unparseable.
+fn error_message_from_body(status: reqwest::StatusCode, body: Option<&str>) -> String {
+    let fallback = body
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("HTTP {status} error"));
+
+    match serde_json::from_str::<ApiErrorResponse>(&fallback) {
+        Ok(body) => body
+            .details
+            .as_ref()
+            .and_then(format_api_details)
+            .or_else(|| body.error.filter(|s| !s.is_empty()))
+            .unwrap_or(fallback),
+        Err(_) => fallback,
     }
 }
 
@@ -430,4 +440,40 @@ fn format_api_details(details: &serde_json::Value) -> Option<String> {
 struct ApiErrorResponse {
     error: Option<String>,
     details: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_message_from_body_falls_back_on_empty_body() {
+        let message =
+            error_message_from_body(reqwest::StatusCode::from_u16(401).unwrap(), Some(""));
+        assert!(!message.is_empty());
+        assert!(message.contains("401"));
+    }
+
+    #[test]
+    fn error_message_from_body_falls_back_on_missing_body() {
+        let message = error_message_from_body(reqwest::StatusCode::from_u16(500).unwrap(), None);
+        assert!(!message.is_empty());
+        assert!(message.contains("500"));
+    }
+
+    #[test]
+    fn error_message_from_body_includes_reason_phrase_on_fallback() {
+        let message = error_message_from_body(reqwest::StatusCode::from_u16(502).unwrap(), None);
+        assert!(message.contains("502"));
+        assert!(message.contains("Bad Gateway"));
+    }
+
+    #[test]
+    fn error_message_from_body_uses_error_field() {
+        let message = error_message_from_body(
+            reqwest::StatusCode::from_u16(400).unwrap(),
+            Some(r#"{"error":"bad email"}"#),
+        );
+        assert_eq!(message, "bad email");
+    }
 }

--- a/client/core/src/controller.rs
+++ b/client/core/src/controller.rs
@@ -40,8 +40,10 @@ impl<C: EventChannel> ClientController<C> {
         if r.success {
             Ok(r.device_id.unwrap_or_default())
         } else {
-            Err(CoreError::CommandFailed(
-                r.error.unwrap_or_else(|| "login failed".to_string()),
+            Err(CoreError::Remote(
+                r.error
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| "login failed".to_string()),
             ))
         }
     }
@@ -52,8 +54,10 @@ impl<C: EventChannel> ClientController<C> {
         if r.success {
             Ok(())
         } else {
-            Err(CoreError::CommandFailed(
-                r.error.unwrap_or_else(|| "logout failed".to_string()),
+            Err(CoreError::Remote(
+                r.error
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| "logout failed".to_string()),
             ))
         }
     }
@@ -97,5 +101,77 @@ impl ClientController<crate::events::RemoteEventBus> {
     pub fn connect(path: &std::path::Path) -> CoreResult<Self> {
         let bus = crate::events::RemoteEventBus::connect(path).map_err(CoreError::from)?;
         Ok(Self::new(bus))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::bus::{Emitter, EventBus, Observer, StateType};
+    use std::any::Any;
+
+    /// Replies to `LoginRequested`/`LogoutRequested` with a failure result
+    /// carrying an empty error string, mimicking a daemon-reported failure
+    /// with no message (e.g. an empty response body upstream).
+    struct EmptyErrorResponder;
+
+    impl Observer for EmptyErrorResponder {
+        fn init(&mut self, _bus: &mut EventBus, _state: StateType) -> CoreResult<()> {
+            Ok(())
+        }
+
+        fn on_event(&mut self, event: &dyn Any, emitter: &Emitter) -> CoreResult<()> {
+            crate::dispatch_event!(event, {
+                _: LoginRequested => emitter.send(LoginResult {
+                    success: false,
+                    error: Some(String::new()),
+                    device_id: None,
+                }),
+                _: LogoutRequested => emitter.send(LogoutResult {
+                    success: false,
+                    error: Some(String::new()),
+                }),
+            })
+        }
+
+        fn save(&self) -> CoreResult<StateType> {
+            Ok(StateType::Null)
+        }
+
+        fn name(&self) -> &'static str {
+            "empty_error_responder"
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn empty_login_error_becomes_default_remote_message() {
+        let bus = EventBus::new(vec![Box::new(EmptyErrorResponder)], StateType::Null).unwrap();
+        let mut controller = ClientController::new(bus);
+
+        let err = controller
+            .login("user@example.com", "password", None)
+            .expect_err("login should fail");
+
+        match err {
+            CoreError::Remote(message) => assert_eq!(message, "login failed"),
+            other => panic!("expected CoreError::Remote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_logout_error_becomes_default_remote_message() {
+        let bus = EventBus::new(vec![Box::new(EmptyErrorResponder)], StateType::Null).unwrap();
+        let mut controller = ClientController::new(bus);
+
+        let err = controller.logout().expect_err("logout should fail");
+
+        match err {
+            CoreError::Remote(message) => assert_eq!(message, "logout failed"),
+            other => panic!("expected CoreError::Remote, got {other:?}"),
+        }
     }
 }

--- a/client/core/src/error.rs
+++ b/client/core/src/error.rs
@@ -41,6 +41,8 @@ pub enum CoreError {
     Crypto(&'static str),
     #[error("external command failed: {0}")]
     CommandFailed(String),
+    #[error("{0}")]
+    Remote(String),
     #[error("classifier error: {0}")]
     Classifier(String),
     #[error("IPC error: {0}")]

--- a/client/windows/Cargo.toml
+++ b/client/windows/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4"
 hostname = "0.4"
 image = { version = "0.25", default-features = false, features = ["png"] }
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/scripts/seed-dev-user.mjs
+++ b/scripts/seed-dev-user.mjs
@@ -97,9 +97,9 @@ const pubKeyHex = toHex(pubKeyBytes);
 const privKeyHex = toHex(encryptedPrivKey);
 
 const sql = `
-INSERT OR IGNORE INTO users (id, email, password_hash, password_salt, password_params_version, email_verified, pub_key, priv_key)
+INSERT OR IGNORE INTO users (id, email, password_hash, password_salt, password_params_version, email_verified, pub_key, encrypted_priv_key)
 VALUES (X'${USER_ID_HEX}', '${EMAIL}', '${passwordHash}', X'${saltHex}', 'argon2id-v1', 1, X'${pubKeyHex}', X'${privKeyHex}');
-UPDATE users SET pub_key = X'${pubKeyHex}', priv_key = X'${privKeyHex}' WHERE id = X'${USER_ID_HEX}';
+UPDATE users SET pub_key = X'${pubKeyHex}', encrypted_priv_key = X'${privKeyHex}' WHERE id = X'${USER_ID_HEX}';
 `;
 
 const tmpFile = join(ROOT, '.seed-dev-user-tmp.sql');

--- a/shared-web/types.ts
+++ b/shared-web/types.ts
@@ -16,7 +16,7 @@ export const hashParamsSchema = z.object({
 export type HashParams = z.infer<typeof hashParamsSchema>;
 
 export const loginMaterialSchema = z.object({
-  password_salt: z.string(),
+  password_salt: z.string().optional(),
   params: hashParamsSchema,
 });
 export type LoginMaterial = z.infer<typeof loginMaterialSchema>;
@@ -32,7 +32,7 @@ export const userSchema = z.object({
   }),
   name: z.string().optional(),
   pub_key: z.string().optional(),
-  priv_key: z.string().optional(),
+  encrypted_priv_key: z.string().optional(),
 });
 export type User = z.infer<typeof userSchema>;
 
@@ -131,12 +131,12 @@ export const signupSchema = z.object({
   password_auth: z.base64(),
   password_salt: z.base64(),
   pub_key: z.base64(),
-  priv_key: z.base64(),
+  encrypted_priv_key: z.base64(),
   name: z.string().min(1).optional(),
 });
 export type SignupPayload = z.infer<typeof signupSchema>;
 
-export const loginMaterialQuerySchema = z.object({ email: z.email() });
+export const loginMaterialQuerySchema = z.object({ email: z.email().optional() });
 export type LoginMaterialQuery = z.infer<typeof loginMaterialQuerySchema>;
 
 export const loginSchema = z.object({
@@ -160,7 +160,7 @@ export const passwordResetSchema = z.object({
   password_auth: z.base64(),
   password_salt: z.base64(),
   pub_key: z.base64(),
-  priv_key: z.base64(),
+  encrypted_priv_key: z.base64(),
 });
 export type PasswordResetPayload = z.infer<typeof passwordResetSchema>;
 
@@ -175,7 +175,7 @@ export const updateUserSchema = z
       })
       .optional(),
     pub_key: z.base64().optional(),
-    priv_key: z.base64().optional(),
+    encrypted_priv_key: z.base64().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, { message: 'No fields to update' });
 export type UpdateUserPayload = z.infer<typeof updateUserSchema>;
@@ -201,7 +201,7 @@ export type UpdateDevicePayload = z.infer<typeof updateDeviceSchema>;
 
 // ── Additional response schemas ──────────────────────────────────────────────
 
-export const loginResponseSchema = z.object({ ok: z.boolean(), refresh_token: z.string() });
+export const loginResponseSchema = z.object({ ok: z.boolean() });
 export type LoginResponse = z.infer<typeof loginResponseSchema>;
 
 export const signupResponseSchema = z.object({

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -7,7 +7,7 @@ export const TEST_USER: User = {
   email_bounced_at: null,
   name: 'Test User',
   pub_key: undefined,
-  priv_key: undefined,
+  encrypted_priv_key: undefined,
   settings: {
     email_frequency: 'daily',
     timezone: 'UTC',

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -3,29 +3,31 @@ import { TEST_DEVICES, TEST_USER, TEST_WATCHER, TEST_WATCHING } from './fixtures
 
 const BASE = 'http://localhost:8787';
 
-export const handlers = [
-  // ── Hash params ────────────────────────────────────────────────────────
-  http.get(`${BASE}/current-hash-params`, () =>
-    HttpResponse.json({
-      salt_length: 16,
-      memory_cost_kib: 65536,
-      time_cost: 3,
-      parallelism: 1,
-    }),
-  ),
+const MOCK_HASH_PARAMS = {
+  version: 'argon2id-v1',
+  algorithm: 'argon2id',
+  salt_length: 16,
+  memory_cost_kib: 65536,
+  time_cost: 3,
+  parallelism: 1,
+  hkdf_hash: 'sha256',
+};
 
-  // ── Login material ─────────────────────────────────────────────────────
-  http.get(`${BASE}/user/login-material`, () =>
-    HttpResponse.json({
+export const handlers = [
+  // ── Login material (also serves current hash params when `email` is omitted) ──
+  http.get(`${BASE}/user/login-material`, ({ request }) => {
+    const url = new URL(request.url);
+    if (!url.searchParams.has('email')) {
+      return HttpResponse.json({ params: MOCK_HASH_PARAMS });
+    }
+    return HttpResponse.json({
       password_salt: btoa('testsalt12345678'),
-      memory_cost_kib: 65536,
-      time_cost: 3,
-      parallelism: 1,
-    }),
-  ),
+      params: MOCK_HASH_PARAMS,
+    });
+  }),
 
   // ── Login ──────────────────────────────────────────────────────────────
-  http.post(`${BASE}/login`, () => HttpResponse.json({ ok: true, refresh_token: 'mock-token' })),
+  http.post(`${BASE}/login`, () => HttpResponse.json({ ok: true })),
 
   // ── Signup ─────────────────────────────────────────────────────────────
   http.post(`${BASE}/signup-request`, () => HttpResponse.json({ ok: true })),

--- a/web/src/pages/Auth/index.tsx
+++ b/web/src/pages/Auth/index.tsx
@@ -168,7 +168,7 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
         password_auth: passwordAuth.toBase64(),
         password_salt: passwordSalt.toBase64(),
         pub_key: keyPair.publicKey.toBase64(),
-        priv_key: (await encryptData(wrappingKey, keyPair.privateKey)).toBase64(),
+        encrypted_priv_key: (await encryptData(wrappingKey, keyPair.privateKey)).toBase64(),
       },
     };
   }

--- a/web/src/utils/api/api.ts
+++ b/web/src/utils/api/api.ts
@@ -166,7 +166,8 @@ async function req<T>(path: string, init: RequestInit = {}): Promise<T> {
 }
 
 export const api = {
-  getCurrentHashParams: () => req<HashParams>('/current-hash-params'),
+  getCurrentHashParams: () =>
+    req<{ params: HashParams }>('/user/login-material').then((res) => res.params),
 
   getLoginMaterial: (email: string) => {
     const qs = new URLSearchParams({ email });
@@ -234,7 +235,7 @@ export const api = {
       password_auth: string;
       password_salt: string;
       pub_key?: string;
-      priv_key?: string;
+      encrypted_priv_key?: string;
     },
   ) =>
     req<{ ok: boolean }>('/password-reset/finalize', {

--- a/web/src/utils/api/client.ts
+++ b/web/src/utils/api/client.ts
@@ -16,7 +16,7 @@ export interface UserSettings {
   name?: string;
   settings?: { email_frequency?: User['settings']['email_frequency']; timezone?: string };
   pub_key?: string;
-  priv_key?: string;
+  encrypted_priv_key?: string;
 }
 
 export interface UpdateSettingsResult {
@@ -161,7 +161,7 @@ export class APIClient {
       password_auth: string;
       password_salt: string;
       pub_key?: string;
-      priv_key?: string;
+      encrypted_priv_key?: string;
     },
   ): Promise<void> {
     await api.resetPassword(token, payload);

--- a/web/src/utils/api/session.ts
+++ b/web/src/utils/api/session.ts
@@ -86,7 +86,7 @@ export class Session {
       password_auth: passwordAuth.toBase64(),
       password_salt: passwordSalt.toBase64(),
       pub_key: keyPair.publicKey.toBase64(),
-      priv_key: encryptedPrivateKey.toBase64(),
+      encrypted_priv_key: encryptedPrivateKey.toBase64(),
       ...(name ? { name } : {}),
     });
     await saveWrappingKey(wrappingKey);
@@ -151,9 +151,9 @@ async function decryptStoredPrivateKey(
   user: User,
   wrappingKey: CryptoKey,
 ): Promise<CryptoKey | null> {
-  if (!user.priv_key) return null;
+  if (!user.encrypted_priv_key) return null;
   try {
-    const raw = await decryptBatch(wrappingKey, Uint8Array.fromBase64(user.priv_key));
+    const raw = await decryptBatch(wrappingKey, Uint8Array.fromBase64(user.encrypted_priv_key));
     return await importUserPrivateKey(raw);
   } catch (err) {
     console.error('Failed to restore private key', err);


### PR DESCRIPTION
## Summary

Nine related cleanups to `api/src/routes/auth.ts` and its neighbors, bundled together since several touch the same handlers and DB helpers, plus three follow-up fixes found while testing against the real dev stack.

**Stacked on #545** (`device-routes-review`) — this branch was rebased on top of it, since that PR's device-auth rewrite (`POST /d/device` authenticating directly with `email`+`password_auth`, no web session required) replaced the cookie-jar-based device registration flow this branch originally shipped. Merge #545 first; this PR's diff will shrink to just the commits below once it does.

### Auth routes cleanup

- **Merge hash-params endpoints**: `GET /current-hash-params` folded into `GET /user/login-material` (email now optional). Web's `getCurrentHashParams()` points at the same endpoint.
- **Close account-existence leaks**: `signup-request`, `signup`, `PATCH /user`, and `email-verification/validate` no longer return distinct 409s for an already-registered/already-taken email. Instead they notify the real account owner via two new email templates (`account_exists_notice`, `email_in_use_notice`) and return the same generic success/failure shape either way.
- **Prefix opaque tokens by purpose** (`wst_`/`dst_`/`sut_`/`ect_`/`prt_`/`pit_`); `assertTokenPurpose` rejects mismatched-purpose tokens before hashing/DB lookup. **Hard cutover** — every existing web session and device session is invalidated the moment this deploys (device tokens have a ~1000-year TTL, so this is effectively every device ever registered). Needs to be treated as a coordinated deploy event.
- **Replace hand-rolled base64/length decode helpers with Zod** for consistent, aggregated field errors matching the rest of the API.
- **Rename `priv_key` → `encrypted_priv_key`** end-to-end (DB column via migration `0010`, API, `shared-web`, `web`) since the value is encrypted and the old name was misleading.
- **Drop `refresh_token` from the `/login` JSON body** — the browser already gets the session via the `Set-Cookie` header, so exposing it in the response body too was unnecessary. (Originally this bullet also covered the Rust client relying on a cookie jar instead of an explicit token — that flow no longer exists post-#545, since device registration authenticates directly and never calls `/login` at all.)
- **Remove inline R2 batch deletion on account deletion** — the confirmed-production bucket lifecycle rule already handles it independently of D1 row lifetime.
- **Fold `invalidateEmailTokens` into `consumeEmailToken`** so every consumption site makes one call instead of two.

### Follow-up fixes (found testing against the real dev stack post-rebase)

- **Trust OS-native root certs in the Rust client's TLS config**: `reqwest`'s `rustls-tls` feature bundles a fixed Mozilla root store instead of the OS trust store, so the client couldn't complete a TLS handshake against locally-trusted dev certs (e.g. Caddy's local CA) — it failed with an opaque "error sending request for url" while `curl` worked fine. Switched to `rustls-tls-native-roots`, which still covers public CAs in production.
- **Fix unhelpful `"external command failed:"` login error message**: `ensure_success()` only built its status-line fallback when `response.text()` itself errored, so a non-2xx response with a genuinely empty body produced an empty `CoreError::HttpStatus` message. Separately, `ClientController` wrapped daemon-reported login/logout failures in `CoreError::CommandFailed` (meant for actual subprocess/OS failures), producing a misleading prefix. Added `CoreError::Remote` for daemon-reported failures and made the fallback message always carry the status line (e.g. `HTTP 502 Bad Gateway error`).
- **Fix a stale test call site**: `auth-routes.test.ts` still called `createDeviceForUser(cookie, name, platform)`, the pre-#545 signature. The helper now takes `(email, password, name, platform)`, so the cookie was silently being passed as the email argument.

## Changes

Type of change: Refactor / Bug fix (enumeration leaks, TLS trust, error messaging)
Components: API, Web, Core (Rust client)

## Testing

- `api`: `npm test` — 56/56 passing (12 files). `npm run typecheck` clean. Migration `0010` applies cleanly to local D1.
- `web`: `npm test` — 102/102 passing. `npm run typecheck` clean.
- `client/core`: `cargo test -p virtue-core --features testing` — 149/149 passing (132 unit + 17 scenario). `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Confirmed the TLS fix live: built a throwaway integration check using the real `ReqwestApiClient` against the running local dev stack (`https://app.auth.localhost`, Caddy-fronted with a locally-trusted dev cert) — got a clean `200 OK` where it previously failed the TLS handshake.
- Confirmed the local hash-server routing end-to-end with `virtue login` against the dev stack: login succeeds, device settings and hash token are populated from the `POST /d/device` response, and a direct `POST /hash` with the minted token returns `200 {"ok":true}`.
- **Manual walkthrough** (pre-rebase, still applicable to the auth-routes-cleanup-specific behavior) against the local dev stack via a real browser: signup → verify → auto-login → email change (success path) → email change to an already-taken address (confirmed leak-safe: identical UI, notice sent to the real owner, no working token issued) → password reset → auto-login → account deletion → re-signup with an already-registered email (confirmed leak-safe: identical UI, `account_exists_notice` sent instead of a new token). Zero console errors/warnings across the session. New token prefixes (`sut_`, `ect_`, `prt_`) observed in real links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWmkmJgU3E6UjMv62LyQLv
