### PR TITLE
Refactor device-facing API routes and fold client login/settings/notify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,10 @@ Key files:
 - Rust: `client/core/src/crypto.rs`
 - TypeScript: `web/src/crypto.ts` (`unwrapBatchKey`, `encryptForPublicKey`)
 
+The `access_keys` JSON envelope and `DeviceSettings` shape are also shared between Rust and
+the API, but are plain JSON relay shapes — not independently-reimplemented crypto — so they
+aren't listed as one of the five contracts above. See `api/API.md` for their wire shapes.
+
 ## Key invariant files
 
 Read these before touching crypto, batch, or auth code:

--- a/api/API.md
+++ b/api/API.md
@@ -12,7 +12,7 @@ Base URL examples:
 - `Base64`: base64-encoded binary
 - `SHA256`: lowercase hex-encoded SHA-256 digest
 - `RefreshToken`: opaque web-session string. Set as the HTTPOnly `refresh_token` cookie by `POST /login`, `POST /signup`, and `POST /email-verification/validate`, and also returned in the `POST /login` body.
-- `HashServerToken`: EdDSA JWT (`Ed25519`) with `type: "hash-server"` and `sub = device id`
+- `HashServerToken`: EdDSA JWT (`Ed25519`) with `type: "hash-server"` and `sub = device id`; minted by `POST /d/device`, `GET /d/device`, and `POST /d/batch`
 - `DeviceRefreshToken`: opaque string returned by `POST /d/device`
 - `ServerToken`: EdDSA JWT (`Ed25519`) with `type: "server"` and `sub = device id`
 
@@ -602,35 +602,15 @@ should pass the largest `created_at` they've seen as `since` on subsequent syncs
 
 The following routes use device auth:
 
-- `POST /d/device` uses the authenticated web session cookie
-- `POST /d/token`, `GET /d/device`, `POST /d/batch`, and `POST /d/notify` use a `DeviceRefreshToken`
+- `POST /d/device` takes the owner's email + `password_auth` directly (same credential
+  material as `POST /login`) — no web session or prior device session required
+- `POST /d/logout`, `GET /d/device`, and `POST /d/batch` use a `DeviceRefreshToken`
 - `POST /hash`, `GET /hash`, and `DELETE /hash` use a `HashServerToken` or `ServerToken` as applicable
 
-### `POST /d/device`
+### DeviceSettings
 
-Registers a device for the authenticated user.
-
-Request:
-
-```js
-{
-  "name": "My Laptop",
-  "platform": "linux"
-}
-```
-
-Response `201`:
-
-```js
-{
-  "id": UUID,
-  "refresh_token": DeviceRefreshToken
-}
-```
-
-### `GET /d/device`
-
-Response `200`:
+Shared shape embedded (alongside a fresh `token`) in the responses of `POST /d/device`,
+`GET /d/device`, and `POST /d/batch`:
 
 ```js
 {
@@ -651,17 +631,61 @@ Response `200`:
 device owner (when they have a public key) followed by all accepted partners.
 The owner, when present, is always the first entry.
 
-### `POST /d/token`
+### `POST /d/device`
 
-Exchanges the `DeviceRefreshToken` (sent as `Bearer`) for a short-lived hash-server JWT.
+Registers a device for the user identified by `email`/`password_auth` — the same
+credential verification `POST /login` performs (401 on bad credentials, 403 if the
+account's email isn't verified). Since this is the device's very first call, no prior
+session of any kind is required.
+
+Request:
+
+```js
+{
+  "email": "user@example.com",
+  "password_auth": Base64,
+  "name": "My Laptop",
+  "platform": "linux"
+}
+```
+
+Response `201`:
+
+```js
+{
+  "refresh_token": DeviceRefreshToken,
+  "settings": DeviceSettings,
+  "token": HashServerToken
+}
+```
+
+Registration alone is enough to start operating: the device gets its credentials,
+initial settings, and an initial hash token in one round trip, with no follow-up call
+needed before its first hash upload.
+
+### `GET /d/device`
+
+Refreshes settings and mints a fresh hash-server token for the authenticated device.
+This is the manual/periodic refresh path — used by clients when their cached hash token
+goes stale without a batch upload happening in the meantime — and also the replacement
+for the removed `POST /d/token`.
 
 Response `200`:
 
 ```js
 {
-  "hash_token": HashServerToken
+  "settings": DeviceSettings,
+  "token": HashServerToken
 }
 ```
+
+### `POST /d/logout`
+
+Revokes the authenticated device's session and soft-deletes it. Clears the device's
+hash-chain state as a best-effort cleanup; batches/screenshots and the device row itself
+are untouched (that's the separate manual hard-delete flow via `DELETE /device/:id`).
+
+Response: `204` with no body.
 
 ### `POST /d/batch`
 
@@ -672,6 +696,7 @@ Multipart form request:
 - `access_keys`: JSON string
 - `high_risk_count`: non-negative integer, optional, default `0`
 - `medium_risk_count`: non-negative integer, optional, default `0`
+- `notifications`: JSON string, optional — array of alert-email entries (see below)
 - `file`: encrypted batch blob
 
 `high_risk_count`/`medium_risk_count` are risk-band tallies computed client-side from the
@@ -683,14 +708,31 @@ used to summarize tamper activity in partner digest emails.
 
 ```js
 {
-  "keys": [
-    {
-      "user_id": UUID,
-      "hpke_key": Base64
-    }
-  ]
+  "keys": {
+    "<user_id UUID>": Base64 // hpke_key
+  }
 }
 ```
+
+`notifications` JSON shape — a JSON-encoded array, each entry triggering the alert email
+for one high-risk event once the batch is durably persisted (best-effort: a failure here
+does not roll back the already-committed batch). The event body itself lives in the
+encrypted batch; each entry only carries what the notification email needs:
+
+```js
+[
+  {
+    ts: DateTime,
+    type: 'system_event',
+    risk: 0.7,
+    title: 'Device reported system event.' | undefined,
+    details: '...' | undefined,
+  },
+];
+```
+
+`risk` is required (`0`-`1`) on each entry. `title`/`details` are optional; when omitted,
+a default title is derived from `type` and no details are included.
 
 Response `201`:
 
@@ -700,39 +742,14 @@ Response `201`:
   "start_time": DateTime,
   "end_time": DateTime,
   "end_hash": SHA256,
-  "url": "https://.../user/.../batches/...enc"
+  "url": "https://.../user/.../batches/...enc",
+  "settings": DeviceSettings,
+  "token": HashServerToken
 }
 ```
 
-### `POST /d/notify`
-
-Sends the alert email for a high-risk event. The event body itself is uploaded separately
-via the encrypted `POST /d/batch` pipeline; this endpoint only carries the metadata needed
-to render the notification email and persists nothing server-side. Replaces the removed
-`POST /d/log` endpoint.
-
-Request:
-
-```js
-{
-  "ts": DateTime,
-  "type": "system_event",
-  "risk": 0.7,
-  "title": "Device reported system event." | undefined,
-  "details": "..." | undefined
-}
-```
-
-`risk` is required (`0`-`1`). `title`/`details` are optional; when omitted, a default title
-is derived from `type` and no details are included.
-
-Response `202`:
-
-```js
-{
-  "ok": true
-}
-```
+Every batch upload refreshes both settings and the hash token, piggybacking on the
+response so the device rarely needs a dedicated `GET /d/device` call.
 
 ## Hash API
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -6,12 +6,12 @@ Cloudflare Workers API using Hono. Entry point: `src/index.ts`.
 
 Two kinds of credential exist: **opaque session refresh tokens** (looked up in the `sessions` table) and **short-lived EdDSA JWTs**.
 
-| Token                | Kind   | TTL        | Auth header             | Notes                                                    |
-| -------------------- | ------ | ---------- | ----------------------- | -------------------------------------------------------- |
-| web refresh token    | opaque | 1 year     | `refresh_token` cookie¹ | Authenticates user/web routes directly                   |
-| device refresh token | opaque | ~1000 yr   | `Bearer <token>`        | Authenticates `/d/*` routes directly                     |
-| `hash-server`        | JWT    | 1 hour     | `Bearer <jwt>`          | Hash-server routes (`/hash`); minted by `POST /d/token`  |
-| `server`             | JWT    | 60 seconds | `Bearer <jwt>`          | Server-to-server (e.g. `DELETE /hash`, `GET /hash/info`) |
+| Token                | Kind   | TTL        | Auth header             | Notes                                                                                      |
+| -------------------- | ------ | ---------- | ----------------------- | ------------------------------------------------------------------------------------------ |
+| web refresh token    | opaque | 1 year     | `refresh_token` cookie¹ | Authenticates user/web routes directly                                                     |
+| device refresh token | opaque | ~1000 yr   | `Bearer <token>`        | Authenticates `/d/*` routes directly                                                       |
+| `hash-server`        | JWT    | 1 hour     | `Bearer <jwt>`          | Hash-server routes (`/hash`); minted by `POST /d/device`, `GET /d/device`, `POST /d/batch` |
+| `server`             | JWT    | 60 seconds | `Bearer <jwt>`          | Server-to-server (e.g. `DELETE /hash`, `GET /hash/info`)                                   |
 
 ¹ The web refresh token is also accepted as `Bearer <token>` (used by the cache worker).
 
@@ -40,9 +40,12 @@ HTTP status codes: 400 bad request, 401 unauthorized, 403 forbidden, 404 not fou
 ## Key files
 
 - `src/lib/db.ts` — all D1 database queries
+- `src/lib/hash-server.ts` — hash-chain state access (local D1 or remote hash server), used by `hashes.ts`, `device-only.ts`, `devices.ts`
+- `src/lib/credentials.ts` — `verifyUserCredentials`, shared by `POST /login` and `POST /d/device`
+- `src/lib/app-url.ts` — `getAppUrl`, shared by every route that links back to the web app in an email
 - `src/middleware/auth.ts` — JWT verification, sets `c.get('sub')`
 - `src/middleware/validation.ts` — Zod validation wrapper
-- `src/routes/device-only.ts` — batch upload and device log endpoints
+- `src/routes/device-only.ts` — device registration, settings, and batch upload endpoints
 - `src/routes/data.ts` — data retrieval with access control
 - `API.md` — complete endpoint specification
 

--- a/api/src/lib/app-url.ts
+++ b/api/src/lib/app-url.ts
@@ -1,5 +1,0 @@
-import { Env } from '../types/bindings';
-
-export function getAppUrl(env: Env): string {
-  return env.APP_URL;
-}

--- a/api/src/lib/app-url.ts
+++ b/api/src/lib/app-url.ts
@@ -1,0 +1,5 @@
+import { Env } from '../types/bindings';
+
+export function getAppUrl(env: Env): string {
+  return env.APP_URL;
+}

--- a/api/src/lib/credentials.ts
+++ b/api/src/lib/credentials.ts
@@ -1,0 +1,44 @@
+import { findUserByEmail } from './db';
+import { decodeBase64 } from './encoding';
+import { verifyPasswordAuth } from './password';
+
+type User = NonNullable<Awaited<ReturnType<typeof findUserByEmail>>>;
+
+export type VerifyCredentialsResult =
+  | { status: 'ok'; user: User }
+  | { status: 'invalid' }
+  | { status: 'unverified'; user: User };
+
+function decodePasswordAuth(value: string): ArrayBuffer | null {
+  let decoded: ArrayBuffer;
+  try {
+    decoded = decodeBase64(value);
+  } catch {
+    return null;
+  }
+  return new Uint8Array(decoded).byteLength === 32 ? decoded : null;
+}
+
+export async function verifyUserCredentials(
+  db: D1Database,
+  email: string,
+  passwordAuthBase64: string,
+): Promise<VerifyCredentialsResult> {
+  const normalizedEmail = email.trim().toLowerCase();
+  const user = await findUserByEmail(db, normalizedEmail);
+
+  const decodedPasswordAuth = decodePasswordAuth(passwordAuthBase64);
+  if (!decodedPasswordAuth) {
+    return { status: 'invalid' };
+  }
+
+  if (!user || !(await verifyPasswordAuth(decodedPasswordAuth, user.password_hash))) {
+    return { status: 'invalid' };
+  }
+
+  if (user.email_verified !== 1) {
+    return { status: 'unverified', user };
+  }
+
+  return { status: 'ok', user };
+}

--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -13,7 +13,7 @@ function parseUserSettings(json: string | null): { email_frequency: string; time
   }
 }
 
