### PR TITLE
Add GET /updates, worker-backed cross-tab cache, rename /data to /batches

### DIFF
--- a/api/API.md
+++ b/api/API.md
@@ -574,9 +574,31 @@ accepted watchers. Returns `404` if the device does not exist or is not owned by
 
 Response: `204 No Content`
 
-## Data
+## Updates
 
-### `GET /data`
+### `GET /updates`
+
+Requires an authenticated web session (the `refresh_token` cookie, or `Bearer <RefreshToken>`).
+
+Combines `GET /user`, `GET /device`, and `GET /partner` into a single round trip for initial page
+load. No parameters.
+
+Response `200`:
+
+```js
+{
+  "user": User,
+  "devices": [Device],
+  "partners": PartnerRelationships
+}
+```
+
+Targeted mutations (renaming a device, updating settings, inviting a partner) should still refetch
+via `/user`, `/device`, or `/partner` directly if not going through the cache worker.
+
+## Batches
+
+### `GET /batches`
 
 Requires an authenticated web session (the `refresh_token` cookie, or `Bearer <RefreshToken>`).
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -43,7 +43,9 @@ HTTP status codes: 400 bad request, 401 unauthorized, 403 forbidden, 404 not fou
 - `src/middleware/auth.ts` — JWT verification, sets `c.get('sub')`
 - `src/middleware/validation.ts` — Zod validation wrapper
 - `src/routes/device-only.ts` — batch upload and device log endpoints
-- `src/routes/data.ts` — data retrieval with access control
+- `src/routes/batches.ts` — batch retrieval with access control
+- `src/routes/updates.ts` — combined `GET /updates` (user + devices + partners in one round trip)
+- `src/lib/views.ts` — shared response-builders used by `/user`, `/device`, `/partner`, and `/updates`
 - `API.md` — complete endpoint specification
 
 ## Type source of truth

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,12 +1,13 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import auth from './routes/auth';
-import data from './routes/data';
+import batches from './routes/batches';
 import deviceOnly from './routes/device-only';
 import devices from './routes/devices';
 import emailWebhooks from './routes/email-webhooks';
 import hashes from './routes/hashes';
 import partners from './routes/partners';
+import updates from './routes/updates';
 import { stripApiBasePath } from './lib/base-path';
 import { getJWKS } from './lib/jwt';
 import { pruneExpiredBatches } from './lib/retention';
