### PR TITLE
ios: fix altool API key discovery for TestFlight upload

### DIFF
--- a/client/ios/scripts/build-and-upload-testflight.sh
+++ b/client/ios/scripts/build-and-upload-testflight.sh
@@ -35,6 +35,12 @@ mkdir -p "$PROFILES_DIR"
 cp "$IOS_APP_PROVISIONING_PROFILE_PATH" "$PROFILES_DIR/virtue-ios-app-store.mobileprovision"
 cp "$IOS_EXT_PROVISIONING_PROFILE_PATH" "$PROFILES_DIR/virtue-ios-safari-ext-app-store.mobileprovision"
 
+# altool only looks for the API key by ID in a fixed set of directories; it
+# doesn't accept an arbitrary path like xcodebuild's -authenticationKeyPath does.
+ASC_KEYS_DIR="$HOME/.appstoreconnect/private_keys"
+mkdir -p "$ASC_KEYS_DIR"
+cp "$IOS_ASC_API_KEY_PATH" "$ASC_KEYS_DIR/AuthKey_${IOS_ASC_KEY_ID}.p8"
+
 echo "Archiving ${SCHEME} ${MARKETING_VERSION} (build ${CURRENT_PROJECT_VERSION})"
 
 xcodebuild archive \


### PR DESCRIPTION
## Summary

- Fixes the TestFlight upload following #567: archive, export, and .ipa lookup all now succeed — this fixes the actual upload auth.

## Changes

<!-- Bug fix -->
<!-- Components: iOS -->

Confirmed in CI (https://github.com/virtue-initiative/virtue-initiative/actions/runs/31898085477/job/95044394856): **ARCHIVE SUCCEEDED**, **EXPORT SUCCEEDED**, `.ipa` found (`Virtue.ipa` — confirms #567's fix was needed, the name wasn't `VirtueIOS.ipa`). Upload then failed:

```
ERROR: [altool.102976DF0] Failed to load AuthKey file. (-43) The file 'AuthKey_***.p8' could not be found in any of these locations: '~/work/virtue-initiative/virtue-initiative/client/ios/private_keys', '~/private_keys', '~/.private_keys', '~/.appstoreconnect/private_keys'.
```

`altool --apiKey` takes a key **ID**, not a path — it only looks for `AuthKey_<ID>.p8` in a fixed set of directories (unlike `xcodebuild -authenticationKeyPath`, which does take an explicit path and is what the rest of this pipeline's mental model was based on). The workflow writes the key to a `$RUNNER_TEMP` path, which isn't one of altool's search locations.

- [client/ios/scripts/build-and-upload-testflight.sh](client/ios/scripts/build-and-upload-testflight.sh): copies the `.p8` into `~/.appstoreconnect/private_keys/AuthKey_<ID>.p8` before invoking `altool`.

## Testing

- Not re-run in CI yet — will confirm the full pipeline (archive → export → upload) completes on the next staging push after merge.