-function uuidToBytes(uuid: string): ArrayBuffer {
+export function uuidToBytes(uuid: string): ArrayBuffer {
   const normalized = normalizeUuidString(uuid);
   const hex = normalized.replace(/-/g, '');
 
@@ -1139,80 +1139,4 @@ export async function listDigestEligiblePartnerships(db: D1Database) {
     ['partnership_id', 'watching_user_id', 'watcher_user_id'],
   );
   return rows.map((row) => ({ ...row, settings: parseUserSettings(row.settings) }));
-}
-
-export async function getHashState(db: D1Database, deviceId: string) {
-  return firstWithUuidFields<{
-    device_id: string;
-    state: ArrayBuffer;
-    updated_at: number;
-    count: number;
-    hashed_at: number | null;
-  }>(
-    db
-      .prepare(
-        'SELECT device_id, state, updated_at, count, hashed_at FROM hash_states WHERE device_id = ?',
-      )
-      .bind(uuidToBytes(deviceId)),
-    ['device_id'],
-  );
-}
-
-export async function upsertHashState(
-  db: D1Database,
-  input: { device_id: string; state: ArrayBuffer; updated_at: number; hashed_at: number },
-) {
-  return db
-    .prepare(
-      `INSERT INTO hash_states (device_id, state, updated_at, count, hashed_at)
-       VALUES (?, ?, ?, 1, ?)
-       ON CONFLICT(device_id) DO UPDATE SET
-           state = excluded.state,
-           updated_at = excluded.updated_at,
-           count = count + 1,
-           hashed_at = excluded.hashed_at`,
-    )
-    .bind(uuidToBytes(input.device_id), input.state, input.updated_at, input.hashed_at)
-    .run();
-}
-
-export async function resetHashState(db: D1Database, deviceId: string, updatedAt: number) {
-  return db
-    .prepare(
-      `INSERT INTO hash_states (device_id, state, updated_at, count)
-       VALUES (?, ?, ?, 0)
-       ON CONFLICT(device_id) DO UPDATE SET
-           state = excluded.state,
-           updated_at = excluded.updated_at,
-           count = 0`,
-    )
-    .bind(uuidToBytes(deviceId), new Uint8Array(32).buffer, updatedAt)
-    .run();
-}
-
-export async function incrementHashCount(db: D1Database, deviceId: string, now: number) {
-  return db
-    .prepare(
-      `INSERT INTO hash_states (device_id, state, updated_at, count, hashed_at)
-       VALUES (?, ?, ?, 1, ?)
-       ON CONFLICT(device_id) DO UPDATE SET
-           count = count + 1,
-           hashed_at = excluded.hashed_at,
-           updated_at = excluded.updated_at`,
-    )
-    .bind(uuidToBytes(deviceId), new Uint8Array(32).buffer, now, now)
-    .run();
-}
-
-export async function resetHashCount(db: D1Database, deviceId: string, now: number) {
-  return db
-    .prepare(
-      `INSERT INTO hash_states (device_id, state, updated_at, count)
-       VALUES (?, ?, ?, 0)
-       ON CONFLICT(device_id) DO UPDATE SET
-           count = 0,
-           updated_at = excluded.updated_at`,
-    )
-    .bind(uuidToBytes(deviceId), new Uint8Array(32).buffer, now)
-    .run();
 }

--- a/api/src/lib/hash-server.ts
+++ b/api/src/lib/hash-server.ts
@@ -1,0 +1,98 @@
+import { uuidToBytes } from './db';
+import { generateToken } from './jwt';
+import { Env } from '../types/bindings';
+
+const ZERO_STATE = new Uint8Array(32);
+
+async function readHashStateRow(db: D1Database, deviceId: string) {
+  // No uuid-field decoding needed here (unlike db.ts's old getHashState) since we
+  // already have deviceId as a string and don't need device_id back in the row.
+  return db
+    .prepare('SELECT state, updated_at, count, hashed_at FROM hash_states WHERE device_id = ?')
+    .bind(uuidToBytes(deviceId))
+    .first<{ state: ArrayBuffer; updated_at: number; count: number; hashed_at: number | null }>();
+}
+
+export async function localHashGet(db: D1Database, deviceId: string): Promise<Uint8Array> {
+  const row = await readHashStateRow(db, deviceId);
+  return row ? new Uint8Array(row.state) : ZERO_STATE;
+}
+
+export async function localHashReset(db: D1Database, deviceId: string): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO hash_states (device_id, state, updated_at, count)
+       VALUES (?, ?, ?, 0)
+       ON CONFLICT(device_id) DO UPDATE SET state = excluded.state, updated_at = excluded.updated_at, count = 0`,
+    )
+    .bind(uuidToBytes(deviceId), ZERO_STATE.buffer, Date.now())
+    .run();
+}
+
+export async function localHashIngest(
+  db: D1Database,
+  deviceId: string,
+  content: Uint8Array,
+): Promise<void> {
+  const now = Date.now();
+  const current = await localHashGet(db, deviceId);
+  const hashInput = new Uint8Array(64);
+  hashInput.set(current, 0);
+  hashInput.set(content, 32);
+  const nextState = await crypto.subtle.digest('SHA-256', hashInput);
+  await db
+    .prepare(
+      `INSERT INTO hash_states (device_id, state, updated_at, count, hashed_at)
+       VALUES (?, ?, ?, 1, ?)
+       ON CONFLICT(device_id) DO UPDATE SET state = excluded.state, updated_at = excluded.updated_at, count = count + 1, hashed_at = excluded.hashed_at`,
+    )
+    .bind(uuidToBytes(deviceId), nextState, now, now)
+    .run();
+}
+
+// Used by hashes.ts's GET /hash/info and by devices.ts's batched local-branch lookup —
+// the one hash-state read shape that isn't get/reset/ingest, kept here so it's still
+// the single owner of hash_states access instead of a duplicate query living in db.ts.
+// Returns null (not a zero-filled object) when no row exists — devices.ts's caller
+// relies on this to distinguish "no hash data yet" (falls back to its own denormalized
+// device.last_hash_at/pending_count columns) from "a real row with zero values".
+export async function localHashInfo(db: D1Database, deviceId: string) {
+  const row = await readHashStateRow(db, deviceId);
+  return row ? { count: row.count, hashed_at: row.hashed_at, updated_at: row.updated_at } : null;
+}
+
+function isLocalHashServer(env: Env): boolean {
+  const url = env.HASH_SERVER_URL?.trim();
+  return !url || url.endsWith('/api');
+}
+
+export async function hashGet(env: Env, deviceId: string): Promise<Uint8Array> {
+  if (isLocalHashServer(env)) return localHashGet(env.DB, deviceId);
+  const token = await generateToken('hash-server', deviceId, env.JWT_PRIVATE_KEY, 60);
+  const resp = await fetch(`${env.HASH_SERVER_URL!.trim()}/hash`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) throw new Error(`remote hash server GET /hash failed: ${resp.status}`);
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+export async function hashReset(env: Env, deviceId: string): Promise<void> {
+  if (isLocalHashServer(env)) return localHashReset(env.DB, deviceId);
+  const token = await generateToken('server', deviceId, env.JWT_PRIVATE_KEY, 60);
+  const resp = await fetch(`${env.HASH_SERVER_URL!.trim()}/hash`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) throw new Error(`remote hash server DELETE /hash failed: ${resp.status}`);
+}
+
+export async function hashIngest(env: Env, deviceId: string, content: Uint8Array): Promise<void> {
+  if (isLocalHashServer(env)) return localHashIngest(env.DB, deviceId, content);
+  const token = await generateToken('hash-server', deviceId, env.JWT_PRIVATE_KEY, 60);
+  const resp = await fetch(`${env.HASH_SERVER_URL!.trim()}/hash`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/octet-stream' },
+    body: content,
+  });
+  if (!resp.ok) throw new Error(`remote hash server POST /hash failed: ${resp.status}`);
+}

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -44,11 +44,12 @@ import {
   HASH_PARAMS_VERSION,
   generatePasswordSalt,
   hashPasswordAuth,
-  verifyPasswordAuth,
 } from '../lib/password';
 import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
 import { deleteObject } from '../lib/r2';
+import { getAppUrl } from '../lib/app-url';
+import { verifyUserCredentials } from '../lib/credentials';
 
 const auth = new Hono<{ Bindings: Env; Variables: Variables }>();
 const REFRESH_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
@@ -126,10 +127,6 @@ async function createSession(
   return refreshToken;
 }
 
-function getAppUrl(c: Context<{ Bindings: Env; Variables: Variables }>) {
-  return c.env.APP_URL;
-}
-
 async function issueEmailToken(
   db: D1Database,
   user: { id: string; email: string },
@@ -158,10 +155,10 @@ async function sendVerificationEmail(
   user: { id: string; email: string; name?: string | null },
   token: string,
 ) {
-  const verifyUrl = `${getAppUrl(c)}/verify-email?token=${encodeURIComponent(token)}`;
+  const verifyUrl = `${getAppUrl(c.env)}/verify-email?token=${encodeURIComponent(token)}`;
   const email = renderEmailVerificationTemplate({
     appName: c.env.APP_NAME,
-    appUrl: getAppUrl(c),
+    appUrl: getAppUrl(c.env),
     recipientName: user.name,
     verifyUrl,
   });
@@ -189,10 +186,10 @@ async function sendSignupConfirmationEmail(
   if (options?.to) {
     params.set('to', options.to);
   }
-  const verifyUrl = `${getAppUrl(c)}/signup?${params.toString()}`;
+  const verifyUrl = `${getAppUrl(c.env)}/signup?${params.toString()}`;
   const email = renderEmailVerificationTemplate({
     appName: c.env.APP_NAME,
-    appUrl: getAppUrl(c),
+    appUrl: getAppUrl(c.env),
     recipientName: recipient.name,
     verifyUrl,
   });
@@ -214,10 +211,10 @@ async function sendPasswordResetEmail(
   user: { id: string; email: string; name?: string | null },
 ) {
   const token = await issueEmailToken(c.env.DB, user, 'password_reset', PASSWORD_RESET_TTL_MS);
-  const resetUrl = `${getAppUrl(c)}/forgot-password?token=${encodeURIComponent(token)}`;
+  const resetUrl = `${getAppUrl(c.env)}/forgot-password?token=${encodeURIComponent(token)}`;
   const email = renderPasswordResetTemplate({
     appName: c.env.APP_NAME,
-    appUrl: getAppUrl(c),
+    appUrl: getAppUrl(c.env),
     recipientName: user.name,
     resetUrl,
   });
@@ -355,23 +352,17 @@ auth.post('/signup', validateZ('json', signupSchema), async (c) => {
 
 auth.post('/login', validateZ('json', loginSchema), async (c) => {
   const { email, password_auth, timezone } = c.req.valid('json');
-  const normalizedEmail = email.trim().toLowerCase();
-  const user = await findUserByEmail(c.env.DB, normalizedEmail);
+  const result = await verifyUserCredentials(c.env.DB, email, password_auth);
 
-  let decodedPasswordAuth: ArrayBuffer;
-  try {
-    decodedPasswordAuth = decodePasswordAuth(password_auth);
-  } catch {
+  if (result.status === 'invalid') {
     return c.json({ error: 'Invalid email or password' }, 401);
   }
 
-  if (!user || !(await verifyPasswordAuth(decodedPasswordAuth, user.password_hash))) {
-    return c.json({ error: 'Invalid email or password' }, 401);
-  }
-
-  if (user.email_verified !== 1) {
+  if (result.status === 'unverified') {
     return c.json({ error: 'Please verify your email before logging in.' }, 403);
   }
+
+  const { user } = result;
 
   if (timezone) {
     await updateUser(c.env.DB, user.id, { settings: { timezone } });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -48,7 +48,6 @@ import {
 import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
 import { deleteObject } from '../lib/r2';
-import { getAppUrl } from '../lib/app-url';
 import { verifyUserCredentials } from '../lib/credentials';
 
 const auth = new Hono<{ Bindings: Env; Variables: Variables }>();
@@ -155,10 +154,10 @@ async function sendVerificationEmail(
   user: { id: string; email: string; name?: string | null },
   token: string,
 ) {
-  const verifyUrl = `${getAppUrl(c.env)}/verify-email?token=${encodeURIComponent(token)}`;
+  const verifyUrl = `${c.env.APP_URL}/verify-email?token=${encodeURIComponent(token)}`;
   const email = renderEmailVerificationTemplate({
     appName: c.env.APP_NAME,
-    appUrl: getAppUrl(c.env),
+    appUrl: c.env.APP_URL,
     recipientName: user.name,
     verifyUrl,
   });
@@ -186,10 +185,10 @@ async function sendSignupConfirmationEmail(
   if (options?.to) {
     params.set('to', options.to);
   }
-  const verifyUrl = `${getAppUrl(c.env)}/signup?${params.toString()}`;
+  const verifyUrl = `${c.env.APP_URL}/signup?${params.toString()}`;
   const email = renderEmailVerificationTemplate({
     appName: c.env.APP_NAME,
-    appUrl: getAppUrl(c.env),
+    appUrl: c.env.APP_URL,
     recipientName: recipient.name,
     verifyUrl,
   });
@@ -211,10 +210,10 @@ async function sendPasswordResetEmail(
   user: { id: string; email: string; name?: string | null },
 ) {
   const token = await issueEmailToken(c.env.DB, user, 'password_reset', PASSWORD_RESET_TTL_MS);
-  const resetUrl = `${getAppUrl(c.env)}/forgot-password?token=${encodeURIComponent(token)}`;
+  const resetUrl = `${c.env.APP_URL}/forgot-password?token=${encodeURIComponent(token)}`;
   const email = renderPasswordResetTemplate({
     appName: c.env.APP_NAME,
-    appUrl: getAppUrl(c.env),
+    appUrl: c.env.APP_URL,
     recipientName: user.name,
     resetUrl,
   });

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -9,13 +9,8 @@ const data = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 function getEncryptedKeyForUser(rawAccessKeys: string, userId: string) {
   try {
-    const payload = JSON.parse(rawAccessKeys) as {
-      keys?: Array<{ user_id?: string; hpke_key?: string }>;
-    };
-    return (
-      payload.keys?.find((key) => key.user_id === userId && typeof key.hpke_key === 'string')
-        ?.hpke_key ?? null
-    );
+    const payload = JSON.parse(rawAccessKeys) as { keys?: Record<string, string> };
+    return payload.keys?.[userId] ?? null;
   } catch {
     return null;
   }

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -1,7 +1,7 @@
 import { Context, Hono } from 'hono';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
-import { authenticateWebSession, authenticateDeviceSession } from '../middleware/auth';
+import { authenticateDeviceSession } from '../middleware/auth';
 import { rateLimitByDevice } from '../middleware/rate-limit';
 import { validateZ } from '../middleware/validation';
 import {
@@ -9,31 +9,38 @@ import {
   createDevice,
   createSessionRecord,
   deleteDeviceSessionsByDeviceId,
-  getHashState,
   findDeviceById,
   listBatchAccessRecipientsForOwner,
   markDeviceDeleted,
-  resetHashState as resetStoredHashState,
 } from '../lib/db';
+import { hashGet, hashReset } from '../lib/hash-server';
 import { encodeBase64, encodeHex } from '../lib/encoding';
 import { generateToken } from '../lib/jwt';
 import { putObject } from '../lib/r2';
 import { notifyPartnersAboutRiskLog, riskToSeverity } from '../lib/tamper';
 import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
+import { getAppUrl } from '../lib/app-url';
+import { verifyUserCredentials } from '../lib/credentials';
 
 const deviceOnly = new Hono<{ Bindings: Env; Variables: Variables }>();
-const ZERO_STATE = new Uint8Array(32);
 
-function getAppUrl(c: Context<{ Bindings: Env; Variables: Variables }>) {
-  return c.env.APP_URL;
-}
 const HASH_TOKEN_TTL_SECONDS = 60 * 60;
 const DEVICE_REFRESH_TOKEN_TTL_SECONDS = 1000 * 365 * 24 * 60 * 60;
 
-const createDeviceSchema = z.object({
+const registerDeviceSchema = z.object({
+  email: z.email(),
+  password_auth: z.base64(),
   name: z.string().min(1),
   platform: z.string().min(1),
+});
+
+const notifyEntrySchema = z.object({
+  ts: z.number().int().nonnegative(),
+  type: z.string().min(1),
+  risk: z.number().min(0).max(1),
+  title: z.string().optional(),
+  details: z.string().optional(),
 });
 
 const uploadBatchSchema = z.object({
@@ -42,57 +49,23 @@ const uploadBatchSchema = z.object({
   access_keys: z.string().min(1),
   high_risk_count: z.coerce.number().int().nonnegative().optional().default(0),
   medium_risk_count: z.coerce.number().int().nonnegative().optional().default(0),
+  notifications: z.string().optional(),
   file: z
     .instanceof(File)
     .refine((file) => file.size > 0, { message: 'File is empty' })
     .refine((file) => file.size <= 100 * 1024 * 1024, { message: 'File exceeds 100MB limit' }),
 });
 
-const accessKeyEntrySchema = z.object({
-  user_id: z.uuid(),
-  hpke_key: z.base64(),
-});
-
 const accessKeysSchema = z.object({
-  keys: z.array(accessKeyEntrySchema).min(1),
-});
-
-const notifySchema = z.object({
-  ts: z.number().int().nonnegative(),
-  type: z.string().min(1),
-  risk: z.number().min(0).max(1),
-  title: z.string().optional(),
-  details: z.string().optional(),
+  keys: z.record(z.uuid(), z.base64()),
 });
 
 function parseAccessKeysPayload(raw: string) {
-  const parsed = JSON.parse(raw) as unknown;
-  const payload = accessKeysSchema.parse(parsed);
-  const seen = new Set<string>();
-
-  for (const key of payload.keys) {
-    if (seen.has(key.user_id)) {
-      throw new Error('access_keys contains duplicate user_id entries');
-    }
-    seen.add(key.user_id);
-  }
-
-  return payload;
+  return accessKeysSchema.parse(JSON.parse(raw) as unknown);
 }
 
-async function readHashState(
-  c: Context<{ Bindings: Env; Variables: Variables }>,
-  deviceId: string,
-) {
-  const state = await getHashState(c.env.DB, deviceId);
-  return state ? state.state : ZERO_STATE.buffer;
-}
-
-async function resetHashState(
-  c: Context<{ Bindings: Env; Variables: Variables }>,
-  device: { id: string; owner: string },
-) {
-  await resetStoredHashState(c.env.DB, device.id, Date.now());
+function parseNotificationsPayload(raw: string) {
+  return z.array(notifyEntrySchema).parse(JSON.parse(raw) as unknown);
 }
 
 async function createDeviceSession(
@@ -114,43 +87,21 @@ async function createDeviceSession(
 }
 
 /**
- * POST /d/device - Register a device using the authenticated web session cookie.
+ * Builds the {settings, token} pair embedded in POST /d/device, GET /d/device, and
+ * POST /d/batch responses — the one canonical place a device's wrapping keys and a
+ * fresh hash-server token are assembled.
  */
-deviceOnly.post(
-  '/device',
-  authenticateWebSession(),
-  validateZ('json', createDeviceSchema),
-  async (c) => {
-    const { name, platform } = c.req.valid('json');
-    const owner = c.get('sub');
-    const id = uuidv4();
-
-    await createDevice(c.env.DB, { id, owner, name, platform });
-
-    const refreshToken = await createDeviceSession(c, id);
-
-    return c.json({ id, refresh_token: refreshToken }, 201);
-  },
-);
-
-/**
- * GET /d/device - Get device settings for the authenticated device.
- */
-deviceOnly.get('/device', authenticateDeviceSession(), rateLimitByDevice(), async (c) => {
-  const device = await findDeviceById(c.env.DB, c.get('sub'));
-
-  if (!device) {
-    return c.json({ error: 'Not found' }, 404);
-  }
-
+async function buildDeviceState(
+  c: Context<{ Bindings: Env; Variables: Variables }>,
+  device: { id: string; owner: string; name: string; platform: string },
+) {
   const hashBaseUrl = c.env.HASH_SERVER_URL?.trim();
   if (!hashBaseUrl) {
-    return c.json({ error: 'Hash server not configured' }, 500);
+    return null; // caller returns the existing 500
   }
 
   const recipients = await listBatchAccessRecipientsForOwner(c.env.DB, device.owner);
-
-  return c.json({
+  const settings = {
     id: device.id,
     name: device.name,
     platform: device.platform,
@@ -159,7 +110,66 @@ deviceOnly.get('/device', authenticateDeviceSession(), rateLimitByDevice(), asyn
       pub_key: encodeBase64(recipient.pub_key!),
     })),
     hash_base_url: hashBaseUrl,
-  });
+  };
+  const token = await generateToken(
+    'hash-server',
+    device.id,
+    c.env.JWT_PRIVATE_KEY,
+    HASH_TOKEN_TTL_SECONDS,
+  );
+
+  return { settings, token };
+}
+
+/**
+ * POST /d/device - Register a device using the owner's email + password_auth
+ * (the same credential material POST /login accepts). No web session required —
+ * this is the device's first call, made before it has any session of its own.
+ */
+deviceOnly.post('/device', validateZ('json', registerDeviceSchema), async (c) => {
+  const { email, password_auth, name, platform } = c.req.valid('json');
+  const result = await verifyUserCredentials(c.env.DB, email, password_auth);
+
+  if (result.status === 'invalid') {
+    return c.json({ error: 'Invalid email or password' }, 401);
+  }
+
+  if (result.status === 'unverified') {
+    return c.json({ error: 'Please verify your email before logging in.' }, 403);
+  }
+
+  const owner = result.user.id;
+  const id = uuidv4();
+
+  await createDevice(c.env.DB, { id, owner, name, platform });
+  const refreshToken = await createDeviceSession(c, id);
+
+  const state = await buildDeviceState(c, { id, owner, name, platform });
+  if (!state) {
+    return c.json({ error: 'Hash server not configured' }, 500);
+  }
+
+  return c.json({ refresh_token: refreshToken, ...state }, 201);
+});
+
+/**
+ * GET /d/device - Refresh settings and mint a fresh hash-server token for the
+ * authenticated device. Used by the client as the manual/periodic refresh path
+ * when its cached hash token goes stale without a batch upload in between.
+ */
+deviceOnly.get('/device', authenticateDeviceSession(), rateLimitByDevice(), async (c) => {
+  const device = await findDeviceById(c.env.DB, c.get('sub'));
+
+  if (!device) {
+    return c.json({ error: 'Not found' }, 404);
+  }
+
+  const state = await buildDeviceState(c, device);
+  if (!state) {
+    return c.json({ error: 'Hash server not configured' }, 500);
+  }
+
+  return c.json(state);
 });
 
 /**
@@ -175,17 +185,8 @@ deviceOnly.post('/logout', authenticateDeviceSession(), async (c) => {
   await deleteDeviceSessionsByDeviceId(c.env.DB, deviceId);
   await markDeviceDeleted(c.env.DB, deviceId, now);
 
-  const hashServerUrl = c.env.HASH_SERVER_URL?.trim();
   try {
-    if (hashServerUrl?.endsWith('/api')) {
-      await resetStoredHashState(c.env.DB, deviceId, now);
-    } else if (hashServerUrl) {
-      const token = await generateToken('server', deviceId, c.env.JWT_PRIVATE_KEY, 60);
-      await fetch(`${hashServerUrl}/hash`, {
-        method: 'DELETE',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-    }
+    await hashReset(c.env, deviceId);
   } catch {
     // Non-fatal — logout/soft-delete already committed; hash state is best-effort.
   }
@@ -194,27 +195,11 @@ deviceOnly.post('/logout', authenticateDeviceSession(), async (c) => {
 });
 
 /**
- * POST /d/token - Exchange the opaque device refresh token for a short-lived hash-server JWT.
- */
-deviceOnly.post('/token', authenticateDeviceSession(), async (c) => {
-  const deviceId = c.get('sub');
-  const device = await findDeviceById(c.env.DB, deviceId);
-  if (!device) {
-    return c.json({ error: 'Not found' }, 404);
-  }
-
-  const hashToken = await generateToken(
-    'hash-server',
-    deviceId,
-    c.env.JWT_PRIVATE_KEY,
-    HASH_TOKEN_TTL_SECONDS,
-  );
-
-  return c.json({ hash_token: hashToken });
-});
-
-/**
  * POST /d/batch - Upload an encrypted batch blob for the authenticated device.
+ *
+ * Optionally carries a `notifications` field (JSON-encoded array) alongside the
+ * batch: after the batch is durably persisted, each entry triggers the same
+ * best-effort partner alert email that POST /d/notify used to send standalone.
  */
 deviceOnly.post(
   '/batch',
@@ -228,24 +213,37 @@ deviceOnly.post(
       return c.json({ error: 'Not found' }, 404);
     }
 
-    const { start_time, end_time, access_keys, high_risk_count, medium_risk_count, file } =
-      c.req.valid('form');
+    const {
+      start_time,
+      end_time,
+      access_keys,
+      high_risk_count,
+      medium_risk_count,
+      notifications: rawNotifications,
+      file,
+    } = c.req.valid('form');
 
-    const hashState = await readHashState(c, device.id);
+    const hashState = await hashGet(c.env, device.id);
     const endHash = encodeHex(hashState);
     const batchId = uuidv4();
     const key = `user/${device.owner}/batches/${batchId}.enc`;
     const url = `${c.env.R2_URL}/${key}`;
     const createdAt = Date.now();
     let parsedAccessKeys: z.infer<typeof accessKeysSchema>;
+    let notifications: z.infer<typeof notifyEntrySchema>[] = [];
 
     try {
       parsedAccessKeys = parseAccessKeysPayload(access_keys);
+      notifications = rawNotifications ? parseNotificationsPayload(rawNotifications) : [];
     } catch (error) {
       return c.json(
         {
           error: 'Bad Request',
-          details: { errors: [error instanceof Error ? error.message : 'Invalid access_keys'] },
+          details: {
+            errors: [
+              error instanceof Error ? error.message : 'Invalid access_keys or notifications',
+            ],
+          },
         },
         400,
       );
@@ -265,50 +263,37 @@ deviceOnly.post(
       medium_risk_count,
       created_at: createdAt,
     });
-    await resetHashState(c, device);
+    await hashReset(c.env, device.id);
 
-    return c.json({ id: batchId, start_time, end_time, end_hash: endHash, url }, 201);
-  },
-);
-
-/**
- * POST /d/notify - Send an alert email for a high-risk event.
- *
- * The event itself is uploaded (end-to-end encrypted) via POST /d/batch; this
- * endpoint only carries the minimal metadata needed to render the notification
- * email and is not persisted. Replaces the removed POST /d/log endpoint.
- */
-deviceOnly.post(
-  '/notify',
-  authenticateDeviceSession(),
-  rateLimitByDevice(),
-  validateZ('json', notifySchema),
-  async (c) => {
-    const device = await findDeviceById(c.env.DB, c.get('sub'));
-
-    if (!device) {
-      return c.json({ error: 'Not found' }, 404);
+    for (const notification of notifications) {
+      try {
+        const providedTitle = notification.title?.trim();
+        const providedDetails = notification.details?.trim();
+        await notifyPartnersAboutRiskLog(c.env.DB, c.env, {
+          logId: uuidv4(),
+          appUrl: getAppUrl(c.env),
+          userId: device.owner,
+          deviceName: device.name,
+          severity: riskToSeverity(notification.risk) ?? 'info',
+          risk: notification.risk,
+          title:
+            providedTitle && providedTitle.length > 0
+              ? providedTitle
+              : `Device reported ${notification.type.replaceAll('_', ' ')}.`,
+          details: providedDetails && providedDetails.length > 0 ? providedDetails : null,
+          happenedAt: notification.ts,
+        });
+      } catch {
+        // Best-effort — the batch itself already committed successfully.
+      }
     }
 
-    const notification = c.req.valid('json');
-    const providedTitle = notification.title?.trim();
-    const providedDetails = notification.details?.trim();
-    await notifyPartnersAboutRiskLog(c.env.DB, c.env, {
-      logId: uuidv4(),
-      appUrl: getAppUrl(c),
-      userId: device.owner,
-      deviceName: device.name,
-      severity: riskToSeverity(notification.risk) ?? 'info',
-      risk: notification.risk,
-      title:
-        providedTitle && providedTitle.length > 0
-          ? providedTitle
-          : `Device reported ${notification.type.replaceAll('_', ' ')}.`,
-      details: providedDetails && providedDetails.length > 0 ? providedDetails : null,
-      happenedAt: notification.ts,
-    });
+    const state = await buildDeviceState(c, device);
+    if (!state) {
+      return c.json({ error: 'Hash server not configured' }, 500);
+    }
 
-    return c.json({ ok: true }, 202);
+    return c.json({ id: batchId, start_time, end_time, end_hash: endHash, url, ...state }, 201);
   },
 );
 

--- a/api/src/routes/device-only.ts
+++ b/api/src/routes/device-only.ts
@@ -20,7 +20,6 @@ import { putObject } from '../lib/r2';
 import { notifyPartnersAboutRiskLog, riskToSeverity } from '../lib/tamper';
 import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
-import { getAppUrl } from '../lib/app-url';
 import { verifyUserCredentials } from '../lib/credentials';
 
 const deviceOnly = new Hono<{ Bindings: Env; Variables: Variables }>();
@@ -271,7 +270,7 @@ deviceOnly.post(
         const providedDetails = notification.details?.trim();
         await notifyPartnersAboutRiskLog(c.env.DB, c.env, {
           logId: uuidv4(),
-          appUrl: getAppUrl(c.env),
+          appUrl: c.env.APP_URL,
           userId: device.owner,
           deviceName: device.name,
           severity: riskToSeverity(notification.risk) ?? 'info',

--- a/api/src/routes/devices.ts
+++ b/api/src/routes/devices.ts
@@ -18,7 +18,6 @@ import { deleteObject } from '../lib/r2';
 import { generateToken } from '../lib/jwt';
 import { Env, Variables } from '../types/bindings';
 import { updateDeviceSchema, type PatchDeviceResponse } from '../../../shared-web/types';
-import { getAppUrl } from '../lib/app-url';
 
 const devices = new Hono<{ Bindings: Env; Variables: Variables }>();
 const ONLINE_WINDOW_MS = 2 * 60 * 60 * 1000;
@@ -123,7 +122,7 @@ devices.delete('/:id', authenticateWebSession(), async (c) => {
   if (owner) {
     const email = renderDeviceDeletedTemplate({
       appName: c.env.APP_NAME,
-      appUrl: getAppUrl(c.env),
+      appUrl: c.env.APP_URL,
       recipientName: owner.name,
       deviceName: device.name,
       devicePlatform: device.platform,
@@ -150,7 +149,7 @@ devices.delete('/:id', authenticateWebSession(), async (c) => {
 
     const email = renderDeviceDeletedTemplate({
       appName: c.env.APP_NAME,
-      appUrl: getAppUrl(c.env),
+      appUrl: c.env.APP_URL,
       recipientName: target.watcher_name,
       deviceName: device.name,
       devicePlatform: device.platform,

--- a/api/src/routes/devices.ts
+++ b/api/src/routes/devices.ts
@@ -5,25 +5,23 @@ import {
   deleteDeviceById,
   findOwnedDevice,
   findUserById,
-  getHashState,
   listBatchUrlsForDevice,
   listAcceptedNotificationTargetsForUser,
   listDevicesForOwners,
   listVisibleOwnerIds,
   updateDevice,
 } from '../lib/db';
+import { localHashInfo } from '../lib/hash-server';
 import { sendEmail } from '../lib/email';
 import { renderDeviceDeletedTemplate } from '../lib/email/templates';
 import { deleteObject } from '../lib/r2';
 import { generateToken } from '../lib/jwt';
 import { Env, Variables } from '../types/bindings';
 import { updateDeviceSchema, type PatchDeviceResponse } from '../../../shared-web/types';
+import { getAppUrl } from '../lib/app-url';
 
 const devices = new Hono<{ Bindings: Env; Variables: Variables }>();
 const ONLINE_WINDOW_MS = 2 * 60 * 60 * 1000;
-function getAppUrl(env: Env) {
-  return env.APP_URL;
-}
 
 devices.get('/', authenticateWebSession(), async (c) => {
   const ownerIds = await listVisibleOwnerIds(c.env.DB, c.get('sub'));
@@ -37,9 +35,9 @@ devices.get('/', authenticateWebSession(), async (c) => {
     // and read the hash state directly from D1.
     await Promise.all(
       rows.map(async (device) => {
-        const state = await getHashState(c.env.DB, device.id);
-        if (state) {
-          hashInfo.set(device.id, { count: state.count, hashed_at: state.hashed_at });
+        const info = await localHashInfo(c.env.DB, device.id);
+        if (info) {
+          hashInfo.set(device.id, { count: info.count, hashed_at: info.hashed_at });
         }
       }),
     );

--- a/api/src/routes/hashes.ts
+++ b/api/src/routes/hashes.ts
@@ -1,11 +1,10 @@
 import { Hono } from 'hono';
 import { authenticate } from '../middleware/auth';
 import { rateLimitByDevice } from '../middleware/rate-limit';
-import { findDeviceById, getHashState, resetHashState, upsertHashState } from '../lib/db';
+import { localHashGet, localHashIngest, localHashInfo, localHashReset } from '../lib/hash-server';
 import { Env, Variables } from '../types/bindings';
 
 const hashes = new Hono<{ Bindings: Env; Variables: Variables }>();
-const ZERO_STATE = new Uint8Array(32);
 
 hashes.post('/', authenticate('hash-server'), rateLimitByDevice(), async (c) => {
   const body = await c.req.arrayBuffer();
@@ -14,27 +13,13 @@ hashes.post('/', authenticate('hash-server'), rateLimitByDevice(), async (c) => 
     return c.json({ error: 'Bad Request', details: { body: ['Expected exactly 32 bytes'] } }, 400);
   }
 
-  const now = Date.now();
-  const deviceId = c.get('sub');
-  const current = await getHashState(c.env.DB, deviceId);
-  const hashInput = new Uint8Array(64);
-  hashInput.set(current ? new Uint8Array(current.state) : ZERO_STATE, 0);
-  hashInput.set(new Uint8Array(body), 32);
-
-  const nextState = await crypto.subtle.digest('SHA-256', hashInput);
-  await upsertHashState(c.env.DB, {
-    device_id: deviceId,
-    state: nextState,
-    updated_at: now,
-    hashed_at: now,
-  });
+  await localHashIngest(c.env.DB, c.get('sub'), new Uint8Array(body));
 
   return c.json({ ok: true });
 });
 
 hashes.get('/', authenticate('hash-server'), rateLimitByDevice(), async (c) => {
-  const state = await getHashState(c.env.DB, c.get('sub'));
-  const body = state ? new Uint8Array(state.state) : ZERO_STATE;
+  const body = await localHashGet(c.env.DB, c.get('sub'));
 
   return new Response(body, {
     headers: { 'Content-Type': 'application/octet-stream' },
@@ -42,21 +27,16 @@ hashes.get('/', authenticate('hash-server'), rateLimitByDevice(), async (c) => {
 });
 
 hashes.delete('/', authenticate('server'), async (c) => {
-  const device = await findDeviceById(c.env.DB, c.get('sub'));
-  if (!device) {
-    return c.json({ error: 'Not found' }, 404);
-  }
-
-  await resetHashState(c.env.DB, device.id, Date.now());
+  await localHashReset(c.env.DB, c.get('sub'));
   return c.json({ ok: true });
 });
 
 hashes.get('/info', authenticate(['hash-server', 'server']), async (c) => {
-  const state = await getHashState(c.env.DB, c.get('sub'));
+  const info = await localHashInfo(c.env.DB, c.get('sub'));
   return c.json({
-    count: state?.count ?? 0,
-    hashed_at: state?.hashed_at ?? null,
-    updated_at: state?.updated_at ?? null,
+    count: info?.count ?? 0,
+    hashed_at: info?.hashed_at ?? null,
+    updated_at: info?.updated_at ?? null,
   });
 });
 

--- a/api/src/routes/partners.ts
+++ b/api/src/routes/partners.ts
@@ -32,7 +32,6 @@ import {
 import { sendEmail } from '../lib/email';
 import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
-import { getAppUrl } from '../lib/app-url';
 
 const partners = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -95,8 +94,8 @@ partners.post(
       ownerName: currentUser.name,
       ownerEmail: currentUser.email,
       appName: c.env.APP_NAME,
-      appUrl: getAppUrl(c.env),
-      inviteUrl: `${getAppUrl(c.env)}/invite-accept?partner_token=${encodeURIComponent(inviteToken)}`,
+      appUrl: c.env.APP_URL,
+      inviteUrl: `${c.env.APP_URL}/invite-accept?partner_token=${encodeURIComponent(inviteToken)}`,
     });
     await sendEmail({
       env: c.env,
@@ -205,7 +204,7 @@ partners.post(
         partnerName: currentUser.name,
         partnerEmail: currentUser.email,
         appName: c.env.APP_NAME,
-        appUrl: getAppUrl(c.env),
+        appUrl: c.env.APP_URL,
       });
       await sendEmail({
         env: c.env,

--- a/api/src/routes/partners.ts
+++ b/api/src/routes/partners.ts
@@ -1,4 +1,4 @@
-import { Context, Hono } from 'hono';
+import { Hono } from 'hono';
 import { v4 as uuidv4 } from 'uuid';
 import { authenticateWebSession } from '../middleware/auth';
 import { validateZ } from '../middleware/validation';
@@ -32,11 +32,9 @@ import {
 import { sendEmail } from '../lib/email';
 import { generateOpaqueToken, hashOpaqueToken } from '../lib/tokens';
 import { Env, Variables } from '../types/bindings';
+import { getAppUrl } from '../lib/app-url';
 
 const partners = new Hono<{ Bindings: Env; Variables: Variables }>();
-function getAppUrl(c: Context<{ Bindings: Env; Variables: Variables }>) {
-  return c.env.APP_URL;
-}
 
 function toPublicNotificationCadence(emailFrequency: string | null | undefined) {
   if (!emailFrequency || !(emailFrequencies as readonly string[]).includes(emailFrequency)) {
@@ -97,8 +95,8 @@ partners.post(
       ownerName: currentUser.name,
       ownerEmail: currentUser.email,
       appName: c.env.APP_NAME,
-      appUrl: getAppUrl(c),
-      inviteUrl: `${getAppUrl(c)}/invite-accept?partner_token=${encodeURIComponent(inviteToken)}`,
+      appUrl: getAppUrl(c.env),
+      inviteUrl: `${getAppUrl(c.env)}/invite-accept?partner_token=${encodeURIComponent(inviteToken)}`,
     });
     await sendEmail({
       env: c.env,
@@ -207,7 +205,7 @@ partners.post(
         partnerName: currentUser.name,
         partnerEmail: currentUser.email,
         appName: c.env.APP_NAME,
-        appUrl: getAppUrl(c),
+        appUrl: getAppUrl(c.env),
       });
       await sendEmail({
         env: c.env,

--- a/api/test/auth-routes.test.ts
+++ b/api/test/auth-routes.test.ts
@@ -362,18 +362,11 @@ describe('Auth routes', () => {
 
   it('requires matching email confirmation and permanently deletes the account with cascaded data cleanup', async () => {
     const { cookie, userId } = await signupAndGetCookie('delete-me@example.com', 'pw', 'Delete Me');
-    const device = await createDeviceForUser(cookie, 'Phone', 'ios');
-
-    const hashTokenRes = await SELF.fetch(`${BASE}/d/token`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${device.refresh_token}` },
-    });
-    expect(hashTokenRes.status).toBe(200);
-    const { hash_token } = (await hashTokenRes.json()) as { hash_token: string };
+    const device = await createDeviceForUser('delete-me@example.com', 'pw', 'Phone', 'ios');
 
     const hashUploadRes = await SELF.fetch(`${BASE}/hash`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${hash_token}` },
+      headers: { Authorization: `Bearer ${device.token}` },
       body: new Uint8Array(32).fill(9),
     });
     expect(hashUploadRes.status).toBe(200);
@@ -384,7 +377,7 @@ describe('Auth routes', () => {
     form.set(
       'access_keys',
       JSON.stringify({
-        keys: [{ user_id: userId, hpke_key: Buffer.from('owner-envelope').toString('base64') }],
+        keys: { [userId]: Buffer.from('owner-envelope').toString('base64') },
       }),
     );
     form.set('file', new File([new Uint8Array([4, 5, 6])], 'batch.enc'));

--- a/api/test/data.test.ts
+++ b/api/test/data.test.ts
@@ -16,31 +16,26 @@ beforeEach(clearDB);
 describe('Data and device API routes', () => {
   it('handles device registration, settings, batch upload, and filtered data listing', async () => {
     const { cookie: userCookie, userId } = await signupAndGetCookie('alice@example.com');
-    const device = await createDeviceForUser(userCookie, 'Phone', 'ios');
+    const device = await createDeviceForUser('alice@example.com', 'password123', 'Phone', 'ios');
 
     const deviceInfoRes = await SELF.fetch(`${BASE}/d/device`, {
       headers: { Authorization: `Bearer ${device.refresh_token}` },
     });
     expect(deviceInfoRes.status).toBe(200);
     const deviceInfo = (await deviceInfoRes.json()) as {
-      wrapping_keys: Array<{ user_id: string; pub_key: string }>;
-      hash_base_url: string;
+      settings: {
+        wrapping_keys: Array<{ user_id: string; pub_key: string }>;
+        hash_base_url: string;
+      };
+      token: string;
     };
-    expect(deviceInfo.wrapping_keys).toHaveLength(1);
-    expect(deviceInfo.wrapping_keys[0]?.user_id).toBe(userId);
-    expect(deviceInfo.hash_base_url).toBeTruthy();
-
-    // Get a hash JWT from POST /d/token
-    const hashTokenRes = await SELF.fetch(`${BASE}/d/token`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${device.refresh_token}` },
-    });
-    expect(hashTokenRes.status).toBe(200);
-    const { hash_token } = (await hashTokenRes.json()) as { hash_token: string };
+    expect(deviceInfo.settings.wrapping_keys).toHaveLength(1);
+    expect(deviceInfo.settings.wrapping_keys[0]?.user_id).toBe(userId);
+    expect(deviceInfo.settings.hash_base_url).toBeTruthy();
 
     const hashUploadRes = await SELF.fetch(`${BASE}/hash`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${hash_token}` },
+      headers: { Authorization: `Bearer ${deviceInfo.token}` },
       body: new Uint8Array(32).fill(7),
     });
     expect(hashUploadRes.status).toBe(200);
@@ -51,12 +46,7 @@ describe('Data and device API routes', () => {
     form.set(
       'access_keys',
       JSON.stringify({
-        keys: [
-          {
-            user_id: userId,
-            hpke_key: Buffer.from('owner-envelope').toString('base64'),
-          },
-        ],
+        keys: { [userId]: Buffer.from('owner-envelope').toString('base64') },
       }),
     );
     form.set('file', new File([new Uint8Array([1, 2, 3])], 'batch.enc'));
@@ -81,12 +71,7 @@ describe('Data and device API routes', () => {
       .bind(uuidToBytes(batch.id))
       .first<{ access_keys: string }>();
     expect(JSON.parse(storedBatch!.access_keys)).toEqual({
-      keys: [
-        {
-          user_id: userId,
-          hpke_key: Buffer.from('owner-envelope').toString('base64'),
-        },
-      ],
+      keys: { [userId]: Buffer.from('owner-envelope').toString('base64') },
     });
 
     const dataRes = await SELF.fetch(`${BASE}/data?since=0`, {
@@ -120,7 +105,7 @@ describe('Data and device API routes', () => {
       await signupAndGetCookie('owner@example.com');
     const { cookie: partnerCookie, userId: partnerUserId } =
       await signupAndGetCookie('partner@example.com');
-    const device = await createDeviceForUser(ownerCookie);
+    const device = await createDeviceForUser('owner@example.com');
 
     const inviteRes = await SELF.fetch(`${BASE}/partner`, {
       method: 'POST',
@@ -145,16 +130,10 @@ describe('Data and device API routes', () => {
     form.set(
       'access_keys',
       JSON.stringify({
-        keys: [
-          {
-            user_id: ownerUserId,
-            hpke_key: Buffer.from('owner-envelope').toString('base64'),
-          },
-          {
-            user_id: partnerUserId,
-            hpke_key: Buffer.from('partner-envelope').toString('base64'),
-          },
-        ],
+        keys: {
+          [ownerUserId]: Buffer.from('owner-envelope').toString('base64'),
+          [partnerUserId]: Buffer.from('partner-envelope').toString('base64'),
+        },
       }),
     );
     form.set('file', new File([new Uint8Array([1, 2, 3])], 'batch.enc'));

--- a/api/test/device-logout.test.ts
+++ b/api/test/device-logout.test.ts
@@ -14,18 +14,16 @@ beforeEach(clearDB);
 describe('POST /d/logout', () => {
   it('revokes the device session, soft-deletes the device, and resets its hash state', async () => {
     const { cookie } = await signupAndGetCookie('logout@example.com');
-    const device = await createDeviceForUser(cookie, 'Laptop', 'linux');
-
-    const hashTokenRes = await SELF.fetch(`${BASE}/d/token`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${device.refresh_token}` },
-    });
-    expect(hashTokenRes.status).toBe(200);
-    const { hash_token } = (await hashTokenRes.json()) as { hash_token: string };
+    const device = await createDeviceForUser(
+      'logout@example.com',
+      'password123',
+      'Laptop',
+      'linux',
+    );
 
     const hashUploadRes = await SELF.fetch(`${BASE}/hash`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${hash_token}` },
+      headers: { Authorization: `Bearer ${device.token}` },
       body: new Uint8Array(32).fill(9),
     });
     expect(hashUploadRes.status).toBe(200);

--- a/api/test/devices.test.ts
+++ b/api/test/devices.test.ts
@@ -15,7 +15,7 @@ beforeEach(clearDB);
 describe('Main device routes', () => {
   it('lists devices owned by the authenticated user', async () => {
     const { cookie } = await signupAndGetCookie('alice@example.com');
-    await createDeviceForUser(cookie, 'Work Laptop', 'linux');
+    await createDeviceForUser('alice@example.com', 'password123', 'Work Laptop', 'linux');
 
     const res = await SELF.fetch(`${BASE}/device`, {
       headers: authHeaders(cookie),
@@ -29,7 +29,7 @@ describe('Main device routes', () => {
 
   it('updates an owned device', async () => {
     const { cookie } = await signupAndGetCookie('bob@example.com');
-    const device = await createDeviceForUser(cookie, 'Old Name', 'macos');
+    const device = await createDeviceForUser('bob@example.com', 'password123', 'Old Name', 'macos');
 
     const res = await SELF.fetch(`${BASE}/device/${device.id}`, {
       method: 'PATCH',
@@ -50,9 +50,9 @@ describe('Main device routes', () => {
   });
 
   it('forbids patching a device owned by another user', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('owner@example.com');
+    await signupAndGetCookie('owner@example.com');
     const { cookie: attackerCookie } = await signupAndGetCookie('attacker@example.com');
-    const device = await createDeviceForUser(ownerCookie);
+    const device = await createDeviceForUser('owner@example.com');
 
     const res = await SELF.fetch(`${BASE}/device/${device.id}`, {
       method: 'PATCH',
@@ -68,7 +68,12 @@ describe('Main device routes', () => {
     const { cookie: partnerCookie, userId: partnerUserId } =
       await signupAndGetCookie('partner2@example.com');
     await markUserEmailVerified(partnerUserId);
-    const device = await createDeviceForUser(ownerCookie, 'Owner Phone', 'android');
+    const device = await createDeviceForUser(
+      'owner2@example.com',
+      'password123',
+      'Owner Phone',
+      'android',
+    );
 
     const inviteRes = await SELF.fetch(`${BASE}/partner`, {
       method: 'POST',
@@ -105,7 +110,12 @@ describe('Main device routes', () => {
       'delete-device-partner@example.com',
     );
     await markUserEmailVerified(partnerUserId);
-    const device = await createDeviceForUser(cookie, 'Delete Me', 'linux');
+    const device = await createDeviceForUser(
+      'delete-device@example.com',
+      'password123',
+      'Delete Me',
+      'linux',
+    );
 
     const inviteRes = await SELF.fetch(`${BASE}/partner`, {
       method: 'POST',
@@ -167,7 +177,12 @@ describe('Main device routes', () => {
     const { cookie: partnerCookie } = await signupAndGetCookie(
       'delete-device-unverified-partner@example.com',
     );
-    const device = await createDeviceForUser(cookie, 'Unverified Delete', 'linux');
+    const device = await createDeviceForUser(
+      'delete-device-unverified@example.com',
+      'password123',
+      'Unverified Delete',
+      'linux',
+    );
 
     const inviteRes = await SELF.fetch(`${BASE}/partner`, {
       method: 'POST',

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -134,21 +134,30 @@ export function authHeaders(cookie: string): Record<string, string> {
   };
 }
 
-export async function createDeviceForUser(cookie: string, name = 'Laptop', platform = 'linux') {
+export async function createDeviceForUser(
+  email: string,
+  password = 'password123',
+  name = 'Laptop',
+  platform = 'linux',
+) {
+  const password_auth = await passwordAuthFor(password);
   const res = await SELF.fetch(`${BASE}/d/device`, {
     method: 'POST',
-    headers: authHeaders(cookie),
-    body: JSON.stringify({ name, platform }),
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password_auth, name, platform }),
   });
 
   if (!res.ok) {
     throw new Error(`device creation failed: ${res.status} ${await res.text()}`);
   }
 
-  return (await res.json()) as {
-    id: string;
+  const body = (await res.json()) as {
     refresh_token: string;
+    settings: { id: string };
+    token: string;
   };
+
+  return { id: body.settings.id, refresh_token: body.refresh_token, token: body.token };
 }
 
 export async function createServerToken(deviceId: string) {

--- a/api/test/notifications.test.ts
+++ b/api/test/notifications.test.ts
@@ -13,6 +13,28 @@ import {
 
 beforeEach(clearDB);
 
+async function uploadBatchWithNotification(
+  deviceRefreshToken: string,
+  ownerUserId: string,
+  notification: Record<string, unknown>,
+) {
+  const form = new FormData();
+  form.set('start_time', '1710000000000');
+  form.set('end_time', '1710003600000');
+  form.set(
+    'access_keys',
+    JSON.stringify({ keys: { [ownerUserId]: Buffer.from('owner-envelope').toString('base64') } }),
+  );
+  form.set('notifications', JSON.stringify([notification]));
+  form.set('file', new File([new Uint8Array([1, 2, 3])], 'batch.enc'));
+
+  return SELF.fetch(`${BASE}/d/batch`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${deviceRefreshToken}` },
+    body: form,
+  });
+}
+
 describe('Notification routes and tamper alerts', () => {
   it('stores notification frequency on the user and reflects it across monitored partners', async () => {
     const { cookie: ownerCookie } = await signupAndGetCookie('notify-owner@example.com', 'pw');
@@ -93,7 +115,10 @@ describe('Notification routes and tamper alerts', () => {
   });
 
   it('sends immediate tamper alerts for high-risk device log events', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('alerts-owner@example.com', 'pw');
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'alerts-owner@example.com',
+      'pw',
+    );
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'alerts-partner@example.com',
       'pw',
@@ -121,17 +146,19 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ token: inviteMetadata.inviteToken }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Workstation', 'linux');
-    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 0.7 }),
+    const device = await createDeviceForUser(
+      'alerts-owner@example.com',
+      'pw',
+      'Workstation',
+      'linux',
+    );
+    const logRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'service_stop',
+      risk: 0.7,
     });
 
