### PR TITLE
ios: fix exported .ipa filename lookup in TestFlight upload script

### DIFF
--- a/client/ios/scripts/build-and-upload-testflight.sh
+++ b/client/ios/scripts/build-and-upload-testflight.sh
@@ -79,9 +79,10 @@ xcodebuild -exportArchive \
   -exportPath "$EXPORT_PATH" \
   -exportOptionsPlist "$EXPORT_PATH/ExportOptions.plist"
 
-IPA_PATH="$EXPORT_PATH/VirtueIOS.ipa"
-if [[ ! -f "$IPA_PATH" ]]; then
-  echo "Exported .ipa not found: $IPA_PATH" >&2
+IPA_PATH="$(find "$EXPORT_PATH" -maxdepth 1 -name '*.ipa' -print -quit)"
+if [[ -z "$IPA_PATH" || ! -f "$IPA_PATH" ]]; then
+  echo "No exported .ipa found under: $EXPORT_PATH" >&2
+  ls -la "$EXPORT_PATH" >&2 || true
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Fixes the TestFlight upload script following #566: signing now works end to end (archive + export succeed), this fixes the last step.

## Changes

<!-- Bug fix -->
<!-- Components: iOS -->

Confirmed in CI that manual distribution signing from #566 works: **ARCHIVE SUCCEEDED**, **EXPORT SUCCEEDED** (https://github.com/virtue-initiative/virtue-initiative/actions/runs/31897604690/job/95043235953). The only remaining failure was the script assuming the exported `.ipa` would be named `VirtueIOS.ipa`; `xcodebuild -exportArchive` named it something else, so the file wasn't found and the `altool` upload step never ran.

- [client/ios/scripts/build-and-upload-testflight.sh](client/ios/scripts/build-and-upload-testflight.sh): globs for `*.ipa` in the export directory instead of assuming the filename; prints the directory listing on failure for easier debugging if this happens again.

## Testing

- Not re-run in CI yet — will confirm the full archive → export → upload path succeeds on the next staging push after merge.