@@ -45,9 +46,10 @@ app.get('/.well-known/jwks.json', async (c) => c.json(await getJWKS(c.env.JWT_PU
 
 app.route('/', auth);
 app.route('/', partners);
+app.route('/', updates);
 app.route('/', emailWebhooks);
 app.route('/device', devices);
-app.route('/data', data);
+app.route('/batches', batches);
 app.route('/d', deviceOnly);
 app.route('/hash', hashes);
 

--- a/api/src/lib/views.ts
+++ b/api/src/lib/views.ts
@@ -10,10 +10,11 @@ import {
 import { generateToken } from './jwt';
 import { DEFAULT_EMAIL_FREQUENCY, emailFrequencies } from './email-domain';
 import { Env } from '../types/bindings';
+import type { Device, PartnerRelationships, User } from '../../../shared-web/types';
 
 export const ONLINE_WINDOW_MS = 2 * 60 * 60 * 1000;
 
-export async function buildUserView(db: D1Database, userId: string) {
+export async function buildUserView(db: D1Database, userId: string): Promise<User | null> {
   const user = await findUserById(db, userId);
   if (!user) return null;
   return {
@@ -21,14 +22,17 @@ export async function buildUserView(db: D1Database, userId: string) {
     email: user.email,
     email_verified: user.email_verified === 1,
     email_bounced_at: user.email_bounced_at,
-    settings: user.settings,
+    settings: {
+      email_frequency: toPublicNotificationCadence(user.settings.email_frequency),
+      timezone: user.settings.timezone,
+    },
     ...(user.name ? { name: user.name } : {}),
     ...(user.pub_key ? { pub_key: encodeBase64(user.pub_key) } : {}),
     ...(user.priv_key ? { priv_key: encodeBase64(user.priv_key) } : {}),
   };
 }
 
-export async function buildDeviceViews(env: Env, requesterId: string) {
+export async function buildDeviceViews(env: Env, requesterId: string): Promise<Device[]> {
   const ownerIds = await listVisibleOwnerIds(env.DB, requesterId);
   const rows = await listDevicesForOwners(env.DB, ownerIds);
   const hashServerUrl = env.HASH_SERVER_URL?.trim() || null;
@@ -91,7 +95,14 @@ function toPublicNotificationCadence(emailFrequency: string | null | undefined) 
   return emailFrequency as (typeof emailFrequencies)[number];
 }
 
-export async function buildPartnerRelationships(db: D1Database, userId: string) {
+function toPartnerStatus(status: string): 'pending' | 'accepted' {
+  return status === 'accepted' ? 'accepted' : 'pending';
+}
+
+export async function buildPartnerRelationships(
+  db: D1Database,
+  userId: string,
+): Promise<PartnerRelationships> {
   const [owned, incoming] = await Promise.all([
     listOwnedPartners(db, userId),
     listIncomingPartners(db, userId),
@@ -105,7 +116,7 @@ export async function buildPartnerRelationships(db: D1Database, userId: string) 
         email: partner.watching_user_email,
         ...(partner.watching_user_name ? { name: partner.watching_user_name } : {}),
       },
-      status: partner.status,
+      status: toPartnerStatus(partner.status),
       digest_cadence: toPublicNotificationCadence(
         partner.settings.email_frequency ?? DEFAULT_EMAIL_FREQUENCY,
       ),
@@ -118,7 +129,7 @@ export async function buildPartnerRelationships(db: D1Database, userId: string) 
         email: partner.watcher_email,
         ...(partner.watcher_name ? { name: partner.watcher_name } : {}),
       },
-      status: partner.status,
+      status: toPartnerStatus(partner.status),
       created_at: partner.created_at,
     })),
   };

--- a/api/src/lib/views.ts
+++ b/api/src/lib/views.ts
@@ -1,0 +1,125 @@
+import { encodeBase64 } from './encoding';
+import {
+  findUserById,
+  getHashState,
+  listDevicesForOwners,
+  listIncomingPartners,
+  listOwnedPartners,
+  listVisibleOwnerIds,
+} from './db';
+import { generateToken } from './jwt';
+import { DEFAULT_EMAIL_FREQUENCY, emailFrequencies } from './email-domain';
+import { Env } from '../types/bindings';
+
+export const ONLINE_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+export async function buildUserView(db: D1Database, userId: string) {
+  const user = await findUserById(db, userId);
+  if (!user) return null;
+  return {
+    id: user.id,
+    email: user.email,
+    email_verified: user.email_verified === 1,
+    email_bounced_at: user.email_bounced_at,
+    settings: user.settings,
+    ...(user.name ? { name: user.name } : {}),
+    ...(user.pub_key ? { pub_key: encodeBase64(user.pub_key) } : {}),
+    ...(user.priv_key ? { priv_key: encodeBase64(user.priv_key) } : {}),
+  };
+}
+
+export async function buildDeviceViews(env: Env, requesterId: string) {
+  const ownerIds = await listVisibleOwnerIds(env.DB, requesterId);
+  const rows = await listDevicesForOwners(env.DB, ownerIds);
+  const hashServerUrl = env.HASH_SERVER_URL?.trim() || null;
+  const hashInfo = new Map<string, { count: number; hashed_at: number | null }>();
+
+  if (hashServerUrl?.endsWith('/api')) {
+    // Hack: when the hash server is this API itself, skip the HTTP round-trip
+    // and read the hash state directly from D1.
+    await Promise.all(
+      rows.map(async (device) => {
+        const state = await getHashState(env.DB, device.id);
+        if (state) {
+          hashInfo.set(device.id, { count: state.count, hashed_at: state.hashed_at });
+        }
+      }),
+    );
+  } else if (hashServerUrl) {
+    await Promise.all(
+      rows.map(async (device) => {
+        try {
+          const token = await generateToken('server', device.id, env.JWT_PRIVATE_KEY, 60);
+          const resp = await fetch(`${hashServerUrl}/hash/info`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (resp.ok) {
+            const info = (await resp.json()) as { count: number; hashed_at: number | null };
+            hashInfo.set(device.id, info);
+          }
+        } catch {
+          // fall back to D1 values for this device
+        }
+      }),
+    );
+  }
+
+  return rows.map((device) => {
+    const hi = hashInfo.get(device.id);
+    return {
+      id: device.id,
+      owner: device.owner,
+      name: device.name,
+      platform: device.platform,
+      last_upload_at: device.last_upload_at,
+      last_hash_at: hi ? hi.hashed_at : device.last_hash_at,
+      pending_count: hi ? hi.count : device.pending_count,
+      status: device.deleted_at
+        ? 'logged_out'
+        : device.last_upload_at && Date.now() - device.last_upload_at < ONLINE_WINDOW_MS
+          ? 'online'
+          : 'offline',
+    };
+  });
+}
+
+function toPublicNotificationCadence(emailFrequency: string | null | undefined) {
+  if (!emailFrequency || !(emailFrequencies as readonly string[]).includes(emailFrequency)) {
+    return 'daily' as const;
+  }
+
+  return emailFrequency as (typeof emailFrequencies)[number];
+}
+
+export async function buildPartnerRelationships(db: D1Database, userId: string) {
+  const [owned, incoming] = await Promise.all([
+    listOwnedPartners(db, userId),
+    listIncomingPartners(db, userId),
+  ]);
+
+  return {
+    watching: incoming.map((partner) => ({
+      id: partner.id,
+      user: {
+        id: partner.watching_user_id,
+        email: partner.watching_user_email,
+        ...(partner.watching_user_name ? { name: partner.watching_user_name } : {}),
+      },
+      status: partner.status,
+      digest_cadence: toPublicNotificationCadence(
+        partner.settings.email_frequency ?? DEFAULT_EMAIL_FREQUENCY,
+      ),
+      created_at: partner.created_at,
+    })),
+    watchers: owned.map((partner) => ({
+      id: partner.id,
+      user: {
+        ...(partner.watcher_id ? { id: partner.watcher_id } : {}),
+        email: partner.watcher_email,
+        ...(partner.watcher_name ? { name: partner.watcher_name } : {}),
+      },
+      status: partner.status,
+      created_at: partner.created_at,
+    })),
+  };
+}

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -24,6 +24,7 @@ import {
 import { sendEmail } from '../lib/email';
 import { decodeBase64, encodeBase64 } from '../lib/encoding';
 import { EMAIL_VERIFICATION_TTL_MS, PASSWORD_RESET_TTL_MS } from '../lib/email-domain';
+import { buildUserView } from '../lib/views';
 import {
   signupRequestSchema,
   signupSchema,
@@ -391,22 +392,13 @@ auth.post('/logout', async (c) => {
 });
 
 auth.get('/user', authenticateWebSession(), async (c) => {
-  const user = await findUserById(c.env.DB, c.get('sub'));
+  const view = await buildUserView(c.env.DB, c.get('sub'));
 
-  if (!user) {
+  if (!view) {
     return c.json({ error: 'User account not found' }, 404);
   }
 
-  return c.json({
-    id: user.id,
-    email: user.email,
-    email_verified: user.email_verified === 1,
-    email_bounced_at: user.email_bounced_at,
-    settings: user.settings,
-    ...(user.name ? { name: user.name } : {}),
-    ...(user.pub_key ? { pub_key: encodeBase64(user.pub_key) } : {}),
-    ...(user.priv_key ? { priv_key: encodeBase64(user.priv_key) } : {}),
-  });
+  return c.json(view);
 });
 
 auth.patch('/user', authenticateWebSession(), validateZ('json', updateUserSchema), async (c) => {

--- a/api/src/routes/batches.ts
+++ b/api/src/routes/batches.ts
@@ -5,7 +5,7 @@ import { canViewUserData, listBatches } from '../lib/db';
 import { validateZ } from '../middleware/validation';
 import { Env, Variables } from '../types/bindings';
 
-const data = new Hono<{ Bindings: Env; Variables: Variables }>();
+const batches = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 function getEncryptedKeyForUser(rawAccessKeys: string, userId: string) {
   try {
@@ -21,13 +21,13 @@ function getEncryptedKeyForUser(rawAccessKeys: string, userId: string) {
   }
 }
 
-const listDataSchema = z.object({
+const listBatchesSchema = z.object({
   device_id: z.uuid().optional(),
   user: z.uuid().optional(),
   since: z.coerce.number().int().nonnegative().optional().default(0),
 });
 
-data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), async (c) => {
+batches.get('/', authenticateWebSession(), validateZ('query', listBatchesSchema), async (c) => {
   const requesterId = c.get('sub');
   const { device_id, user, since } = c.req.valid('query');
   const targetUserId = user ?? requesterId;
@@ -36,10 +36,10 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
     return c.json({ error: 'Forbidden' }, 403);
   }
 
-  const batches = await listBatches(c.env.DB, [targetUserId], { deviceId: device_id, since });
+  const rows = await listBatches(c.env.DB, [targetUserId], { deviceId: device_id, since });
 
   return c.json({
-    batches: batches
+    batches: rows
       .map((batch) => {
         const encryptedKey = getEncryptedKeyForUser(batch.access_keys, requesterId);
         if (!encryptedKey) {
@@ -61,4 +61,4 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
   });
 });
 
-export default data;
+export default batches;

--- a/api/src/routes/devices.ts
+++ b/api/src/routes/devices.ts
@@ -5,82 +5,25 @@ import {
   deleteDeviceById,
   findOwnedDevice,
   findUserById,
-  getHashState,
   listBatchUrlsForDevice,
   listAcceptedNotificationTargetsForUser,
-  listDevicesForOwners,
-  listVisibleOwnerIds,
   updateDevice,
 } from '../lib/db';
 import { sendEmail } from '../lib/email';
 import { renderDeviceDeletedTemplate } from '../lib/email/templates';
 import { deleteObject } from '../lib/r2';
-import { generateToken } from '../lib/jwt';
+import { buildDeviceViews } from '../lib/views';
 import { Env, Variables } from '../types/bindings';
 import { updateDeviceSchema, type PatchDeviceResponse } from '../../../shared-web/types';
 
 const devices = new Hono<{ Bindings: Env; Variables: Variables }>();
-const ONLINE_WINDOW_MS = 2 * 60 * 60 * 1000;
 function getAppUrl(env: Env) {
   return env.APP_URL;
 }
 
 devices.get('/', authenticateWebSession(), async (c) => {
-  const ownerIds = await listVisibleOwnerIds(c.env.DB, c.get('sub'));
-  const rows = await listDevicesForOwners(c.env.DB, ownerIds);
-
-  const hashServerUrl = c.env.HASH_SERVER_URL?.trim() || null;
-  const hashInfo = new Map<string, { count: number; hashed_at: number | null }>();
-
-  if (hashServerUrl?.endsWith('/api')) {
-    // Hack: when the hash server is this API itself, skip the HTTP round-trip
-    // and read the hash state directly from D1.
-    await Promise.all(
-      rows.map(async (device) => {
-        const state = await getHashState(c.env.DB, device.id);
-        if (state) {
-          hashInfo.set(device.id, { count: state.count, hashed_at: state.hashed_at });
-        }
-      }),
-    );
-  } else if (hashServerUrl) {
-    await Promise.all(
-      rows.map(async (device) => {
-        try {
-          const token = await generateToken('server', device.id, c.env.JWT_PRIVATE_KEY, 60);
-          const resp = await fetch(`${hashServerUrl}/hash/info`, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          if (resp.ok) {
-            const info = (await resp.json()) as { count: number; hashed_at: number | null };
-            hashInfo.set(device.id, info);
-          }
-        } catch {
-          // fall back to D1 values for this device
-        }
-      }),
-    );
-  }
-
-  return c.json(
-    rows.map((device) => {
-      const hi = hashInfo.get(device.id);
-      return {
-        id: device.id,
-        owner: device.owner,
-        name: device.name,
-        platform: device.platform,
-        last_upload_at: device.last_upload_at,
-        last_hash_at: hi ? hi.hashed_at : device.last_hash_at,
-        pending_count: hi ? hi.count : device.pending_count,
-        status: device.deleted_at
-          ? 'logged_out'
-          : device.last_upload_at && Date.now() - device.last_upload_at < ONLINE_WINDOW_MS
-            ? 'online'
-            : 'offline',
-      };
-    }),
-  );
+  const views = await buildDeviceViews(c.env, c.get('sub'));
+  return c.json(views);
 });
 
 devices.patch(

--- a/api/src/routes/partners.ts
+++ b/api/src/routes/partners.ts
@@ -13,16 +13,11 @@ import {
   findPartnerInviteForOwner,
   findPartnerForOwnerAndUser,
   findUserById,
-  listIncomingPartners,
-  listOwnedPartners,
   updatePartnerNotificationPreference,
 } from '../lib/db';
 import { renderPartnerAcceptedTemplate, renderPartnerInviteTemplate } from '../lib/email/templates';
-import {
-  DEFAULT_EMAIL_FREQUENCY,
-  emailFrequencies,
-  PARTNER_INVITE_TTL_MS,
-} from '../lib/email-domain';
+import { PARTNER_INVITE_TTL_MS } from '../lib/email-domain';
+import { buildPartnerRelationships } from '../lib/views';
 import {
   createPartnerSchema,
   inviteTokenSchema,
@@ -36,14 +31,6 @@ import { Env, Variables } from '../types/bindings';
 const partners = new Hono<{ Bindings: Env; Variables: Variables }>();
 function getAppUrl(c: Context<{ Bindings: Env; Variables: Variables }>) {
   return c.env.APP_URL;
-}
-
-function toPublicNotificationCadence(emailFrequency: string | null | undefined) {
-  if (!emailFrequency || !(emailFrequencies as readonly string[]).includes(emailFrequency)) {
-    return 'daily' as const;
-  }
-
-  return emailFrequency as (typeof emailFrequencies)[number];
 }
 
 partners.post(
@@ -235,36 +222,8 @@ partners.get('/partner', authenticateWebSession(), async (c) => {
     return c.json({ error: 'Not found' }, 404);
   }
 
-  const [owned, incoming] = await Promise.all([
-    listOwnedPartners(c.env.DB, userId),
-    listIncomingPartners(c.env.DB, userId),
-  ]);
-
-  return c.json({
-    watching: incoming.map((partner) => ({
-      id: partner.id,
-      user: {
-        id: partner.watching_user_id,
-        email: partner.watching_user_email,
-        ...(partner.watching_user_name ? { name: partner.watching_user_name } : {}),
-      },
-      status: partner.status,
-      digest_cadence: toPublicNotificationCadence(
-        partner.settings.email_frequency ?? DEFAULT_EMAIL_FREQUENCY,
-      ),
-      created_at: partner.created_at,
-    })),
-    watchers: owned.map((partner) => ({
-      id: partner.id,
-      user: {
-        ...(partner.watcher_id ? { id: partner.watcher_id } : {}),
-        email: partner.watcher_email,
-        ...(partner.watcher_name ? { name: partner.watcher_name } : {}),
-      },
-      status: partner.status,
-      created_at: partner.created_at,
-    })),
-  });
+  const relationships = await buildPartnerRelationships(c.env.DB, userId);
+  return c.json(relationships);
 });
 
 partners.patch(

--- a/api/src/routes/updates.ts
+++ b/api/src/routes/updates.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono';
+import { authenticateWebSession } from '../middleware/auth';
+import { buildDeviceViews, buildPartnerRelationships, buildUserView } from '../lib/views';
+import { Env, Variables } from '../types/bindings';
+import type { Updates } from '../../../shared-web/types';
+
+const updates = new Hono<{ Bindings: Env; Variables: Variables }>();
+
+updates.get('/updates', authenticateWebSession(), async (c) => {
+  const userId = c.get('sub');
+  const user = await buildUserView(c.env.DB, userId);
+  if (!user) return c.json({ error: 'User account not found' }, 404);
+
+  const [devices, partners] = await Promise.all([
+    buildDeviceViews(c.env, userId),
+    buildPartnerRelationships(c.env.DB, userId),
+  ]);
+  return c.json<Updates>({ user, devices, partners });
+});
+
+export default updates;

--- a/api/test/batches.test.ts
+++ b/api/test/batches.test.ts
@@ -89,7 +89,7 @@ describe('Data and device API routes', () => {
       ],
     });
 
-    const dataRes = await SELF.fetch(`${BASE}/data?since=0`, {
+    const dataRes = await SELF.fetch(`${BASE}/batches?since=0`, {
       headers: authHeaders(userCookie),
     });
     expect(dataRes.status).toBe(200);
@@ -165,7 +165,7 @@ describe('Data and device API routes', () => {
     });
     expect(batchUploadRes.status).toBe(201);
 
-    const ownerDataRes = await SELF.fetch(`${BASE}/data?since=0`, {
+    const ownerDataRes = await SELF.fetch(`${BASE}/batches?since=0`, {
       headers: authHeaders(ownerCookie),
     });
     expect(ownerDataRes.status).toBe(200);
@@ -177,7 +177,7 @@ describe('Data and device API routes', () => {
     );
 
     const partnerDataRes = await SELF.fetch(
-      `${BASE}/data?since=0&user=${encodeURIComponent(ownerUserId)}`,
+      `${BASE}/batches?since=0&user=${encodeURIComponent(ownerUserId)}`,
       {
         headers: authHeaders(partnerCookie),
       },

--- a/api/test/updates.test.ts
+++ b/api/test/updates.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SELF } from 'cloudflare:test';
+import {
+  authHeaders,
+  BASE,
+  clearDB,
+  createDeviceForUser,
+  listEmailDeliveries,
+  signupAndGetCookie,
+} from './helpers';
+
+beforeEach(clearDB);
+
+describe('GET /updates', () => {
+  it('requires authentication', async () => {
+    const res = await SELF.fetch(`${BASE}/updates`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the combined user, devices, and partners shape for a real invite/accept flow', async () => {
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'owner@example.com',
+      'pw',
+      'Owner',
+    );
+    const { cookie: partnerCookie } = await signupAndGetCookie(
+      'partner@example.com',
+      'pw',
+      'Partner',
+    );
+    const device = await createDeviceForUser(ownerCookie, 'Laptop', 'linux');
+
+    const inviteRes = await SELF.fetch(`${BASE}/partner`, {
+      method: 'POST',
+      headers: authHeaders(ownerCookie),
+      body: JSON.stringify({ email: 'partner@example.com' }),
+    });
+    expect(inviteRes.status).toBe(201);
+
+    const inviteDelivery = (await listEmailDeliveries()).find(
+      (delivery) => delivery.kind === 'partner_invite',
+    );
+    const inviteMetadata = JSON.parse(inviteDelivery!.metadata) as { inviteToken: string };
+
+    const acceptRes = await SELF.fetch(`${BASE}/partner/accept`, {
+      method: 'POST',
+      headers: authHeaders(partnerCookie),
+      body: JSON.stringify({ token: inviteMetadata.inviteToken }),
+    });
+    expect(acceptRes.status).toBe(200);
+
+    const ownerUpdatesRes = await SELF.fetch(`${BASE}/updates`, {
+      headers: authHeaders(ownerCookie),
+    });
+    expect(ownerUpdatesRes.status).toBe(200);
+    const ownerUpdates = (await ownerUpdatesRes.json()) as {
+      user: { id: string; email: string };
+      devices: Array<{ id: string; owner: string }>;
+      partners: {
+        watchers: Array<{ status: string; user: { email: string } }>;
+        watching: Array<unknown>;
+      };
+    };
+
+    expect(ownerUpdates.user).toMatchObject({ id: ownerUserId, email: 'owner@example.com' });
+    expect(ownerUpdates.devices).toHaveLength(1);
+    expect(ownerUpdates.devices[0]).toMatchObject({ id: device.id, owner: ownerUserId });
+    expect(ownerUpdates.partners.watchers).toHaveLength(1);
+    expect(ownerUpdates.partners.watchers[0]).toMatchObject({
+      status: 'accepted',
+      user: { email: 'partner@example.com' },
+    });
+    expect(ownerUpdates.partners.watching).toHaveLength(0);
+
+    const partnerUpdatesRes = await SELF.fetch(`${BASE}/updates`, {
+      headers: authHeaders(partnerCookie),
+    });
+    expect(partnerUpdatesRes.status).toBe(200);
+    const partnerUpdates = (await partnerUpdatesRes.json()) as {
+      partners: { watching: Array<{ status: string; user: { email: string } }> };
+    };
+    expect(partnerUpdates.partners.watching).toHaveLength(1);
+    expect(partnerUpdates.partners.watching[0]).toMatchObject({
+      status: 'accepted',
+      user: { email: 'owner@example.com' },
+    });
+  });
+
+  it('matches the independent /user, /device, and /partner responses for the same session', async () => {
+    const { cookie: ownerCookie } = await signupAndGetCookie('owner2@example.com', 'pw', 'Owner');
+    const { cookie: partnerCookie } = await signupAndGetCookie(
+      'partner2@example.com',
+      'pw',
+      'Partner',
+    );
+    await createDeviceForUser(ownerCookie, 'Phone', 'ios');
+
+    const inviteRes = await SELF.fetch(`${BASE}/partner`, {
+      method: 'POST',
+      headers: authHeaders(ownerCookie),
+      body: JSON.stringify({ email: 'partner2@example.com' }),
+    });
+    expect(inviteRes.status).toBe(201);
+    const inviteDelivery = (await listEmailDeliveries()).find(
+      (delivery) => delivery.kind === 'partner_invite',
+    );
+    const inviteMetadata = JSON.parse(inviteDelivery!.metadata) as { inviteToken: string };
+    await SELF.fetch(`${BASE}/partner/accept`, {
+      method: 'POST',
+      headers: authHeaders(partnerCookie),
+      body: JSON.stringify({ token: inviteMetadata.inviteToken }),
+    });
+
+    const [updatesRes, userRes, deviceRes, partnerRes] = await Promise.all([
+      SELF.fetch(`${BASE}/updates`, { headers: authHeaders(ownerCookie) }),
+      SELF.fetch(`${BASE}/user`, { headers: authHeaders(ownerCookie) }),
+      SELF.fetch(`${BASE}/device`, { headers: authHeaders(ownerCookie) }),
+      SELF.fetch(`${BASE}/partner`, { headers: authHeaders(ownerCookie) }),
+    ]);
+
+    expect(updatesRes.status).toBe(200);
+    expect(userRes.status).toBe(200);
+    expect(deviceRes.status).toBe(200);
+    expect(partnerRes.status).toBe(200);
+
+    const updates = (await updatesRes.json()) as {
+      user: unknown;
+      devices: unknown;
+      partners: unknown;
+    };
+    const user = await userRes.json();
+    const devices = await deviceRes.json();
+    const partners = await partnerRes.json();
+
+    expect(updates.user).toEqual(user);
+    expect(updates.devices).toEqual(devices);
+    expect(updates.partners).toEqual(partners);
+  });
+});

--- a/shared-web/types.ts
+++ b/shared-web/types.ts
@@ -71,10 +71,10 @@ export const dataLogSchema = z.object({
 });
 export type DataLog = z.infer<typeof dataLogSchema>;
 
-export const dataPageSchema = z.object({
+export const batchesPageSchema = z.object({
   batches: z.array(batchSchema),
 });
-export type DataPage = z.infer<typeof dataPageSchema>;
+export type BatchesPage = z.infer<typeof batchesPageSchema>;
 
 const partnerUserSchema = z.object({
   id: z.string(),
@@ -104,6 +104,13 @@ export const partnerRelationshipsSchema = z.object({
   watchers: z.array(watcherPartnerSchema),
 });
 export type PartnerRelationships = z.infer<typeof partnerRelationshipsSchema>;
+
+export const updatesSchema = z.object({
+  user: userSchema,
+  devices: z.array(deviceSchema),
+  partners: partnerRelationshipsSchema,
+});
+export type Updates = z.infer<typeof updatesSchema>;
 
 export const partnerInviteValidationSchema = z.object({
   ok: z.boolean(),

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Device, User, WatcherPartner, WatchingPartner } from '../utils/api/api';
+import type { Device, Updates, User, WatcherPartner, WatchingPartner } from '../utils/api/api';
 
 export const TEST_USER: User = {
   id: 'user-1',
@@ -47,4 +47,10 @@ export const TEST_WATCHING: WatchingPartner = {
   status: 'accepted',
   digest_cadence: 'daily',
   created_at: Date.now() - 86_400_000,
+};
+
+export const TEST_UPDATES: Updates = {
+  user: TEST_USER,
+  devices: TEST_DEVICES,
+  partners: { watchers: [TEST_WATCHER], watching: [TEST_WATCHING] },
 };

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { TEST_DEVICES, TEST_USER, TEST_WATCHER, TEST_WATCHING } from './fixtures';
+import { TEST_DEVICES, TEST_UPDATES, TEST_USER, TEST_WATCHER, TEST_WATCHING } from './fixtures';
 
 const BASE = 'http://localhost:8787';
 
@@ -50,6 +50,9 @@ export const handlers = [
   http.patch(`${BASE}/user`, () => HttpResponse.json({ email_verification_required: false })),
   http.delete(`${BASE}/user`, () => new HttpResponse(null, { status: 204 })),
 
+  // ── Updates ────────────────────────────────────────────────────────────
+  http.get(`${BASE}/updates`, () => HttpResponse.json(TEST_UPDATES)),
+
   // ── Email verify ───────────────────────────────────────────────────────
   http.post(`${BASE}/user/verify-email`, () => new HttpResponse(null, { status: 204 })),
 
@@ -76,6 +79,6 @@ export const handlers = [
   http.delete(`${BASE}/partner/watcher/:id`, () => new HttpResponse(null, { status: 204 })),
   http.delete(`${BASE}/partner/watching/:id`, () => new HttpResponse(null, { status: 204 })),
 
-  // ── Data ───────────────────────────────────────────────────────────────
-  http.get(`${BASE}/data`, () => HttpResponse.json({ batches: [] })),
+  // ── Batches ────────────────────────────────────────────────────────────
+  http.get(`${BASE}/batches`, () => HttpResponse.json({ batches: [] })),
 ];

--- a/web/src/pages/Logs/logs.test.tsx
+++ b/web/src/pages/Logs/logs.test.tsx
@@ -45,6 +45,9 @@ vi.mock('../../utils/cache/client', () => ({
     deleteDeviceData: vi.fn().mockResolvedValue(undefined),
     getEventImage: vi.fn().mockResolvedValue(null),
     getDeviceBatchEndTimes: vi.fn().mockResolvedValue([]),
+    refetchUpdates: vi.fn().mockResolvedValue(undefined),
+    subscribeUpdates: vi.fn().mockReturnValue(() => {}),
+    setUnauthorizedHandler: vi.fn(),
   },
 }));
 

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -5,6 +5,23 @@ import { server } from './mocks/server';
 
 expect.extend(matchers);
 
+// Node's test runtime doesn't enable Uint8Array.prototype.toBase64/fromBase64 without the
+// --js-base-64 flag, even though every real browser we ship to supports it natively. Polyfill
+// so tests exercising the crypto/session code paths that use these don't need that flag.
+if (typeof Uint8Array.prototype.toBase64 !== 'function') {
+  Uint8Array.prototype.toBase64 = function toBase64(this: Uint8Array): string {
+    return Buffer.from(this).toString('base64');
+  };
+}
+if (typeof Uint8Array.fromBase64 !== 'function') {
+  Uint8Array.fromBase64 = (base64: string): Uint8Array<ArrayBuffer> => {
+    const buf = Buffer.from(base64, 'base64');
+    const out = new Uint8Array(new ArrayBuffer(buf.length));
+    out.set(buf);
+    return out;
+  };
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/web/src/utils/api/api.ts
+++ b/web/src/utils/api/api.ts
@@ -8,7 +8,8 @@ import type {
   Device,
   Batch,
   DataLog,
-  DataPage,
+  BatchesPage,
+  Updates,
   WatchingPartner,
   WatcherPartner,
   PartnerRelationships,
@@ -31,7 +32,8 @@ export type {
   Device,
   Batch,
   DataLog,
-  DataPage,
+  BatchesPage,
+  Updates,
   WatchingPartner,
   WatcherPartner,
   PartnerRelationships,
@@ -198,6 +200,8 @@ export const api = {
 
   getUser: () => req<User>('/user'),
 
+  getUpdates: () => req<Updates>('/updates'),
+
   updateUser: (fields: UpdateUserPayload) =>
     req<UpdateUserResponse>('/user', {
       method: 'PATCH',
@@ -276,11 +280,11 @@ export const api = {
 
   deleteWatching: (id: string) => req<void>(`/partner/watching/${id}`, { method: 'DELETE' }),
 
-  getData: (params?: { user?: string; since?: number }) => {
+  getBatches: (params?: { user?: string; since?: number }) => {
     const qs = new URLSearchParams();
     if (params?.user) qs.set('user', params.user);
     if (params?.since !== undefined) qs.set('since', String(params.since));
     const query = qs.toString();
-    return req<DataPage>(`/data${query ? `?${query}` : ''}`);
+    return req<BatchesPage>(`/batches${query ? `?${query}` : ''}`);
   },
 };

--- a/web/src/utils/api/client.test.ts
+++ b/web/src/utils/api/client.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { APIClient } from './client';
 import { server } from '../../mocks/server';
-import { TEST_DEVICES, TEST_USER, TEST_WATCHER, TEST_WATCHING } from '../../mocks/fixtures';
+import {
+  TEST_DEVICES,
+  TEST_UPDATES,
+  TEST_USER,
+  TEST_WATCHER,
+  TEST_WATCHING,
+} from '../../mocks/fixtures';
 import { makeFakeSession } from '../../test-utils';
 
 const BASE = 'http://localhost:8787';
@@ -61,6 +67,34 @@ describe('APIClient — user cache', () => {
     const client = new APIClient(makeFakeSession({ user: TEST_USER }));
     expect(client.getUser()).toEqual(TEST_USER);
     expect(callCount).toBe(0);
+  });
+
+  it('seeds user/devices/watchers/watchings from session.updates and skips all fetches', () => {
+    let userCalls = 0;
+    let deviceCalls = 0;
+    let partnerCalls = 0;
+    server.use(
+      http.get(`${BASE}/user`, () => {
+        userCalls++;
+        return HttpResponse.json(TEST_USER);
+      }),
+      http.get(`${BASE}/device`, () => {
+        deviceCalls++;
+        return HttpResponse.json(TEST_DEVICES);
+      }),
+      http.get(`${BASE}/partner`, () => {
+        partnerCalls++;
+        return HttpResponse.json({ watchers: [TEST_WATCHER], watching: [TEST_WATCHING] });
+      }),
+    );
+    const client = new APIClient(makeFakeSession({ user: TEST_USER, updates: TEST_UPDATES }));
+    expect(client.getUser()).toEqual(TEST_USER);
+    expect(client.listDevices()).toEqual(TEST_DEVICES);
+    expect(client.listWatchers()).toEqual([TEST_WATCHER]);
+    expect(client.listWatchings()).toEqual([TEST_WATCHING]);
+    expect(userCalls).toBe(0);
+    expect(deviceCalls).toBe(0);
+    expect(partnerCalls).toBe(0);
   });
 });
 

--- a/web/src/utils/api/client.test.ts
+++ b/web/src/utils/api/client.test.ts
@@ -49,6 +49,19 @@ describe('APIClient — user cache', () => {
     await vi.waitFor(() => expect(client.getUser()).toEqual(TEST_USER));
     expect(cb).not.toHaveBeenCalled();
   });
+
+  it('seeds the cache from session.user and skips the fetch', async () => {
+    let callCount = 0;
+    server.use(
+      http.get(`${BASE}/user`, () => {
+        callCount++;
+        return HttpResponse.json(TEST_USER);
+      }),
+    );
+    const client = new APIClient(makeFakeSession({ user: TEST_USER }));
+    expect(client.getUser()).toEqual(TEST_USER);
+    expect(callCount).toBe(0);
+  });
 });
 
 describe('APIClient — devices cache', () => {

--- a/web/src/utils/api/client.ts
+++ b/web/src/utils/api/client.ts
@@ -84,6 +84,7 @@ export class APIClient {
   constructor(session: Session) {
     this.session = session;
     this.userId = session.userId;
+    this.userCache = session.user ?? null;
     cacheClient?.setSession(session.userId, session.privateKey ?? null);
     session.onTokenRefreshFailed(() => {
       this.fireLogoutOnce();

--- a/web/src/utils/api/client.ts
+++ b/web/src/utils/api/client.ts
@@ -3,6 +3,7 @@ import {
   Batch,
   Device,
   PartnerRelationships,
+  Updates,
   User,
   WatcherPartner,
   WatchingPartner,
@@ -81,14 +82,46 @@ export class APIClient {
   private logoutSubscribers = new Set<() => void>();
   private loggedOut = false;
 
+  private unsubscribeUpdates: (() => void) | null = null;
+
   constructor(session: Session) {
     this.session = session;
     this.userId = session.userId;
+
+    const updates = session.updates;
     this.userCache = session.user ?? null;
+    this.devicesCache = updates?.devices ?? null;
+    this.watchersCache = updates?.partners.watchers ?? null;
+    this.watchingsCache = updates?.partners.watching ?? null;
+
     cacheClient?.setSession(session.userId, session.privateKey ?? null);
+    this.unsubscribeUpdates =
+      cacheClient?.subscribeUpdates((next) => this.applyUpdates(next)) ?? null;
+
     session.onTokenRefreshFailed(() => {
       this.fireLogoutOnce();
     });
+  }
+
+  private applyUpdates(updates: Updates): void {
+    this.userCache = updates.user;
+    notify(this.userSubscribers, updates.user);
+    this.devicesCache = updates.devices;
+    notify(this.devicesSubscribers, updates.devices);
+    this.watchersCache = updates.partners.watchers;
+    notify(this.watchersSubscribers, updates.partners.watchers);
+    this.watchingsCache = updates.partners.watching;
+    notify(this.watchingsSubscribers, updates.partners.watching);
+  }
+
+  private async refreshAfterMutation(fallback: () => Promise<unknown>): Promise<void> {
+    if (cacheClient) {
+      await cacheClient.refetchUpdates().catch((err) => {
+        console.warn('[api-client] worker refetchUpdates failed', err);
+      });
+      return;
+    }
+    await fallback();
   }
 
   // ── User ────────────────────────────────────────────────────────────────
@@ -112,7 +145,7 @@ export class APIClient {
 
   async updateSettings(settings: UserSettings): Promise<UpdateSettingsResult> {
     const result = await api.updateUser(settings);
-    await this.fetchUser(true);
+    await this.refreshAfterMutation(() => this.fetchUser(true));
     return {
       email_verification_required: result.email_verification_required,
       pending_email: result.pending_email,
@@ -223,25 +256,28 @@ export class APIClient {
 
   async invitePartner(email: string): Promise<void> {
     await api.invitePartner(email);
-    await this.fetchPartners(true);
+    await this.refreshAfterMutation(() => this.fetchPartners(true));
   }
 
   async acceptInvite(inviteToken: string): Promise<void> {
     await api.acceptPartnerInvite(inviteToken);
-    await this.fetchPartners(true);
-    await this.fetchDevices(true);
+    await this.refreshAfterMutation(() =>
+      Promise.all([this.fetchPartners(true), this.fetchDevices(true)]),
+    );
   }
 
   async removeWatcher(id: string): Promise<void> {
     await api.deleteWatcher(id);
-    await this.fetchPartners(true);
-    await this.fetchDevices(true);
+    await this.refreshAfterMutation(() =>
+      Promise.all([this.fetchPartners(true), this.fetchDevices(true)]),
+    );
   }
 
   async stopWatching(id: string): Promise<void> {
     await api.deleteWatching(id);
-    await this.fetchPartners(true);
-    await this.fetchDevices(true);
+    await this.refreshAfterMutation(() =>
+      Promise.all([this.fetchPartners(true), this.fetchDevices(true)]),
+    );
   }
 
   private async fetchPartners(force = false): Promise<PartnerRelationships | null> {
@@ -291,7 +327,7 @@ export class APIClient {
 
   async updateDevice(id: string, patch: { name?: string }): Promise<void> {
     await api.patchDevice(id, patch);
-    await this.fetchDevices(true);
+    await this.refreshAfterMutation(() => this.fetchDevices(true));
   }
 
   async removeDevice(id: string): Promise<void> {
@@ -299,7 +335,7 @@ export class APIClient {
     cacheClient
       ?.deleteDeviceData(this.userId, id)
       .catch((err) => console.warn('[api-client] failed to wipe device data from cache', err));
-    await this.fetchDevices(true);
+    await this.refreshAfterMutation(() => this.fetchDevices(true));
   }
 
   private async fetchDevices(force = false): Promise<Device[] | null> {
@@ -361,6 +397,7 @@ export class APIClient {
   private fireLogoutOnce() {
     if (this.loggedOut) return;
     this.loggedOut = true;
+    this.unsubscribeUpdates?.();
     for (const cb of this.logoutSubscribers) {
       try {
         cb();

--- a/web/src/utils/api/session.test.ts
+++ b/web/src/utils/api/session.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { TEST_UPDATES, TEST_USER } from '../../mocks/fixtures';
+import { Session } from './session';
+
+const BASE = 'http://localhost:8787';
+const WRAPPING_KEY_STORAGE = 'virtue_wrapping_key';
+
+async function plantWrappingKey(): Promise<void> {
+  const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+    'encrypt',
+    'decrypt',
+  ]);
+  const raw = await crypto.subtle.exportKey('raw', key);
+  localStorage.setItem(WRAPPING_KEY_STORAGE, btoa(String.fromCharCode(...new Uint8Array(raw))));
+}
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('Session.restore', () => {
+  it('fetches /updates (not /user) and populates both session.user and session.updates', async () => {
+    await plantWrappingKey();
+    let updatesCalls = 0;
+    let userCalls = 0;
+    server.use(
+      http.get(`${BASE}/updates`, () => {
+        updatesCalls++;
+        return HttpResponse.json(TEST_UPDATES);
+      }),
+      http.get(`${BASE}/user`, () => {
+        userCalls++;
+        return HttpResponse.json(TEST_USER);
+      }),
+    );
+
+    const session = await Session.restore();
+
+    expect(session).not.toBeNull();
+    expect(session!.user).toEqual(TEST_UPDATES.user);
+    expect(session!.updates).toEqual(TEST_UPDATES);
+    expect(updatesCalls).toBe(1);
+    expect(userCalls).toBe(0);
+  });
+
+  it('returns null when no wrapping key is stored', async () => {
+    const session = await Session.restore();
+    expect(session).toBeNull();
+  });
+});
+
+describe('Session.fromFinishSignup', () => {
+  it('populates both session.user and session.updates', async () => {
+    let updatesCalls = 0;
+    server.use(
+      http.get(`${BASE}/updates`, () => {
+        updatesCalls++;
+        return HttpResponse.json(TEST_UPDATES);
+      }),
+    );
+
+    const session = await Session.fromFinishSignup('verify-token', 'New User', 'password123');
+
+    expect(session.user).toEqual(TEST_UPDATES.user);
+    expect(session.updates).toEqual(TEST_UPDATES);
+    expect(updatesCalls).toBe(1);
+  }, 20000);
+});

--- a/web/src/utils/api/session.ts
+++ b/web/src/utils/api/session.ts
@@ -1,4 +1,4 @@
-import { api, setUnauthorizedHandler, User } from './api';
+import { api, setUnauthorizedHandler, Updates, User } from './api';
 import { cacheClient } from '../cache/client';
 import {
   decryptBatch,
@@ -38,7 +38,7 @@ export class Session {
   userId: string;
   wrappingKey: CryptoKey;
   privateKey: CryptoKey | null;
-  user: User | null;
+  updates: Updates | null;
   private invalidated = false;
   private onInvalidate: (() => void) | null = null;
 
@@ -46,12 +46,16 @@ export class Session {
     userId: string,
     wrappingKey: CryptoKey,
     privateKey: CryptoKey | null,
-    user: User | null = null,
+    updates: Updates | null = null,
   ) {
     this.userId = userId;
     this.wrappingKey = wrappingKey;
     this.privateKey = privateKey;
-    this.user = user;
+    this.updates = updates;
+  }
+
+  get user(): User | null {
+    return this.updates?.user ?? null;
   }
 
   static async fromLogin(email: string, password: string): Promise<Session> {
@@ -67,9 +71,9 @@ export class Session {
       Intl.DateTimeFormat().resolvedOptions().timeZone,
     );
     await saveWrappingKey(wrappingKey);
-    const user = await api.getUser();
-    const privateKey = await decryptStoredPrivateKey(user, wrappingKey);
-    const session = new Session(user.id, wrappingKey, privateKey, user);
+    const updates = await api.getUpdates();
+    const privateKey = await decryptStoredPrivateKey(updates.user, wrappingKey);
+    const session = new Session(updates.user.id, wrappingKey, privateKey, updates);
     session.installUnauthorizedHandler();
     return session;
   }
@@ -97,8 +101,9 @@ export class Session {
       ...(name ? { name } : {}),
     });
     await saveWrappingKey(wrappingKey);
+    const updates = await api.getUpdates();
     const privateKey = await importUserPrivateKey(keyPair.privateKey);
-    const session = new Session(res.user.id, wrappingKey, privateKey);
+    const session = new Session(res.user.id, wrappingKey, privateKey, updates);
     session.installUnauthorizedHandler();
     return session;
   }
@@ -106,14 +111,14 @@ export class Session {
   static async restore(): Promise<Session | null> {
     const wrappingKey = await loadWrappingKey().catch(() => null);
     if (!wrappingKey) return null;
-    let user: User;
+    let updates: Updates;
     try {
-      user = await api.getUser();
+      updates = await api.getUpdates();
     } catch {
       return null;
     }
-    const privateKey = await decryptStoredPrivateKey(user, wrappingKey);
-    const session = new Session(user.id, wrappingKey, privateKey, user);
+    const privateKey = await decryptStoredPrivateKey(updates.user, wrappingKey);
+    const session = new Session(updates.user.id, wrappingKey, privateKey, updates);
     session.installUnauthorizedHandler();
     return session;
   }
@@ -142,6 +147,7 @@ export class Session {
   private async invalidate(): Promise<void> {
     this.invalidated = true;
     setUnauthorizedHandler(null);
+    cacheClient?.setUnauthorizedHandler(null);
     await cacheClient?.clearCache().catch(() => {});
     clearWrappingKey();
     this.onInvalidate?.();
@@ -149,6 +155,9 @@ export class Session {
 
   private installUnauthorizedHandler() {
     setUnauthorizedHandler(() => {
+      void this.invalidate();
+    });
+    cacheClient?.setUnauthorizedHandler(() => {
       void this.invalidate();
     });
   }

--- a/web/src/utils/api/session.ts
+++ b/web/src/utils/api/session.ts
@@ -38,13 +38,20 @@ export class Session {
   userId: string;
   wrappingKey: CryptoKey;
   privateKey: CryptoKey | null;
+  user: User | null;
   private invalidated = false;
   private onInvalidate: (() => void) | null = null;
 
-  private constructor(userId: string, wrappingKey: CryptoKey, privateKey: CryptoKey | null) {
+  private constructor(
+    userId: string,
+    wrappingKey: CryptoKey,
+    privateKey: CryptoKey | null,
+    user: User | null = null,
+  ) {
     this.userId = userId;
     this.wrappingKey = wrappingKey;
     this.privateKey = privateKey;
+    this.user = user;
   }
 
   static async fromLogin(email: string, password: string): Promise<Session> {
@@ -62,7 +69,7 @@ export class Session {
     await saveWrappingKey(wrappingKey);
     const user = await api.getUser();
     const privateKey = await decryptStoredPrivateKey(user, wrappingKey);
-    const session = new Session(user.id, wrappingKey, privateKey);
+    const session = new Session(user.id, wrappingKey, privateKey, user);
     session.installUnauthorizedHandler();
     return session;
   }
@@ -106,7 +113,7 @@ export class Session {
       return null;
     }
     const privateKey = await decryptStoredPrivateKey(user, wrappingKey);
-    const session = new Session(user.id, wrappingKey, privateKey);
+    const session = new Session(user.id, wrappingKey, privateKey, user);
     session.installUnauthorizedHandler();
     return session;
   }

--- a/web/src/utils/cache/client.ts
+++ b/web/src/utils/cache/client.ts
@@ -1,4 +1,5 @@
 import type { FeedLog } from '../../pages/Logs/types';
+import type { Updates } from '../api/api';
 
 export type CacheQuery = {
   userId?: string;
@@ -17,6 +18,7 @@ export type CacheRequest =
     }
   | { id: string; method: 'cacheQuery'; query: CacheQuery; targetUserId: string }
   | { id: string; method: 'refetch' }
+  | { id: string; method: 'refetchUpdates' }
   | { id: string; method: 'clearCache' }
   | { id: string; method: 'deleteDeviceData'; viewerId: string; deviceId: string }
   | { id: string; method: 'getEventImage'; eventId: string }
@@ -42,6 +44,9 @@ export type CacheChunk = {
 
 // Counts-only progress signal emitted during a sync; carries no log payload.
 export type CacheProgress = { type: 'queryProgress'; id: string; processed: number; total: number };
+
+export type UpdatesChangedBroadcast = { type: 'updatesChanged'; updates: Updates };
+export type UnauthorizedBroadcast = { type: 'unauthorized' };
 
 // A single update delivered to a cacheQuery subscriber. `logs` is present on data updates and
 // omitted on the lightweight intermediate progress ticks, where only the block counts change.
@@ -69,6 +74,9 @@ export interface CacheClient {
     targetUserId: string,
     deviceId: string,
   ): Promise<number[]>;
+  refetchUpdates(): Promise<Updates>;
+  subscribeUpdates(callback: (updates: Updates) => void): () => void;
+  setUnauthorizedHandler(handler: (() => void) | null): void;
 }
 
 const CHANNEL_NAME = 'cache-worker';
@@ -94,6 +102,8 @@ function handleResponse(msg: CacheResponse, pending: Map<string, PendingEntry>) 
 export function createCacheClient(): CacheClient {
   const pending = new Map<string, PendingEntry>();
   const streamCallbacks = new Map<string, CacheQueryCallback>();
+  const updatesCallbacks = new Set<(updates: Updates) => void>();
+  let unauthorizedHandler: (() => void) | null = null;
   const channel = new BroadcastChannel(CHANNEL_NAME);
   let leaderWorker: Worker | null = null;
   let localUserId: string | null = null;
@@ -155,6 +165,14 @@ export function createCacheClient(): CacheClient {
     cb({ done: false, processed: data.processed, total: data.total });
   }
 
+  function handleUpdatesChanged(data: UpdatesChangedBroadcast) {
+    for (const cb of updatesCallbacks) cb(data.updates);
+  }
+
+  function handleUnauthorized() {
+    unauthorizedHandler?.();
+  }
+
   function becomeLeader() {
     console.log('[cache-client] acquired leader lock, starting worker');
     role = 'leader';
@@ -180,12 +198,23 @@ export function createCacheClient(): CacheClient {
     }
 
     leaderWorker.onmessage = (e: MessageEvent) => {
-      const data = e.data as CacheResponse | CacheChunk | CacheProgress;
+      const data = e.data as
+        | CacheResponse
+        | CacheChunk
+        | CacheProgress
+        | UpdatesChangedBroadcast
+        | UnauthorizedBroadcast;
       if ('type' in data && data.type === 'queryChunk') {
         handleChunk(data as CacheChunk);
         channel.postMessage(data);
       } else if ('type' in data && data.type === 'queryProgress') {
         handleProgress(data as CacheProgress);
+        channel.postMessage(data);
+      } else if ('type' in data && data.type === 'updatesChanged') {
+        handleUpdatesChanged(data as UpdatesChangedBroadcast);
+        channel.postMessage(data);
+      } else if ('type' in data && data.type === 'unauthorized') {
+        handleUnauthorized();
         channel.postMessage(data);
       } else {
         handleResponse(data as CacheResponse, pending);
@@ -247,6 +276,14 @@ export function createCacheClient(): CacheClient {
       handleProgress(data as unknown as CacheProgress);
       return;
     }
+    if (data?.type === 'updatesChanged') {
+      handleUpdatesChanged(data as unknown as UpdatesChangedBroadcast);
+      return;
+    }
+    if (data?.type === 'unauthorized') {
+      handleUnauthorized();
+      return;
+    }
     handleResponse(data as unknown as CacheResponse, pending);
   };
 
@@ -294,6 +331,17 @@ export function createCacheClient(): CacheClient {
 
     getDeviceBatchEndTimes: (viewerId, targetUserId, deviceId) =>
       call<number[]>({ method: 'getDeviceBatchEndTimes', viewerId, targetUserId, deviceId }),
+
+    refetchUpdates: () => call<Updates>({ method: 'refetchUpdates' }),
+
+    subscribeUpdates: (callback) => {
+      updatesCallbacks.add(callback);
+      return () => updatesCallbacks.delete(callback);
+    },
+
+    setUnauthorizedHandler: (handler) => {
+      unauthorizedHandler = handler;
+    },
   };
 }
 

--- a/web/src/utils/cache/worker.ts
+++ b/web/src/utils/cache/worker.ts
@@ -3,7 +3,7 @@ import sqlite3InitModule from '@sqlite.org/sqlite-wasm';
 import { decryptAndFlattenBatch, DecryptionError } from '../api/batch-materializer';
 import { unwrapBatchKey } from '../api/crypto';
 import { createNativeBatchKeyUnwrapper } from '../api/hpke-native';
-import type { Batch, DataPage } from '../api/api';
+import type { Batch, BatchesPage, Updates } from '../api/api';
 import type { FeedLog } from '../../pages/Logs/types';
 
 export type {};
@@ -28,6 +28,7 @@ type CacheRequest =
     }
   | { id: string; method: 'cacheQuery'; query: WorkerCacheQuery; targetUserId: string }
   | { id: string; method: 'refetch' }
+  | { id: string; method: 'refetchUpdates' }
   | { id: string; method: 'clearCache' }
   | { id: string; method: 'deleteDeviceData'; viewerId: string; deviceId: string }
   | { id: string; method: 'getEventImage'; eventId: string }
@@ -55,6 +56,8 @@ type CacheChunk = {
 // stays a fixed ~tiny size no matter how much data has accumulated. The full log set is
 // only ever shipped on the fast-path chunk and the final done chunk.
 type CacheProgress = { type: 'queryProgress'; id: string; processed: number; total: number };
+type UpdatesChangedBroadcast = { type: 'updatesChanged'; updates: Updates };
+type UnauthorizedBroadcast = { type: 'unauthorized' };
 
 // ---------------------------------------------------------------------------
 // SQLite / OPFS
@@ -151,7 +154,7 @@ function sqlGetSince(viewerId: string, targetUserId: string): number {
   );
 }
 
-function sqlMergeDataPage(viewerId: string, targetUserId: string, page: DataPage): void {
+function sqlMergeBatchesPage(viewerId: string, targetUserId: string, page: BatchesPage): void {
   db.exec('BEGIN');
   try {
     for (const batch of page.batches) {
@@ -432,6 +435,19 @@ function postProgress(id: string, processed: number, total: number): void {
   } satisfies CacheProgress);
 }
 
+function postUpdatesChanged(updates: Updates): void {
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage({
+    type: 'updatesChanged',
+    updates,
+  } satisfies UpdatesChangedBroadcast);
+}
+
+function postUnauthorized(): void {
+  (self as unknown as DedicatedWorkerGlobalScope).postMessage({
+    type: 'unauthorized',
+  } satisfies UnauthorizedBroadcast);
+}
+
 // JS mirror of the WHERE clauses in sqlQueryEvents, used to filter in-memory delta events
 // for a query without re-hitting SQLite.
 function matchesQuery(log: FeedLog, query: WorkerCacheQuery): boolean {
@@ -445,16 +461,30 @@ function matchesQuery(log: FeedLog, query: WorkerCacheQuery): boolean {
   return true;
 }
 
-async function fetchData(params?: { user?: string; since?: number }): Promise<DataPage> {
+function reportIfUnauthorized(res: Response): void {
+  if (res.status === 401) postUnauthorized();
+}
+
+async function fetchBatches(params?: { user?: string; since?: number }): Promise<BatchesPage> {
   const qs = new URLSearchParams();
   if (params?.user) qs.set('user', params.user);
   if (params?.since !== undefined) qs.set('since', String(params.since));
   const q = qs.toString();
-  const res = await fetch(`${BASE}/data${q ? `?${q}` : ''}`, {
+  const res = await fetch(`${BASE}/batches${q ? `?${q}` : ''}`, {
     credentials: 'include',
   });
-  if (!res.ok) throw new Error(`getData failed: ${res.status}`);
-  return res.json() as Promise<DataPage>;
+  reportIfUnauthorized(res);
+  if (!res.ok) throw new Error(`getBatches failed: ${res.status}`);
+  return res.json() as Promise<BatchesPage>;
+}
+
+async function fetchUpdates(): Promise<Updates> {
+  const res = await fetch(`${BASE}/updates`, {
+    credentials: 'include',
+  });
+  reportIfUnauthorized(res);
+  if (!res.ok) throw new Error(`getUpdates failed: ${res.status}`);
+  return res.json() as Promise<Updates>;
 }
 
 // ---------------------------------------------------------------------------
@@ -488,13 +518,13 @@ async function fetchAndDecrypt(targetUserId: string): Promise<void> {
 
   try {
     const since = sqlGetSince(viewerId, targetUserId);
-    console.log('[cache-worker] fetching /data since=', since, 'for', targetUserId);
-    const page = await fetchData({
+    console.log('[cache-worker] fetching /batches since=', since, 'for', targetUserId);
+    const page = await fetchBatches({
       user: targetUserId === viewerId ? undefined : targetUserId,
       since,
     });
-    console.log('[cache-worker] /data returned', page.batches.length, 'batches');
-    sqlMergeDataPage(viewerId, targetUserId, page);
+    console.log('[cache-worker] /batches returned', page.batches.length, 'batches');
+    sqlMergeBatchesPage(viewerId, targetUserId, page);
   } catch (err) {
     console.warn('[cache-worker] fetch failed for', targetUserId, err);
     serveAll();
@@ -673,6 +703,11 @@ async function handleStreaming(
 // One-shot handlers
 
 async function dispatchOneShot(req: CacheRequest): Promise<unknown> {
+  if (req.method === 'refetchUpdates') {
+    const updates = await fetchUpdates();
+    postUpdatesChanged(updates);
+    return updates;
+  }
   if (req.method === 'clearCache') {
     sqlClearAll();
     return 0;


### PR DESCRIPTION
## Summary

- Adds a consolidated `GET /updates` endpoint (`{ user, devices, partners }`) so an authenticated page load fires one round trip instead of 3-4 separate GETs (`/user` twice, `/device`, `/partner`).
- Extends the existing leader-elected cross-tab cache worker (`web/src/utils/cache/worker.ts` + `client.ts`) to also own `/updates`: after any mutation (invite/accept partner, remove watcher/watching, update/remove device, update settings) the refresh routes through the worker, which refetches and broadcasts the fresh snapshot to every open tab live, no manual refresh needed.
- Renames `/data` to `/batches` now that `/updates` exists and means something different.
- Bootstrap (`Session.restore()`/`fromLogin()`/`fromFinishSignup()`) stays a plain direct `fetch('/updates')` on the main thread — login-state detection never depends on the Worker/OPFS/sqlite-wasm stack being healthy.

## Changes

Type of change: Feature / Refactor
Components: Web / API

- `api/src/lib/views.ts` (new): shared response-builders (`buildUserView`, `buildDeviceViews`, `buildPartnerRelationships`) used by `/user`, `/device`, `/partner`, and the new `/updates`.
- `api/src/routes/updates.ts` (new): `GET /updates`.
- `api/src/routes/data.ts` → `api/src/routes/batches.ts` (renamed, mounted at `/batches`).
- `shared-web/types.ts`: `DataPage` → `BatchesPage`, new `Updates` schema.
- `web/src/utils/api/session.ts`: `Session` stores `updates`, `user` is now a derived getter; `fromLogin`/`restore`/`fromFinishSignup` call `getUpdates()`.
- `web/src/utils/cache/worker.ts` + `web/src/utils/cache/client.ts`: new `refetchUpdates` request, `updatesChanged`/`unauthorized` broadcasts, `subscribeUpdates`/`setUnauthorizedHandler` on `CacheClient`.
- `web/src/utils/api/client.ts` (`APIClient`): seeds caches from `session.updates`, subscribes to worker broadcasts, mutation methods route their post-mutation refresh through `refetchUpdates` (falling back to today's per-resource refetch when the worker is unavailable).

## Testing

- `api/`: full test suite passes (13 files, 52 tests), including new `api/test/updates.test.ts` (401 check, combined-shape check against a real invite/accept flow, and a parity check against the independent `/user`/`/device`/`/partner` responses) and renamed `api/test/batches.test.ts`.
- `web/`: full test suite passes (14 files, 107 tests), including a new seed-from-`session.updates` test in `client.test.ts` and a new `session.test.ts` covering `restore()`/`fromFinishSignup()` populating `session.updates`.
- `tsc --noEmit` clean in both `api/` and `web/`.
- Manual, via `./scripts/launch.sh`: signed up a fresh account and confirmed via DevTools Network that a hard reload fires exactly one `GET /updates` (no `/user`, `/device`, `/partner`), plus the separately-timed `/batches` sync. Opened a second tab, confirmed leader/follower election in the console, changed the display name in tab 1's Settings page, and confirmed tab 2's sidebar updated live with no reload and no independent `/updates` fetch of its own (received via `BroadcastChannel`). No console errors observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sPadRU8okHuFvQB1Xbue4