-    expect(logRes.status).toBe(202);
+    expect(logRes.status).toBe(201);
 
     const deliveries = await listEmailDeliveries();
     expect(deliveries.some((delivery) => delivery.kind === 'tamper_alert')).toBe(true);
@@ -143,7 +170,10 @@ describe('Notification routes and tamper alerts', () => {
   });
 
   it('passes custom title/details through to the rendered tamper alert email', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('custom-owner@example.com', 'pw');
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'custom-owner@example.com',
+      'pw',
+    );
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'custom-partner@example.com',
       'pw',
@@ -171,23 +201,21 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ token: inviteMetadata.inviteToken }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Workstation', 'linux');
-    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({
-        ts: Date.now(),
-        type: 'service_stop',
-        risk: 0.7,
-        title: 'Custom alert title',
-        details: 'Custom alert details',
-      }),
+    const device = await createDeviceForUser(
+      'custom-owner@example.com',
+      'pw',
+      'Workstation',
+      'linux',
+    );
+    const logRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'service_stop',
+      risk: 0.7,
+      title: 'Custom alert title',
+      details: 'Custom alert details',
     });
 
-    expect(logRes.status).toBe(202);
+    expect(logRes.status).toBe(201);
 
     const tamperDelivery = (await listEmailDeliveries()).find(
       (delivery) => delivery.kind === 'tamper_alert',
@@ -198,7 +226,10 @@ describe('Notification routes and tamper alerts', () => {
   });
 
   it('sends immediate tamper alerts for moderate-risk device log events', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('moderate-owner@example.com', 'pw');
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'moderate-owner@example.com',
+      'pw',
+    );
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'moderate-partner@example.com',
       'pw',
@@ -226,24 +257,24 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ token: inviteMetadata.inviteToken }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Laptop', 'linux');
-    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 0.69 }),
+    const device = await createDeviceForUser('moderate-owner@example.com', 'pw', 'Laptop', 'linux');
+    const logRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'service_stop',
+      risk: 0.69,
     });
 
-    expect(logRes.status).toBe(202);
+    expect(logRes.status).toBe(201);
     expect((await listEmailDeliveries()).some((delivery) => delivery.kind === 'tamper_alert')).toBe(
       true,
     );
   });
 
   it('sends an immediate tamper alert even for zero risk; requires the risk field', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('non-tamper-owner@example.com', 'pw');
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'non-tamper-owner@example.com',
+      'pw',
+    );
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'non-tamper-partner@example.com',
       'pw',
@@ -271,37 +302,38 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ token: inviteMetadata.inviteToken }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Desktop', 'linux');
+    const device = await createDeviceForUser(
+      'non-tamper-owner@example.com',
+      'pw',
+      'Desktop',
+      'linux',
+    );
 
-    // The notify endpoint doesn't re-filter by risk — the client's uploader only
-    // calls it for high-risk events, so any call here should send an alert.
-    const zeroRiskRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: Date.now(), type: 'heartbeat', risk: 0 }),
+    // The notify path doesn't re-filter by risk — the client's uploader only
+    // includes a notification for high-risk events, so any entry here should send an alert.
+    const zeroRiskRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'heartbeat',
+      risk: 0,
     });
-    expect(zeroRiskRes.status).toBe(202);
+    expect(zeroRiskRes.status).toBe(201);
     expect((await listEmailDeliveries()).some((delivery) => delivery.kind === 'tamper_alert')).toBe(
       true,
     );
 
-    // Risk is still a required field on the notify endpoint.
-    const missingRiskRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: Date.now(), type: 'heartbeat' }),
+    // Risk is still a required field on each notification entry.
+    const missingRiskRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'heartbeat',
     });
     expect(missingRiskRes.status).toBe(400);
   });
 
   it('stops all partner emails when receive emails is disabled', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('mute-owner@example.com', 'pw');
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'mute-owner@example.com',
+      'pw',
+    );
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'mute-partner@example.com',
       'pw',
@@ -334,25 +366,30 @@ describe('Notification routes and tamper alerts', () => {
       body: JSON.stringify({ settings: { email_frequency: 'none' } }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Muted Device', 'linux');
+    const device = await createDeviceForUser(
+      'mute-owner@example.com',
+      'pw',
+      'Muted Device',
+      'linux',
+    );
     const baselineCount = (await listEmailDeliveries()).length;
-    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 1 }),
+    const logRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'service_stop',
+      risk: 1,
     });
 
-    expect(logRes.status).toBe(202);
+    expect(logRes.status).toBe(201);
     const deliveries = await listEmailDeliveries();
     expect(deliveries).toHaveLength(baselineCount);
     expect(deliveries.some((delivery) => delivery.kind === 'tamper_alert')).toBe(false);
   });
 
   it('suppresses tamper alerts to unverified recipient accounts', async () => {
-    const { cookie: ownerCookie } = await signupAndGetCookie('unverified-owner@example.com', 'pw');
+    const { cookie: ownerCookie, userId: ownerUserId } = await signupAndGetCookie(
+      'unverified-owner@example.com',
+      'pw',
+    );
     const { cookie: partnerCookie, userId: partnerUserId } = await signupAndGetCookie(
       'unverified-partner@example.com',
       'pw',
@@ -382,18 +419,20 @@ describe('Notification routes and tamper alerts', () => {
       .bind(uuidToBytes(partnerUserId))
       .run();
 
-    const device = await createDeviceForUser(ownerCookie, 'Quiet Device', 'linux');
+    const device = await createDeviceForUser(
+      'unverified-owner@example.com',
+      'pw',
+      'Quiet Device',
+      'linux',
+    );
     const baselineCount = (await listEmailDeliveries()).length;
-    const logRes = await SELF.fetch(`${BASE}/d/notify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${device.refresh_token}`,
-      },
-      body: JSON.stringify({ ts: Date.now(), type: 'service_stop', risk: 1 }),
+    const logRes = await uploadBatchWithNotification(device.refresh_token, ownerUserId, {
+      ts: Date.now(),
+      type: 'service_stop',
+      risk: 1,
     });
 
-    expect(logRes.status).toBe(202);
+    expect(logRes.status).toBe(201);
     expect(await listEmailDeliveries()).toHaveLength(baselineCount);
   });
 });

--- a/api/test/rate-limit.test.ts
+++ b/api/test/rate-limit.test.ts
@@ -6,8 +6,13 @@ beforeEach(clearDB);
 
 describe('Per-device rate limiting', () => {
   it('returns 429 once a device exceeds the configured request rate', async () => {
-    const { cookie } = await signupAndGetCookie('rate-limited@example.com');
-    const device = await createDeviceForUser(cookie, 'Rate Limited Device', 'linux');
+    await signupAndGetCookie('rate-limited@example.com');
+    const device = await createDeviceForUser(
+      'rate-limited@example.com',
+      'password123',
+      'Rate Limited Device',
+      'linux',
+    );
     const headers = { Authorization: `Bearer ${device.refresh_token}` };
 
     // wrangler.json's staging RATE_LIMITER is configured for 60 requests/60s.
@@ -24,9 +29,19 @@ describe('Per-device rate limiting', () => {
   });
 
   it('does not rate limit two different devices independently of each other', async () => {
-    const { cookie } = await signupAndGetCookie('two-devices@example.com');
-    const deviceA = await createDeviceForUser(cookie, 'Device A', 'linux');
-    const deviceB = await createDeviceForUser(cookie, 'Device B', 'macos');
+    await signupAndGetCookie('two-devices@example.com');
+    const deviceA = await createDeviceForUser(
+      'two-devices@example.com',
+      'password123',
+      'Device A',
+      'linux',
+    );
+    const deviceB = await createDeviceForUser(
+      'two-devices@example.com',
+      'password123',
+      'Device B',
+      'macos',
+    );
 
     const resA = await SELF.fetch(`${BASE}/d/device`, {
       headers: { Authorization: `Bearer ${deviceA.refresh_token}` },

--- a/api/test/retention.test.ts
+++ b/api/test/retention.test.ts
@@ -7,7 +7,7 @@ beforeEach(clearDB);
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RETENTION_MS = 30 * DAY_MS;
-const EMPTY_ACCESS_KEYS = JSON.stringify({ keys: [] });
+const EMPTY_ACCESS_KEYS = JSON.stringify({ keys: {} });
 
 async function insertBatch(
   id: string,
@@ -45,8 +45,13 @@ describe('pruneExpiredBatches', () => {
   it('deletes batches older than 30 days and keeps recent ones', async () => {
     const now = Date.UTC(2026, 0, 6, 0, 0, 0);
     const { userId } = await signupAndGetCookie('retention-owner@example.com', 'pw');
-    const { cookie } = await signupAndGetCookie('retention-owner-login@example.com', 'pw');
-    const device = await createDeviceForUser(cookie, 'Retention Device', 'linux');
+    await signupAndGetCookie('retention-owner-login@example.com', 'pw');
+    const device = await createDeviceForUser(
+      'retention-owner-login@example.com',
+      'pw',
+      'Retention Device',
+      'linux',
+    );
 
     const oldId = '00000000-0000-4000-8000-000000000101';
     const recentId = '00000000-0000-4000-8000-000000000102';
@@ -70,8 +75,13 @@ describe('pruneExpiredBatches', () => {
   it('retains a batch created exactly at the 30-day boundary', async () => {
     const now = Date.UTC(2026, 0, 6, 0, 0, 0);
     const { userId } = await signupAndGetCookie('retention-boundary@example.com', 'pw');
-    const { cookie } = await signupAndGetCookie('retention-boundary-login@example.com', 'pw');
-    const device = await createDeviceForUser(cookie, 'Boundary Device', 'linux');
+    await signupAndGetCookie('retention-boundary-login@example.com', 'pw');
+    const device = await createDeviceForUser(
+      'retention-boundary-login@example.com',
+      'pw',
+      'Boundary Device',
+      'linux',
+    );
 
     const boundaryId = '00000000-0000-4000-8000-000000000103';
     await insertBatch(
@@ -91,8 +101,13 @@ describe('pruneExpiredBatches', () => {
   it('drains a backlog larger than the per-round-trip chunk limit', async () => {
     const now = Date.UTC(2026, 0, 6, 0, 0, 0);
     const { userId } = await signupAndGetCookie('retention-backlog@example.com', 'pw');
-    const { cookie } = await signupAndGetCookie('retention-backlog-login@example.com', 'pw');
-    const device = await createDeviceForUser(cookie, 'Backlog Device', 'linux');
+    await signupAndGetCookie('retention-backlog-login@example.com', 'pw');
+    const device = await createDeviceForUser(
+      'retention-backlog-login@example.com',
+      'pw',
+      'Backlog Device',
+      'linux',
+    );
 
     const backlogSize = 620; // exceeds the 500-row PRUNE_CHUNK_LIMIT
     for (let i = 0; i < backlogSize; i += 1) {

--- a/api/test/routing.test.ts
+++ b/api/test/routing.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SELF } from 'cloudflare:test';
-import { authHeaders, BASE, clearDB, signupAndGetCookie } from './helpers';
+import { BASE, clearDB, passwordAuthFor, signupAndGetCookie } from './helpers';
 
 beforeEach(clearDB);
 
@@ -46,12 +46,17 @@ describe('API base path routing', () => {
   });
 
   it('preserves the /api base path in device hash_base_url responses', async () => {
-    const { cookie } = await signupAndGetCookie('prefixed-device@example.com', 'pw');
+    await signupAndGetCookie('prefixed-device@example.com', 'pw');
 
     const createDeviceRes = await SELF.fetch(`${BASE}/api/d/device`, {
       method: 'POST',
-      headers: authHeaders(cookie),
-      body: JSON.stringify({ name: 'Laptop', platform: 'linux' }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'prefixed-device@example.com',
+        password_auth: await passwordAuthFor('pw'),
+        name: 'Laptop',
+        platform: 'linux',
+      }),
     });
 
     expect(createDeviceRes.status).toBe(201);
@@ -63,7 +68,7 @@ describe('API base path routing', () => {
 
     expect(settingsRes.status).toBe(200);
     expect(await settingsRes.json()).toMatchObject({
-      hash_base_url: `${BASE}/api`,
+      settings: { hash_base_url: `${BASE}/api` },
     });
   });
 });

--- a/api/test/scheduler.test.ts
+++ b/api/test/scheduler.test.ts
@@ -17,7 +17,7 @@ beforeEach(clearDB);
 const DAILY_BATCH_ID = '00000000-0000-4000-8000-000000000001';
 const WEEKLY_BATCH_ID = '00000000-0000-4000-8000-000000000003';
 const OLD_DAILY_BATCH_ID = '00000000-0000-4000-8000-000000000004';
-const EMPTY_ACCESS_KEYS = JSON.stringify({ keys: [] });
+const EMPTY_ACCESS_KEYS = JSON.stringify({ keys: {} });
 
 describe('Notification scheduler', () => {
   it('sends a daily digest at the configured local hour using the prior 24 hours', async () => {
@@ -66,8 +66,18 @@ describe('Notification scheduler', () => {
       }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Digest Device', 'linux');
-    const silentDevice = await createDeviceForUser(ownerCookie, 'Silent Device', 'linux');
+    const device = await createDeviceForUser(
+      'digest-owner@example.com',
+      'pw',
+      'Digest Device',
+      'linux',
+    );
+    const silentDevice = await createDeviceForUser(
+      'digest-owner@example.com',
+      'pw',
+      'Silent Device',
+      'linux',
+    );
     await env.DB.prepare('UPDATE devices SET created_at = ? WHERE id IN (?, ?)')
       .bind(previousWindowStart, uuidToBytes(device.id), uuidToBytes(silentDevice.id))
       .run();
@@ -158,8 +168,18 @@ describe('Notification scheduler', () => {
       body: JSON.stringify({ token: inviteMetadata.inviteToken }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Batch Device', 'linux');
-    const silentDevice = await createDeviceForUser(ownerCookie, 'Silent Device', 'linux');
+    const device = await createDeviceForUser(
+      'batch-owner@example.com',
+      'pw',
+      'Batch Device',
+      'linux',
+    );
+    const silentDevice = await createDeviceForUser(
+      'batch-owner@example.com',
+      'pw',
+      'Silent Device',
+      'linux',
+    );
     await env.DB.prepare('UPDATE devices SET created_at = ? WHERE id IN (?, ?)')
       .bind(previousWindowStart, uuidToBytes(device.id), uuidToBytes(silentDevice.id))
       .run();
@@ -239,8 +259,18 @@ describe('Notification scheduler', () => {
       });
     }
 
-    const ownerOneDevice = await createDeviceForUser(ownerOneCookie, 'Owner One Device', 'linux');
-    const ownerTwoDevice = await createDeviceForUser(ownerTwoCookie, 'Owner Two Device', 'linux');
+    const ownerOneDevice = await createDeviceForUser(
+      'multi-owner-one@example.com',
+      'pw',
+      'Owner One Device',
+      'linux',
+    );
+    const ownerTwoDevice = await createDeviceForUser(
+      'multi-owner-two@example.com',
+      'pw',
+      'Owner Two Device',
+      'linux',
+    );
 
     await env.DB.prepare(
       `INSERT INTO batches (id, user_id, device_id, url, start_time, end_time, end_hash, access_keys, created_at)
@@ -329,7 +359,12 @@ describe('Notification scheduler', () => {
       body: JSON.stringify({ settings: { email_frequency: 'weekly' } }),
     });
 
-    const device = await createDeviceForUser(ownerCookie, 'Twice Device', 'linux');
+    const device = await createDeviceForUser(
+      'twice-owner@example.com',
+      'pw',
+      'Twice Device',
+      'linux',
+    );
     await env.DB.prepare(
       `INSERT INTO batches (id, user_id, device_id, url, start_time, end_time, end_hash, access_keys, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -8,8 +8,9 @@ is a thin wrapper that supplies raw screen data and OS hooks.
 ### Auth / login / logout
 
 - `core/src/module/auth.rs` — `AuthModule`: handles `LoginRequested`/`LogoutRequested`,
-  calls API, fires `Login`/`Logout` events with credentials and initial device settings
-  (settings are subsequently refreshed by `UploadModule` before each batch upload)
+  calls API, fires `Login`/`Logout` events with credentials, initial device settings, and
+  an initial hash token (settings/token are subsequently refreshed opportunistically from
+  every `GET /d/device` and `POST /d/batch` response, not a dedicated pre-batch fetch)
 - `core/src/storage.rs` — reads/writes `stop_intent.json` and other state files
 
 ### Event system
@@ -27,8 +28,9 @@ Observer state is persisted to `event_state.json` after each iteration.
 
 ### Upload / batching / hash chain
 
-- `core/src/module/upload.rs` — `UploadModule`: manages 3 queues (hash-pending, batch-pending,
-  notify-pending), retry logic
+- `core/src/module/upload.rs` — `UploadModule`: manages 2 queues (hash-pending,
+  batch-pending) plus retry logic; high-risk notify metadata rides with its event into
+  whichever batch carries it rather than living in a separate queue
 - `core/src/module/upload/batch.rs` — `BatchBuilder`: msgpack + gzip batch construction
 - `core/src/crypto.rs` — AES-256-GCM encryption, HPKE key wrap, `compute_event_hash`,
   `encode_batch_event`

--- a/client/core/architecture.md
+++ b/client/core/architecture.md
@@ -34,7 +34,7 @@ client/
         lifecycle.rs    — LifecycleModule: process/suspend/ping-gap alerts
         screenshot.rs   — ScreenshotModule: interval scheduling + capture
         status.rs       — StatusModule: partial-status aggregation
-        upload.rs       — UploadModule: hash-pending, batch-pending, and notify-pending queues
+        upload.rs       — UploadModule: hash-pending and batch-pending queues (notify rides with its batch)
       platform.rs       — ScreenshotHooks / PlatformHooks traits
       state.rs          — load_state / store_state (event_state.json)
       storage.rs        — auth.json, device_settings.json, stop_intent.json
@@ -324,11 +324,14 @@ wire:  nonce[12 bytes] || ciphertext+tag
 
 Each upload also wraps the batch key per recipient using HPKE
 (`DhkemX25519HkdfSha256 / HkdfSha256 / Aes256Gcm`). The recipient set comes from
-the device's `wrapping_keys`, which `UploadModule` refetches from `GET /d/device`
-immediately before every batch upload — this is the sole refresh path, so a partner
-added or removed is picked up on the very next batch. A transient refetch failure
-falls back to the last known settings; a 404/401 means the device is gone and
-triggers logout.
+the device's `wrapping_keys`, sourced from `state.settings` — which is refreshed
+opportunistically from the `settings` field embedded in every `GET /d/device` and
+`POST /d/batch` response, not from a dedicated pre-batch fetch. A partner added or
+removed is therefore picked up with a one-batch lag (the batch in flight when they're
+added still uses the old recipient set; the next one uses the new one), not
+immediately. A batch upload that fails with 404/401 means the device is gone and
+triggers logout; other failures leave the events queued and retry on the next
+batch attempt using the last known settings.
 
 Each `BatchUpload` also carries `high_risk_count`/`medium_risk_count`: tallies of how many
 events in the batch fall in the high (`risk >= 0.7`) and medium (`0.4 <= risk < 0.7`) bands,
@@ -338,13 +341,18 @@ digest emails without ever decrypting the batch.
 
 ## Notify flow
 
-High-risk events (`risk >= lifecycle::EXTRA_HIGH_RISK`) are additionally pushed into
-`UploadModule`'s `pending_notify_events: Vec<NotifyPayload>` queue, where
-`NotifyPayload { ts, type, risk, title?, details? }`. `retry_pending_notifies` drains this
-queue by POSTing each payload to `/d/notify` once the device is authenticated. This happens
-independently of, but alongside, the always-present hash/batch path — the event body itself
-still goes through the normal encrypted batch pipeline; `/d/notify` only triggers the alert
-email.
+High-risk events (`risk >= lifecycle::EXTRA_HIGH_RISK`) no longer travel through a
+separate notify queue. When `retry_pending_hashes` successfully hashes an event, it
+checks whether that event was high-risk and, if so, attaches a `NotifyPayload
+{ ts, type, risk, title?, details? }` to the `PendingBatchEvent.notify` field. The
+notify payload then rides with that event into whichever batch carries it: `try_upload_batch`
+collects every `notify` present in the events it's about to send into `BatchUpload.notifications`
+and uploads them in the same `POST /d/batch` multipart request (`notifications` field —
+a JSON-encoded array), where the server processes them (best-effort) only after the
+batch itself has durably persisted. A high-risk or heartbeat event still force-flushes
+the batch immediately (`handle_upload`'s `is_heartbeat || is_high_risk` check), so
+notify latency is preserved — it's just "flush the batch sooner" rather than "flush a
+separate notify queue." `POST /d/notify` no longer exists.
 
 ## Hash chain
 
@@ -354,6 +362,12 @@ Per-event content hashes are uploaded to `POST /hash` independently of batches:
 content_hash = sha256(ts_le64 || type_utf8 || sorted(key_utf8 || encoded_value))
 new_state    = sha256(current_state[32] || content_hash[32])
 ```
+
+`POST /hash` itself requires a `HashServerToken`, minted by `POST /d/device`, `GET
+/d/device`, and `POST /d/batch` — there is no longer a dedicated `POST /d/token`
+endpoint. `UploadModule::ensure_hash_token` caches the token from whichever of those
+responses arrived most recently and only calls `GET /d/device` when that cache goes
+stale (55 minutes) without a batch having refreshed it in the meantime.
 
 ## Testing
 

--- a/client/core/src/api.rs
+++ b/client/core/src/api.rs
@@ -8,30 +8,88 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::crypto::derive_password_auth;
 use crate::error::{CoreError, CoreResult};
-use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, HashParams, NotifyPayload};
+use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, HashParams};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadedBatchResponse {
     pub id: String,
+    pub settings: DeviceSettings,
+    pub hash_token: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RegisteredDevice {
+    pub credentials: DeviceCredentials,
+    pub settings: DeviceSettings,
+    pub hash_token: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeviceState {
+    pub settings: DeviceSettings,
+    pub hash_token: String,
+}
+
+/// Raw wire shape for the `{settings, token}` pair embedded in `POST /d/device`,
+/// `GET /d/device`, and `POST /d/batch` responses. `DeviceSettingsResponse` differs
+/// from the public `DeviceSettings` only in its `id`/`device_id` field name.
+#[derive(Deserialize)]
+struct DeviceRecipientResponse {
+    user_id: String,
+    pub_key: String,
+}
+
+#[derive(Deserialize)]
+struct DeviceSettingsResponse {
+    id: String,
+    name: String,
+    platform: String,
+    #[serde(default)]
+    wrapping_keys: Vec<DeviceRecipientResponse>,
+    #[serde(default)]
+    hash_base_url: Option<String>,
+}
+
+impl From<DeviceSettingsResponse> for DeviceSettings {
+    fn from(response: DeviceSettingsResponse) -> Self {
+        DeviceSettings {
+            device_id: response.id,
+            name: response.name,
+            platform: response.platform,
+            wrapping_keys: response
+                .wrapping_keys
+                .into_iter()
+                .map(|key| crate::model::BatchRecipient {
+                    user_id: key.user_id,
+                    pub_key_base64: key.pub_key,
+                })
+                .collect(),
+            hash_base_url: response.hash_base_url,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct DeviceStateResponse {
+    settings: DeviceSettingsResponse,
+    token: String,
 }
 
 pub trait ApiTransport: Send + Sync {
-    fn login(&self, username: &str, password: &str) -> CoreResult<String>;
     fn logout(&self, device_refresh_token: &str) -> CoreResult<()>;
     fn register_device(
         &self,
-        user_refresh_token: &str,
+        email: &str,
+        password: &str,
         name: &str,
         platform: &str,
-    ) -> CoreResult<DeviceCredentials>;
-    fn get_device_settings(&self, device_refresh_token: &str) -> CoreResult<DeviceSettings>;
-    fn get_hash_token(&self, device_refresh_token: &str) -> CoreResult<String>;
+    ) -> CoreResult<RegisteredDevice>;
+    fn get_device_settings(&self, device_refresh_token: &str) -> CoreResult<DeviceState>;
     fn upload_batch(
         &self,
         device_refresh_token: &str,
         batch: &BatchUpload,
     ) -> CoreResult<UploadedBatchResponse>;
-    fn notify(&self, device_refresh_token: &str, payload: &NotifyPayload) -> CoreResult<()>;
     fn upload_hash(
         &self,
         hash_base_url: Option<&str>,
@@ -68,46 +126,6 @@ impl ApiTransport for ReqwestApiClient {
         Ok(())
     }
 
-    fn login(&self, username: &str, password: &str) -> CoreResult<String> {
-        #[derive(Serialize)]
-        struct LoginRequest<'a> {
-            email: &'a str,
-            password_auth: String,
-        }
-
-        #[derive(Deserialize)]
-        struct LoginMaterialResponse {
-            password_salt: String,
-            params: HashParams,
-        }
-
-        #[derive(Deserialize)]
-        struct LoginResponse {
-            refresh_token: String,
-        }
-
-        let material: LoginMaterialResponse = self.expect_json(
-            self.request(Method::GET, None, "/user/login-material", None)
-                .query(&[("email", username)])
-                .send()?,
-        )?;
-        let password_salt =
-            base64::engine::general_purpose::STANDARD.decode(material.password_salt)?;
-        let password_auth = derive_password_auth(password, &password_salt, &material.params)?;
-
-        let response: LoginResponse = self.send_json(
-            Method::POST,
-            None,
-            "/login",
-            None,
-            Some(&LoginRequest {
-                email: username,
-                password_auth: base64::engine::general_purpose::STANDARD.encode(password_auth),
-            }),
-        )?;
-        Ok(response.refresh_token)
-    }
-
     fn logout(&self, device_refresh_token: &str) -> CoreResult<()> {
         self.send_empty(
             Method::POST,
@@ -120,89 +138,77 @@ impl ApiTransport for ReqwestApiClient {
 
     fn register_device(
         &self,
-        user_refresh_token: &str,
+        email: &str,
+        password: &str,
         name: &str,
         platform: &str,
-    ) -> CoreResult<DeviceCredentials> {
+    ) -> CoreResult<RegisteredDevice> {
+        #[derive(Deserialize)]
+        struct LoginMaterialResponse {
+            password_salt: String,
+            params: HashParams,
+        }
+
         #[derive(Serialize)]
         struct RegisterDeviceRequest<'a> {
+            email: &'a str,
+            password_auth: String,
             name: &'a str,
             platform: &'a str,
         }
 
         #[derive(Deserialize)]
         struct RegisterDeviceResponse {
-            id: String,
             refresh_token: String,
+            #[serde(flatten)]
+            state: DeviceStateResponse,
         }
+
+        let material: LoginMaterialResponse = self.expect_json(
+            self.request(Method::GET, None, "/user/login-material", None)
+                .query(&[("email", email)])
+                .send()?,
+        )?;
+        let password_salt =
+            base64::engine::general_purpose::STANDARD.decode(material.password_salt)?;
+        let password_auth = derive_password_auth(password, &password_salt, &material.params)?;
 
         let response: RegisterDeviceResponse = self.send_json(
             Method::POST,
             None,
             "/d/device",
-            Some(user_refresh_token),
-            Some(&RegisterDeviceRequest { name, platform }),
+            None,
+            Some(&RegisterDeviceRequest {
+                email,
+                password_auth: base64::engine::general_purpose::STANDARD.encode(password_auth),
+                name,
+                platform,
+            }),
         )?;
 
-        Ok(DeviceCredentials {
-            device_id: response.id,
-            refresh_token: response.refresh_token,
+        let settings: DeviceSettings = response.state.settings.into();
+        Ok(RegisteredDevice {
+            credentials: DeviceCredentials {
+                device_id: settings.device_id.clone(),
+                refresh_token: response.refresh_token,
+            },
+            settings,
+            hash_token: response.state.token,
         })
     }
 
-    fn get_device_settings(&self, device_refresh_token: &str) -> CoreResult<DeviceSettings> {
-        #[derive(Deserialize)]
-        struct DeviceSettingsResponse {
-            id: String,
-            name: String,
-            platform: String,
-            wrapping_keys: Vec<DeviceRecipientResponse>,
-            hash_base_url: Option<String>,
-        }
-
-        #[derive(Deserialize)]
-        struct DeviceRecipientResponse {
-            user_id: String,
-            pub_key: String,
-        }
-
-        let response: DeviceSettingsResponse = self.send_json(
+    fn get_device_settings(&self, device_refresh_token: &str) -> CoreResult<DeviceState> {
+        let response: DeviceStateResponse = self.send_json(
             Method::GET,
             None,
             "/d/device",
             Some(device_refresh_token),
             None::<&()>,
         )?;
-        Ok(DeviceSettings {
-            device_id: response.id,
-            name: response.name,
-            platform: response.platform,
-            wrapping_keys: response
-                .wrapping_keys
-                .into_iter()
-                .map(|key| crate::model::BatchRecipient {
-                    user_id: key.user_id,
-                    pub_key_base64: key.pub_key,
-                })
-                .collect(),
-            hash_base_url: response.hash_base_url,
+        Ok(DeviceState {
+            settings: response.settings.into(),
+            hash_token: response.token,
         })
-    }
-
-    fn get_hash_token(&self, device_refresh_token: &str) -> CoreResult<String> {
-        #[derive(Deserialize)]
-        struct HashTokenResponse {
-            hash_token: String,
-        }
-
-        let response: HashTokenResponse = self.send_json(
-            Method::POST,
-            None,
-            "/d/token",
-            Some(device_refresh_token),
-            None::<&()>,
-        )?;
-        Ok(response.hash_token)
     }
 
     fn upload_batch(
@@ -212,13 +218,14 @@ impl ApiTransport for ReqwestApiClient {
     ) -> CoreResult<UploadedBatchResponse> {
         #[derive(Serialize)]
         struct AccessKeysPayload<'a> {
-            keys: Vec<AccessKeyEntry<'a>>,
+            keys: std::collections::BTreeMap<&'a str, &'a str>,
         }
 
-        #[derive(Serialize)]
-        struct AccessKeyEntry<'a> {
-            user_id: &'a str,
-            hpke_key: &'a str,
+        #[derive(Deserialize)]
+        struct UploadBatchResponse {
+            id: String,
+            #[serde(flatten)]
+            state: DeviceStateResponse,
         }
 
         let part = Part::bytes(batch.bytes.clone())
@@ -228,31 +235,30 @@ impl ApiTransport for ReqwestApiClient {
             keys: batch
                 .access_keys
                 .iter()
-                .map(|entry| AccessKeyEntry {
-                    user_id: &entry.user_id,
-                    hpke_key: &entry.hpke_key_base64,
-                })
+                .map(|entry| (entry.user_id.as_str(), entry.hpke_key_base64.as_str()))
                 .collect(),
         })?;
-        let form = Form::new()
+        let mut form = Form::new()
             .part("file", part)
             .text("start_time", batch.start_time_ms.to_string())
             .text("end_time", batch.end_time_ms.to_string())
             .text("high_risk_count", batch.high_risk_count.to_string())
             .text("medium_risk_count", batch.medium_risk_count.to_string())
             .text("access_keys", access_keys);
+        if !batch.notifications.is_empty() {
+            form = form.text(
+                "notifications",
+                serde_json::to_string(&batch.notifications)?,
+            );
+        }
 
-        self.send_form(Method::POST, None, "/d/batch", device_refresh_token, form)
-    }
-
-    fn notify(&self, device_refresh_token: &str, payload: &NotifyPayload) -> CoreResult<()> {
-        self.send_empty(
-            Method::POST,
-            None,
-            "/d/notify",
-            Some(device_refresh_token),
-            Some(payload),
-        )
+        let response: UploadBatchResponse =
+            self.send_form(Method::POST, None, "/d/batch", device_refresh_token, form)?;
+        Ok(UploadedBatchResponse {
+            id: response.id,
+            settings: response.state.settings.into(),
+            hash_token: response.state.token,
+        })
     }
 
     fn upload_hash(
@@ -311,14 +317,17 @@ impl ReqwestApiClient {
         self.expect_success(response)
     }
 
-    fn send_form(
+    fn send_form<TResponse>(
         &self,
         method: Method,
         base_override: Option<&str>,
         path: &str,
         bearer_token: &str,
         form: Form,
-    ) -> CoreResult<UploadedBatchResponse> {
+    ) -> CoreResult<TResponse>
+    where
+        TResponse: for<'de> Deserialize<'de>,
+    {
         let response = self
             .request(method, base_override, path, Some(bearer_token))
             .multipart(form)

--- a/client/core/src/events/remote.rs
+++ b/client/core/src/events/remote.rs
@@ -395,15 +395,25 @@ mod tests {
     }
 
     fn make_bus_pair() -> (RemoteEventBus, RemoteEventBus) {
+        // A pid+timestamp nonce isn't unique enough on its own: several tests in
+        // this module call make_bus_pair() and the default test runner executes
+        // them in parallel threads within the same process, so two calls landing
+        // in the same clock tick (observed on macOS CI) previously collided on
+        // the same socket path. The atomic counter guarantees each call gets a
+        // distinct path regardless of clock resolution.
+        use std::sync::atomic::{AtomicU32, Ordering};
         use std::time::{SystemTime, UNIX_EPOCH};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .subsec_nanos();
+        let count = COUNTER.fetch_add(1, Ordering::Relaxed);
         let sock = std::env::temp_dir().join(format!(
-            "virtue-remote-test-{}-{}.sock",
+            "virtue-remote-test-{}-{}-{}.sock",
             std::process::id(),
-            nonce
+            nonce,
+            count
         ));
         let listener = IpcListener::bind(&sock).expect("bind");
 

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -214,12 +214,16 @@ pub struct BatchUpload {
     pub high_risk_count: u32,
     /// Number of events in this batch whose risk fell in the medium band (0.4–0.7).
     pub medium_risk_count: u32,
+    /// Alert-email metadata for any high-risk events in this batch, carried
+    /// alongside the batch upload instead of a separate notify call.
+    #[serde(default)]
+    pub notifications: Vec<NotifyPayload>,
 }
 
-/// Minimal metadata sent to `POST /d/notify` to trigger an alert email for a
-/// high-risk event. The event body itself is uploaded end-to-end encrypted via a
-/// batch; this payload carries only what the notification email needs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Minimal metadata sent alongside a batch upload to trigger an alert email for a
+/// high-risk event. The event body itself is uploaded end-to-end encrypted via the
+/// same batch; this payload carries only what the notification email needs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NotifyPayload {
     pub ts: i64,
     #[serde(rename = "type")]

--- a/client/core/src/module/auth.rs
+++ b/client/core/src/module/auth.rs
@@ -14,6 +14,7 @@ use crate::module::status::StatusRequest;
 pub struct Login {
     pub credentials: DeviceCredentials,
     pub settings: DeviceSettings,
+    pub hash_token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,11 +85,12 @@ impl<A: ApiTransport + Send + Sync + 'static> AuthModule<A> {
             let _ = emitter.send(Logout);
         }
         match self.do_login(email, password, device_name) {
-            Ok((credentials, settings)) => {
+            Ok((credentials, settings, hash_token)) => {
                 let device_id = credentials.device_id.clone();
                 let _ = emitter.send(Login {
                     credentials,
                     settings,
+                    hash_token,
                 });
                 let _ = emitter.send(LoginResult {
                     success: true,
@@ -111,20 +113,22 @@ impl<A: ApiTransport + Send + Sync + 'static> AuthModule<A> {
         email: &str,
         password: &str,
         device_name: Option<&str>,
-    ) -> CoreResult<(DeviceCredentials, crate::model::DeviceSettings)> {
-        let user_token = self.api.login(email, password)?;
+    ) -> CoreResult<(DeviceCredentials, crate::model::DeviceSettings, String)> {
         // Use the user-supplied override when present and non-empty (trimmed),
         // otherwise fall back to the construction-time device name (hostname).
         let resolved_name = device_name
             .map(str::trim)
             .filter(|name| !name.is_empty())
             .unwrap_or(self.device_name.as_str());
-        let device = self
-            .api
-            .register_device(&user_token, resolved_name, &self.platform_name)?;
-        let settings = self.api.get_device_settings(&device.refresh_token)?;
-        self.state.device_credentials = Some(device.clone());
-        Ok((device, settings))
+        let registered =
+            self.api
+                .register_device(email, password, resolved_name, &self.platform_name)?;
+        self.state.device_credentials = Some(registered.credentials.clone());
+        Ok((
+            registered.credentials,
+            registered.settings,
+            registered.hash_token,
+        ))
     }
 
     fn handle_logout_requested(&mut self, emitter: &Emitter) {
@@ -298,7 +302,7 @@ mod tests {
         ));
         let mut t = b.build();
         t.api
-            .program_login(Err(CoreError::InvalidState("bad credentials")));
+            .program_register_device(Err(CoreError::InvalidState("bad credentials")));
         t.emit(
             1,
             LoginRequested {

--- a/client/core/src/module/heartbeat.rs
+++ b/client/core/src/module/heartbeat.rs
@@ -112,6 +112,7 @@ mod tests {
                 }],
                 hash_base_url: None,
             },
+            hash_token: "test-hash-token".into(),
         }
     }
 

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -410,6 +410,7 @@ mod tests {
                 }],
                 hash_base_url: None,
             },
+            hash_token: "test-hash-token".into(),
         }
     }
 

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use batch::BatchBuilder;
 pub(crate) use batch::MAX_BATCH_ITEMS_PER_UPLOAD;
 
-use crate::api::ApiTransport;
+use crate::api::{ApiTransport, UploadedBatchResponse};
 use crate::crypto::{CryptoEngine, compute_event_hash, encode_batch_event};
 use crate::error::{CoreError, CoreResult};
 use crate::events::Ping;
@@ -42,6 +42,12 @@ pub struct PendingBatchEvent {
     pub ts: i64,
     pub risk: f32,
     pub encoded: Vec<u8>,
+    /// Alert-email metadata, set when the event's risk is >= `EXTRA_HIGH_RISK` at
+    /// hash time. Rides with this event into the batch it's uploaded in — never
+    /// sent standalone. Local/persisted state only, not part of the wire/hash
+    /// contract.
+    #[serde(default)]
+    pub notify: Option<NotifyPayload>,
 }
 
 /// Builds the notification payload for a high-risk event. Title/details are pulled
@@ -73,7 +79,6 @@ fn build_notify_payload(entry: &LogEntry) -> NotifyPayload {
 }
 
 const MAX_HASH_RETRIES_PER_LOOP: usize = 8;
-const MAX_NOTIFY_RETRIES_PER_LOOP: usize = 8;
 const HASH_TOKEN_MAX_AGE: Duration = Duration::from_secs(55 * 60);
 
 const INITIAL_BACKOFF_MS: i64 = 1_000; // 1s — matches today's single-failure retry-next-tick behavior
@@ -126,8 +131,6 @@ const MEDIUM_RISK_RATING: f32 = 0.4;
 pub struct UploadObserverState {
     pub pending_batch_events: Vec<PendingBatchEvent>,
     pub pending_hash_events: Vec<LogEntry>,
-    #[serde(default)]
-    pub pending_notify_events: Vec<NotifyPayload>,
     pub last_batch_at_ms: Option<i64>,
     pub post_login_proof_batches_remaining: u32,
     #[serde(default)]
@@ -140,7 +143,6 @@ impl UploadObserverState {
     pub fn reset_for_login(&mut self) {
         self.pending_batch_events.clear();
         self.pending_hash_events.clear();
-        self.pending_notify_events.clear();
         self.last_batch_at_ms = None;
         self.post_login_proof_batches_remaining = POST_LOGIN_PROOF_BATCH_COUNT;
     }
@@ -148,7 +150,6 @@ impl UploadObserverState {
     pub fn reset_for_logout(&mut self) {
         self.pending_batch_events.clear();
         self.pending_hash_events.clear();
-        self.pending_notify_events.clear();
         self.last_batch_at_ms = None;
         self.post_login_proof_batches_remaining = 0;
         self.settings = None;
@@ -156,9 +157,7 @@ impl UploadObserverState {
     }
 
     pub fn pending_request_count(&self) -> usize {
-        self.pending_hash_events.len()
-            + self.pending_notify_events.len()
-            + usize::from(!self.pending_batch_events.is_empty())
+        self.pending_hash_events.len() + usize::from(!self.pending_batch_events.is_empty())
     }
 }
 
@@ -193,7 +192,6 @@ pub struct UploadModule<A: ApiTransport + Clone + Send + Sync + 'static> {
     platform: Box<dyn ScreenshotHooks>,
     pub authenticated: bool,
     hash_backoff: RetryBackoff,
-    notify_backoff: RetryBackoff,
     batch_backoff: RetryBackoff,
     error_log: Option<crate::storage::FileStateStore>,
 }
@@ -208,7 +206,6 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             platform,
             authenticated: false,
             hash_backoff: RetryBackoff::default(),
-            notify_backoff: RetryBackoff::default(),
             batch_backoff: RetryBackoff::default(),
             error_log: None,
         }
@@ -222,24 +219,13 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         self
     }
 
-    fn upload_batch(&self, batch: &BatchUpload) -> CoreResult<()> {
+    fn upload_batch(&self, batch: &BatchUpload) -> CoreResult<UploadedBatchResponse> {
         let creds = self
             .state
             .device_credentials
             .as_ref()
             .ok_or(CoreError::NotAuthenticated)?;
-        self.api
-            .upload_batch(&creds.refresh_token, batch)
-            .map(|_| ())
-    }
-
-    fn notify(&self, payload: &NotifyPayload) -> CoreResult<()> {
-        let creds = self
-            .state
-            .device_credentials
-            .as_ref()
-            .ok_or(CoreError::NotAuthenticated)?;
-        self.api.notify(&creds.refresh_token, payload).map(|_| ())
+        self.api.upload_batch(&creds.refresh_token, batch)
     }
 
     fn upload_hash(
@@ -251,8 +237,11 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         self.api.upload_hash(hash_base_url, &hash_jwt, content_hash)
     }
 
-    /// Fetches a hash-server JWT, caching it for [`HASH_TOKEN_MAX_AGE`] so we don't hit
-    /// `POST /d/token` on every hash upload. Cleared on login/logout.
+    /// Returns the cached hash-server JWT, refreshing it via `GET /d/device` once it's
+    /// older than [`HASH_TOKEN_MAX_AGE`] — the replacement for the deleted
+    /// `POST /d/token`. A batch upload also refreshes this cache from its own response,
+    /// so on an active device this rarely needs to hit the network at all. The refresh
+    /// also opportunistically updates `state.settings`, same as a batch response does.
     fn ensure_hash_token(&mut self) -> CoreResult<String> {
         let refresh_token = self
             .state
@@ -268,9 +257,10 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         };
 
         if needs_refresh {
-            let token = self.api.get_hash_token(&refresh_token)?;
-            self.hash_token_cache = Some((token.clone(), Instant::now()));
-            Ok(token)
+            let result = self.api.get_device_settings(&refresh_token)?;
+            self.hash_token_cache = Some((result.hash_token.clone(), Instant::now()));
+            self.state.settings = Some(result.settings);
+            Ok(result.hash_token)
         } else {
             Ok(self.hash_token_cache.as_ref().unwrap().0.clone())
         }
@@ -315,10 +305,15 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
                 let hash = compute_event_hash(&encoded);
                 match self.upload_hash(hash_base_url.as_deref(), &hash) {
                     Ok(()) => {
+                        let is_high_risk = event
+                            .risk
+                            .is_some_and(|r| r >= crate::module::lifecycle::EXTRA_HIGH_RISK);
+                        let notify = is_high_risk.then(|| build_notify_payload(&event));
                         self.state.pending_batch_events.push(PendingBatchEvent {
                             ts: event.ts,
                             risk: event.risk.unwrap_or(0.0),
                             encoded,
+                            notify,
                         });
                         None
                     }
@@ -341,51 +336,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         Ok(())
     }
 
-    fn retry_pending_notifies(&mut self, now_ms: i64) -> CoreResult<()> {
-        if self.state.pending_notify_events.is_empty() || !self.notify_backoff.ready(now_ms) {
-            return Ok(());
-        }
-        let events = std::mem::take(&mut self.state.pending_notify_events);
-        let mut had_failure = false;
-        self.state.pending_notify_events =
-            drain_retry_queue(events, MAX_NOTIFY_RETRIES_PER_LOOP, |payload| {
-                match self.notify(&payload) {
-                    Ok(()) => None,
-                    Err(err) if err.is_bad_request() => {
-                        log_error("notify failed permanently", Some(&err));
-                        None
-                    }
-                    Err(_) => {
-                        had_failure = true;
-                        Some(payload)
-                    }
-                }
-            });
-        if had_failure {
-            self.notify_backoff.record_failure(now_ms);
-        } else {
-            self.notify_backoff.record_success();
-        }
-        Ok(())
-    }
-
-    /// Only sends queued notify emails once the hash + batch pipeline is confirmed
-    /// fully drained. `try_upload_batch`/`maybe_upload_batch` can return `Ok(())` on a
-    /// deferred/transient failure (no recipients yet, device settings refresh failed,
-    /// upload rejected) without actually uploading, so a plain `Ok(())` from those calls
-    /// is not sufficient evidence that a queued notify's event reached the server. An
-    /// empty `pending_hash_events` + `pending_batch_events` is: every event has been
-    /// hashed *and* its batch has been accepted.
-    fn retry_pending_notifies_if_flushed(&mut self, now_ms: i64) -> CoreResult<()> {
-        if self.state.pending_hash_events.is_empty() && self.state.pending_batch_events.is_empty() {
-            self.retry_pending_notifies(now_ms)?;
-        }
-        Ok(())
-    }
-
     fn maybe_upload_batch(&mut self, now_ms: i64, emitter: &Emitter) -> CoreResult<()> {
-        // Whether we have recipients to wrap for is decided in `try_upload_batch`
-        // after refetching settings, not from the (possibly stale) cached copy.
         if self.state.pending_batch_events.is_empty() {
             return Ok(());
         }
@@ -402,39 +353,6 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         Ok(())
     }
 
-    /// Refetches device settings from the API immediately before a batch upload
-    /// so the batch key is wrapped for the current recipient set (e.g. a partner
-    /// added or removed since the last periodic refresh). Returns `false` when the
-    /// device is gone and the batch should be abandoned; a transient failure
-    /// returns `true` so the batch still uploads against the last known settings.
-    fn refresh_settings_before_batch(&mut self, emitter: &Emitter) -> bool {
-        let Some(creds) = self.state.device_credentials.as_ref() else {
-            return true;
-        };
-        let refresh_token = creds.refresh_token.clone();
-        match self.api.get_device_settings(&refresh_token) {
-            Ok(settings) => {
-                self.state.settings = Some(settings);
-                true
-            }
-            Err(err) if err.is_not_found() || err.is_unauthorized() => {
-                log_warning(
-                    "settings refresh before batch: device deregistered or unauth, logging out",
-                    Some(&err),
-                );
-                let _ = emitter.send(LogoutRequested);
-                false
-            }
-            Err(err) => {
-                log_warning(
-                    "settings refresh before batch failed; using last known settings",
-                    Some(&err),
-                );
-                true
-            }
-        }
-    }
-
     pub(crate) fn try_upload_batch(
         &mut self,
         now_ms: i64,
@@ -447,11 +365,9 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         if respect_backoff && !self.batch_backoff.ready(now_ms) {
             return Ok(());
         }
-        if !self.refresh_settings_before_batch(emitter) {
-            return Ok(());
-        }
-        // With freshly fetched settings in hand, only proceed when there is at
-        // least one recipient to wrap for; otherwise keep the events queued.
+        // Settings come from the last Login/batch/ensure_hash_token response — no
+        // pre-batch fetch. Only proceed when there is at least one recipient to
+        // wrap for; otherwise keep the events queued until settings arrive.
         let settings = match self.state.settings.as_ref() {
             Some(s) if can_capture(s) => s,
             _ => return Ok(()),
@@ -469,6 +385,8 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             .iter()
             .filter(|e| e.risk >= MEDIUM_RISK_RATING && e.risk < HIGH_RISK_RATING)
             .count() as u32;
+        let notifications: Vec<NotifyPayload> =
+            items.iter().filter_map(|e| e.notify.clone()).collect();
         let encoded: Vec<Vec<u8>> = items.into_iter().map(|event| event.encoded).collect();
         let recipients = batch_recipients(settings)?;
         let batch = BatchBuilder::build_upload(
@@ -479,15 +397,21 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             now_ms,
             high_risk_count,
             medium_risk_count,
+            notifications,
         )?;
         match self.upload_batch(&batch) {
-            Ok(_) => {
+            Ok(response) => {
                 tracing::info!(count, start_time_ms, "batch upload ok");
                 self.state.pending_batch_events.drain(..count);
                 if self.state.post_login_proof_batches_remaining > 0 {
                     self.state.post_login_proof_batches_remaining -= 1;
                 }
                 self.state.last_batch_at_ms = Some(now_ms);
+                // A batch that just landed also resets the hash-token staleness
+                // clock, so ensure_hash_token rarely needs to hit the network on
+                // an active device.
+                self.state.settings = Some(response.settings);
+                self.hash_token_cache = Some((response.hash_token, Instant::now()));
                 self.batch_backoff.record_success();
                 Ok(())
             }
@@ -525,15 +449,7 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
         }
 
         self.retry_pending_hashes(now_ms)?;
-        // Force the batch out before sending any queued notify emails so the
-        // event(s) they reference already exist server-side by the time the
-        // email goes out, rather than waiting on the interval timer.
-        if self.state.pending_notify_events.is_empty() {
-            self.maybe_upload_batch(now_ms, emitter)?;
-        } else {
-            self.try_upload_batch(now_ms, emitter, true)?;
-        }
-        self.retry_pending_notifies_if_flushed(now_ms)?;
+        self.maybe_upload_batch(now_ms, emitter)?;
         Ok(())
     }
 
@@ -556,14 +472,11 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             risk: Some(risk),
             event: kind,
         };
-        // High-risk events trigger an immediate email notification, but the event
-        // body still rides through the hash chain + encrypted batch below — the
-        // server never receives it unencrypted.
-        if is_high_risk {
-            self.state
-                .pending_notify_events
-                .push(build_notify_payload(&entry));
-        }
+        // High-risk events trigger an alert-email notification once their batch
+        // lands (the notify payload is attached to the PendingBatchEvent once the
+        // hash succeeds — see retry_pending_hashes), but the event body still
+        // rides through the hash chain + encrypted batch — the server never
+        // receives it unencrypted.
         // Always enqueue, but only attempt network I/O while the screen is active
         // (battery): a locked/off screen leaves events queued for the next ping flush.
         self.state.pending_hash_events.push(entry);
@@ -572,16 +485,12 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> UploadModule<A> {
             self.retry_pending_hashes(now_ms)?;
             if is_heartbeat || is_high_risk {
                 // Force an immediate batch flush — don't wait for the interval timer.
-                // For a high-risk event this also guarantees the encrypted event is
-                // uploaded before the notify email below goes out, so the event
-                // already exists server-side when the recipient follows the link.
+                // For a high-risk event this also minimizes the delay before the
+                // attached notify email goes out, since it rides with this batch.
                 self.try_upload_batch(now_ms, emitter, true)?;
             } else {
                 self.maybe_upload_batch(now_ms, emitter)?;
             }
-        }
-        if is_high_risk && screen_active {
-            self.retry_pending_notifies_if_flushed(now_ms)?;
         }
         Ok(())
     }
@@ -610,7 +519,9 @@ impl<A: ApiTransport + Clone + Send + Sync + 'static> Observer for UploadModule<
         crate::dispatch_event!(event, {
             ev: Login => {
                 self.authenticated = true;
-                self.hash_token_cache = None;
+                // Registration already minted a hash token — seed the cache so we
+                // don't immediately turn around and hit GET /d/device for one.
+                self.hash_token_cache = Some((ev.hash_token.clone(), Instant::now()));
                 self.state.settings = Some(ev.settings.clone());
                 self.state.device_credentials = Some(ev.credentials.clone());
                 self.state.reset_for_login();
@@ -714,6 +625,7 @@ mod tests {
         Login {
             credentials: valid_credentials(),
             settings: valid_settings(),
+            hash_token: "test-hash-token".into(),
         }
     }
 
@@ -784,11 +696,19 @@ mod tests {
     }
 
     #[test]
-    fn hash_token_is_fetched_once_and_cached_across_uploads() {
+    fn hash_token_from_login_is_cached_and_reused_across_uploads() {
         let mut b = EventTester::builder();
         b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
         let mut t = b.build();
         t.emit(1, login_event());
+        // Isolate hash-token caching from batch-upload interference: a landed batch
+        // also refreshes the cached token from its own response, which would
+        // otherwise replace the login-minted token this test is checking for.
+        {
+            let m = t.observer::<UploadModule<MockApiClient>>();
+            m.state.post_login_proof_batches_remaining = 0;
+            m.state.last_batch_at_ms = Some(0);
+        }
 
         // Two low-risk uploads both flush through the hash server on an active screen.
         t.emit(2, skipped_upload());
@@ -796,23 +716,36 @@ mod tests {
 
         let s = t.api.state();
         assert_eq!(s.hash_uploads.len(), 2, "both hashes should upload");
+        assert!(
+            s.batch_uploads.is_empty(),
+            "batch interval not elapsed, no batch expected"
+        );
+        assert!(
+            s.hash_uploads
+                .iter()
+                .all(|h| h.hash_jwt == "test-hash-token"),
+            "both hash uploads should reuse the token minted at login"
+        );
         assert_eq!(
-            s.get_hash_token_calls.len(),
-            1,
-            "hash-server token should be fetched once and cached"
+            s.get_device_settings_calls.len(),
+            0,
+            "the login-minted hash token should be cached and reused, no GET /d/device needed"
         );
     }
 
     #[test]
-    fn settings_are_refetched_before_batch_and_new_recipients_are_used() {
+    fn batch_response_settings_update_recipients_for_the_next_batch() {
         let mut b = EventTester::builder();
         b.add(UploadModule::new(Box::new(b.platform()), b.api(), 60_000));
         let mut t = b.build();
         // Login seeds settings with a single recipient (the owner).
         t.emit(1, login_event());
 
-        // A partner is added server-side: the next settings fetch returns two recipients.
-        t.api.program_get_device_settings(Ok(DeviceSettings {
+        // A partner is added server-side: the next batch's response carries the
+        // updated recipient set. Settings now come from GET/POST /d/device and
+        // POST /d/batch responses, not a pre-batch fetch, so a newly added
+        // recipient shows up with a one-batch lag rather than immediately.
+        let updated_settings = DeviceSettings {
             device_id: "test-device".into(),
             name: "test device".into(),
             platform: "test".into(),
@@ -827,19 +760,49 @@ mod tests {
                 },
             ],
             hash_base_url: None,
+        };
+        t.api.program_batch(Ok(crate::api::UploadedBatchResponse {
+            id: "batch-1".into(),
+            settings: updated_settings,
+            hash_token: "fresh-hash-token".into(),
         }));
 
-        // A low-risk upload flushes a batch (post-login proof batches force it out).
+        // First low-risk upload flushes a batch (post-login proof batches force it
+        // out), wrapped for the single-recipient settings known since login.
         t.emit(2, skipped_upload());
 
-        let s = t.api.state();
+        {
+            let s = t.api.state();
+            assert_eq!(s.batch_uploads.len(), 1, "first batch should upload");
+            let recipients: Vec<String> = s.batch_uploads[0]
+                .batch
+                .access_keys
+                .iter()
+                .map(|k| k.user_id.clone())
+                .collect();
+            assert_eq!(
+                recipients,
+                vec!["test-user".to_string()],
+                "first batch should still be wrapped for the settings known at login time"
+            );
+        }
         assert_eq!(
-            s.get_device_settings_calls.len(),
-            1,
-            "settings should be refetched once, right before the batch upload"
+            t.observer::<UploadModule<MockApiClient>>()
+                .state
+                .settings
+                .as_ref()
+                .unwrap()
+                .wrapping_keys
+                .len(),
+            2,
+            "settings should be updated from the first batch's response"
         );
-        assert_eq!(s.batch_uploads.len(), 1, "batch should upload");
-        let recipients: Vec<String> = s.batch_uploads[0]
+
+        // A second upload now uses the settings the first batch's response delivered.
+        t.emit(3, skipped_upload());
+        let s = t.api.state();
+        assert_eq!(s.batch_uploads.len(), 2, "second batch should upload");
+        let recipients: Vec<String> = s.batch_uploads[1]
             .batch
             .access_keys
             .iter()
@@ -848,7 +811,7 @@ mod tests {
         assert_eq!(
             recipients,
             vec!["test-user".to_string(), "partner-user".to_string()],
-            "batch should be wrapped for the freshly fetched recipient set"
+            "second batch should be wrapped using settings from the first batch's response"
         );
     }
 
@@ -877,6 +840,7 @@ mod tests {
                     ts: 500,
                     risk: 0.0,
                     encoded: vec![1, 2, 3],
+                    notify: None,
                 });
         }
         t.emit(1, StatusRequest);
@@ -936,6 +900,7 @@ mod tests {
                 ts: 500,
                 risk: 0.0,
                 encoded: vec![1, 2, 3],
+                notify: None,
             });
 
         // A plain ping does not flush while locked.
@@ -1105,11 +1070,12 @@ mod tests {
             "event should remain queued after a deferred batch failure"
         );
         assert!(
-            !t.observer::<UploadModule<MockApiClient>>()
+            t.observer::<UploadModule<MockApiClient>>()
                 .state
-                .pending_notify_events
-                .is_empty(),
-            "notify should remain queued after a deferred batch failure"
+                .pending_batch_events
+                .iter()
+                .any(|e| e.notify.is_some()),
+            "the still-queued event should retain its notify payload for when the batch lands"
         );
 
         // A later ping, once the batch upload starts succeeding again, should flush the
@@ -1141,6 +1107,7 @@ mod tests {
                 ts: 500,
                 risk: 0.0,
                 encoded: vec![1, 2, 3],
+                notify: None,
             });
 
         // ProcessStopped is a terminal flush path → uploads regardless of lock.
@@ -1279,6 +1246,7 @@ mod tests {
                 ts: 500,
                 risk: 0.0,
                 encoded: vec![1, 2, 3],
+                notify: None,
             });
 
         // First flush fails, putting `batch_backoff` into a ~1s cooldown.
@@ -1338,6 +1306,7 @@ mod tests {
                 ts: 500,
                 risk: 0.0,
                 encoded: vec![1, 2, 3],
+                notify: None,
             });
 
         // First flush fails, putting `batch_backoff` into a ~1s cooldown.

--- a/client/core/src/module/upload/batch.rs
+++ b/client/core/src/module/upload/batch.rs
@@ -5,7 +5,7 @@ use flate2::write::GzEncoder;
 
 use crate::crypto::CryptoEngine;
 use crate::error::{CoreError, CoreResult};
-use crate::model::{BatchRecipient, BatchUpload};
+use crate::model::{BatchRecipient, BatchUpload, NotifyPayload};
 
 pub(crate) const MAX_BATCH_ITEMS_PER_UPLOAD: usize = 200;
 
@@ -22,6 +22,7 @@ impl BatchBuilder {
         end_time_ms: i64,
         high_risk_count: u32,
         medium_risk_count: u32,
+        notifications: Vec<NotifyPayload>,
     ) -> CoreResult<BatchUpload> {
         if encoded_events.is_empty() {
             return Err(CoreError::InvalidState(
@@ -58,6 +59,7 @@ impl BatchBuilder {
             access_keys,
             high_risk_count,
             medium_risk_count,
+            notifications,
         })
     }
 }

--- a/client/core/src/testing/api.rs
+++ b/client/core/src/testing/api.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use crate::api::{ApiTransport, UploadedBatchResponse};
+use crate::api::{ApiTransport, DeviceState, RegisteredDevice, UploadedBatchResponse};
 use crate::error::CoreResult;
 use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, NotifyPayload};
 
@@ -26,24 +26,22 @@ pub struct MockApiClient {
 
 pub struct MockApiState {
     // --- recordings ---
-    pub login_calls: Vec<(String, String)>,
     pub logout_calls: Vec<String>,
     pub register_device_calls: Vec<RegisterDeviceCall>,
     pub get_device_settings_calls: Vec<String>,
-    pub get_hash_token_calls: Vec<String>,
     pub batch_uploads: Vec<BatchCall>,
+    /// Derived from each successful `upload_batch` call's `batch.notifications` —
+    /// there is no standalone notify method anymore, so this records what the
+    /// batch carried rather than a separate API call.
     pub notify_calls: Vec<NotifyCall>,
     pub hash_uploads: Vec<HashCall>,
     pub reconfigure_calls: Vec<String>,
 
     // --- canned responses (FIFO per method) ---
-    pub login_responses: VecDeque<CoreResult<String>>,
     pub logout_responses: VecDeque<CoreResult<()>>,
-    pub register_device_responses: VecDeque<CoreResult<DeviceCredentials>>,
-    pub get_device_settings_responses: VecDeque<CoreResult<DeviceSettings>>,
-    pub get_hash_token_responses: VecDeque<CoreResult<String>>,
+    pub register_device_responses: VecDeque<CoreResult<RegisteredDevice>>,
+    pub get_device_settings_responses: VecDeque<CoreResult<DeviceState>>,
     pub batch_responses: VecDeque<CoreResult<UploadedBatchResponse>>,
-    pub notify_responses: VecDeque<CoreResult<()>>,
     pub hash_responses: VecDeque<CoreResult<()>>,
 
     // --- default values used when the canned queue is empty ---
@@ -56,7 +54,8 @@ pub struct MockApiState {
 
 #[derive(Debug, Clone)]
 pub struct RegisterDeviceCall {
-    pub user_refresh_token: String,
+    pub email: String,
+    pub password: String,
     pub name: String,
     pub platform: String,
 }
@@ -83,23 +82,18 @@ pub struct HashCall {
 impl Default for MockApiState {
     fn default() -> Self {
         Self {
-            login_calls: Vec::new(),
             logout_calls: Vec::new(),
             register_device_calls: Vec::new(),
             get_device_settings_calls: Vec::new(),
-            get_hash_token_calls: Vec::new(),
             batch_uploads: Vec::new(),
             notify_calls: Vec::new(),
             hash_uploads: Vec::new(),
             reconfigure_calls: Vec::new(),
 
-            login_responses: VecDeque::new(),
             logout_responses: VecDeque::new(),
             register_device_responses: VecDeque::new(),
             get_device_settings_responses: VecDeque::new(),
-            get_hash_token_responses: VecDeque::new(),
             batch_responses: VecDeque::new(),
-            notify_responses: VecDeque::new(),
             hash_responses: VecDeque::new(),
 
             default_device_id: "mock-device".to_string(),
@@ -136,30 +130,18 @@ impl MockApiClient {
 
     // --- convenience programming helpers (each pushes one canned response) ---
 
-    pub fn program_login(&self, response: CoreResult<String>) {
-        self.state().login_responses.push_back(response);
-    }
-
-    pub fn program_register_device(&self, response: CoreResult<DeviceCredentials>) {
+    pub fn program_register_device(&self, response: CoreResult<RegisteredDevice>) {
         self.state().register_device_responses.push_back(response);
     }
 
-    pub fn program_get_device_settings(&self, response: CoreResult<DeviceSettings>) {
+    pub fn program_get_device_settings(&self, response: CoreResult<DeviceState>) {
         self.state()
             .get_device_settings_responses
             .push_back(response);
     }
 
-    pub fn program_get_hash_token(&self, response: CoreResult<String>) {
-        self.state().get_hash_token_responses.push_back(response);
-    }
-
     pub fn program_batch(&self, response: CoreResult<UploadedBatchResponse>) {
         self.state().batch_responses.push_back(response);
-    }
-
-    pub fn program_notify(&self, response: CoreResult<()>) {
-        self.state().notify_responses.push_back(response);
     }
 
     pub fn program_hash(&self, response: CoreResult<()>) {
@@ -181,18 +163,6 @@ impl ApiTransport for MockApiClient {
         Ok(())
     }
 
-    fn login(&self, username: &str, password: &str) -> CoreResult<String> {
-        let mut state = self.state();
-        state
-            .login_calls
-            .push((username.to_string(), password.to_string()));
-        if let Some(canned) = state.login_responses.pop_front() {
-            canned
-        } else {
-            Ok("mock-user-refresh-token".to_string())
-        }
-    }
-
     fn logout(&self, device_refresh_token: &str) -> CoreResult<()> {
         let mut state = self.state();
         state.logout_calls.push(device_refresh_token.to_string());
@@ -205,27 +175,33 @@ impl ApiTransport for MockApiClient {
 
     fn register_device(
         &self,
-        user_refresh_token: &str,
+        email: &str,
+        password: &str,
         name: &str,
         platform: &str,
-    ) -> CoreResult<DeviceCredentials> {
+    ) -> CoreResult<RegisteredDevice> {
         let mut state = self.state();
         state.register_device_calls.push(RegisterDeviceCall {
-            user_refresh_token: user_refresh_token.to_string(),
+            email: email.to_string(),
+            password: password.to_string(),
             name: name.to_string(),
             platform: platform.to_string(),
         });
         if let Some(canned) = state.register_device_responses.pop_front() {
             canned
         } else {
-            Ok(DeviceCredentials {
-                device_id: state.default_device_id.clone(),
-                refresh_token: state.default_refresh_token.clone(),
+            Ok(RegisteredDevice {
+                credentials: DeviceCredentials {
+                    device_id: state.default_device_id.clone(),
+                    refresh_token: state.default_refresh_token.clone(),
+                },
+                settings: state.default_device_settings.clone(),
+                hash_token: state.default_hash_token.clone(),
             })
         }
     }
 
-    fn get_device_settings(&self, device_refresh_token: &str) -> CoreResult<DeviceSettings> {
+    fn get_device_settings(&self, device_refresh_token: &str) -> CoreResult<DeviceState> {
         let mut state = self.state();
         state
             .get_device_settings_calls
@@ -233,19 +209,10 @@ impl ApiTransport for MockApiClient {
         if let Some(canned) = state.get_device_settings_responses.pop_front() {
             canned
         } else {
-            Ok(state.default_device_settings.clone())
-        }
-    }
-
-    fn get_hash_token(&self, device_refresh_token: &str) -> CoreResult<String> {
-        let mut state = self.state();
-        state
-            .get_hash_token_calls
-            .push(device_refresh_token.to_string());
-        if let Some(canned) = state.get_hash_token_responses.pop_front() {
-            canned
-        } else {
-            Ok(state.default_hash_token.clone())
+            Ok(DeviceState {
+                settings: state.default_device_settings.clone(),
+                hash_token: state.default_hash_token.clone(),
+            })
         }
     }
 
@@ -259,27 +226,27 @@ impl ApiTransport for MockApiClient {
             device_refresh_token: device_refresh_token.to_string(),
             batch: batch.clone(),
         });
-        if let Some(canned) = state.batch_responses.pop_front() {
+        let response = if let Some(canned) = state.batch_responses.pop_front() {
             canned
         } else {
             state.batch_id_counter += 1;
             Ok(UploadedBatchResponse {
                 id: format!("mock-batch-{}", state.batch_id_counter),
+                settings: state.default_device_settings.clone(),
+                hash_token: state.default_hash_token.clone(),
             })
+        };
+        // Notify only counts once the batch actually lands (mirrors what the
+        // real server does: notifications are processed after the batch commits).
+        if response.is_ok() {
+            for payload in &batch.notifications {
+                state.notify_calls.push(NotifyCall {
+                    device_refresh_token: device_refresh_token.to_string(),
+                    payload: payload.clone(),
+                });
+            }
         }
-    }
-
-    fn notify(&self, device_refresh_token: &str, payload: &NotifyPayload) -> CoreResult<()> {
-        let mut state = self.state();
-        state.notify_calls.push(NotifyCall {
-            device_refresh_token: device_refresh_token.to_string(),
-            payload: payload.clone(),
-        });
-        if let Some(canned) = state.notify_responses.pop_front() {
-            canned
-        } else {
-            Ok(())
-        }
+        response
     }
 
     fn upload_hash(

--- a/client/core/src/testing/mod.rs
+++ b/client/core/src/testing/mod.rs
@@ -88,11 +88,20 @@ mod tests {
         let api = MockApiClient::new();
         let inspector = api.clone();
 
-        api.login("alice@example.org", "secret").unwrap();
-        assert_eq!(inspector.state().login_calls.len(), 1);
+        api.register_device(
+            "alice@example.org",
+            "secret",
+            "test-device",
+            "test-platform",
+        )
+        .unwrap();
+        assert_eq!(inspector.state().register_device_calls.len(), 1);
 
+        let default_settings = inspector.state().default_device_settings.clone();
         api.program_batch(Ok(crate::api::UploadedBatchResponse {
             id: "canned-batch".into(),
+            settings: default_settings,
+            hash_token: "canned-hash-token".into(),
         }));
         let batch = crate::model::BatchUpload {
             start_time_ms: 0,
@@ -101,6 +110,7 @@ mod tests {
             access_keys: Vec::new(),
             high_risk_count: 0,
             medium_risk_count: 0,
+            notifications: Vec::new(),
         };
         let response = api.upload_batch("tok", &batch).unwrap();
         assert_eq!(response.id, "canned-batch");


### PR DESCRIPTION
## Summary

Reviews and refactors the `/d/*` device-facing API routes and `/login`, which grew
organically and had accumulated several rough edges (see linked context below). This is
a coordinated breaking change across `api/` and `client/core/` — ships together as one
release, no backward-compatibility shims.

- Deduplicates a copy-pasted `getAppUrl` helper (4 copies → 1, `api/src/lib/app-url.ts`)
- `access_keys` wire shape: array → object keyed by `user_id`, eliminating a hand-rolled
  duplicate check on write and an asymmetric `.find()` on read
- New `api/src/lib/hash-server.ts` becomes the sole owner of `hash_states` access (local
  D1 or remote hash server), fixing a latent bug where `POST /d/batch`'s hash read/reset
  silently ignored `HASH_SERVER_URL` while `POST /d/logout` respected it
- Folds device login/settings/notify: `POST /d/device` now authenticates with
  `email`/`password_auth` directly (no web session) and returns
  `{refresh_token, settings, token}` in one call; `GET /d/device` replaces the deleted
  `POST /d/token`; `POST /d/batch` embeds a fresh `{settings, token}` pair and accepts an
  optional `notifications` array, replacing the deleted `POST /d/notify`
- Net effect: a Rust client goes from 8 HTTP round trips to log in and upload its first
  high-risk batch down to 3
- Matching Rust client changes: `ApiTransport` gains `register_device`/`DeviceState` in
  place of `login`/`get_hash_token`; `UploadModule` collapses its hash/batch/notify
  queues from 3 to 2 (notify metadata now rides with its event into whichever batch
  carries it, instead of a separate queue and endpoint); settings/hash-token refresh now
  piggyback on `Login`, `GET /d/device`, and `POST /d/batch` responses instead of a
  dedicated pre-batch fetch (partner add/remove now has a one-batch lag instead of
  zero-lag — documented in `client/core/architecture.md`)

None of the 5 crypto contracts in the root `CLAUDE.md` (batch wire format, content hash,
rolling hash state, password derivation, HPKE wrapping) changed — only endpoint shapes,
request/response envelopes, and the `access_keys` JSON encoding.

## Changes

Type: Refactor
Components: API, Core (client/core Rust)

## Testing

- `api/`: full vitest suite passes (49 tests, 12 files), `tsc` typecheck clean
- `client/core/`: `cargo test -p virtue-core` (126 unit tests) and
  `cargo test -p virtue-core --features testing` (126 unit + 17 scenario tests) pass
- `client/linux` and `client/ios/rust` compile clean; `client/android` has a pre-existing
  host-target `cfg` gate unrelated to this change; `mac`/`windows` need toolchains not
  available in this environment
- End-to-end: built and installed the real Linux `.deb`, registered a device against a
  live local dev API (`GET /user/login-material` → `POST /d/device` → hash uploads →
  `POST /d/batch`, all 2xx), confirmed the stored batch's `access_keys` column in D1 uses
  the new object shape, and confirmed the client parsed the new `{settings, token}`
  response shapes cleanly (no deserialization errors in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4nbEbpPxc2qBBTWCgRVad