### PR TITLE
Fix Windows dev MSIX version so it's actually Store-acceptable and allows multiple builds/day

### DIFF
--- a/.github/workflows/client-windows.yml
+++ b/.github/workflows/client-windows.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/client-windows.yml
+++ b/.github/workflows/client-windows.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/client/windows/scripts/build-msix.ps1
+++ b/client/windows/scripts/build-msix.ps1
@@ -425,7 +425,7 @@ function Get-AppPackageName {
     return $name
 }
 
-function Get-InstalledPackageRevision {
+function Get-InstalledPackageBuildNumber {
     param([string]$PackageName)
 
     try {
@@ -443,55 +443,27 @@ function Get-InstalledPackageRevision {
 
     $versionText = $installed.Version.ToString()
     $versionParts = $versionText.Split('.')
-    if ($versionParts.Count -lt 4) {
+    if ($versionParts.Count -lt 3) {
         return 0
     }
 
-    return [int]$versionParts[3]
+    return [int]$versionParts[2]
 }
 
-function Get-CommitsSinceVersionBump {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoRoot
-    )
+function Get-DevMsixBuildNumber {
+    param([string]$PackageName)
 
-    $git = (Get-Command git -ErrorAction SilentlyContinue | Select-Object -First 1).Source
-    if (-not $git) {
-        throw "git not found; cannot compute commits since the last version bump."
-    }
-
-    $bumpCommit = & $git -C $RepoRoot log -1 --format=%H -- client/version.properties 2>$null
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($bumpCommit)) {
-        throw "Unable to locate a commit that touched client/version.properties. Ensure the checkout has full history (fetch-depth: 0)."
-    }
-    $bumpCommit = $bumpCommit.Trim()
-
-    $countText = & $git -C $RepoRoot rev-list --count "$bumpCommit..HEAD" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw "git rev-list failed while counting commits since the last version bump."
-    }
-
-    return [int]$countText.Trim()
-}
-
-function New-DevMsixRevision {
-    param(
-        [string]$PackageName,
-        [string]$RepoRoot
-    )
-
-    if ($env:GITHUB_ACTIONS -eq "true") {
-        $nextRevision = Get-CommitsSinceVersionBump -RepoRoot $RepoRoot
+    if ($env:GITHUB_RUN_NUMBER) {
+        $buildNumber = [int]$env:GITHUB_RUN_NUMBER
     } else {
-        $nextRevision = (Get-InstalledPackageRevision -PackageName $PackageName) + 1
+        $buildNumber = (Get-InstalledPackageBuildNumber -PackageName $PackageName) + 1
     }
 
-    if ($nextRevision -gt 65535) {
-        throw "Computed MSIX revision $nextRevision exceeds the Appx limit of 65535."
+    if ($buildNumber -gt 65535) {
+        throw "Computed MSIX build number $buildNumber exceeds the Appx limit of 65535."
     }
 
-    return $nextRevision
+    return $buildNumber
 }
 
 $VersionHelper = Join-Path $PSScriptRoot "Get-VersionInfo.ps1"
@@ -536,7 +508,7 @@ if ([string]::IsNullOrWhiteSpace($PackageVersion)) {
     $PackageVersion = Convert-ToMsixVersion -Value $VersionInfo.BaseVersion
     if ($VersionInfo.ReleaseChannel -eq "dev") {
         $versionParts = $PackageVersion.Split('.')
-        $versionParts[3] = [string](New-DevMsixRevision -PackageName $PackageName -RepoRoot $RepoRoot)
+        $versionParts[2] = [string](Get-DevMsixBuildNumber -PackageName $PackageName)
         $PackageVersion = $versionParts -join '.'
     }
 }

--- a/client/windows/scripts/build-msix.ps1
+++ b/client/windows/scripts/build-msix.ps1
@@ -450,13 +450,42 @@ function Get-InstalledPackageRevision {
     return [int]$versionParts[3]
 }
 
-function New-DevMsixRevision {
-    param([string]$PackageName)
+function Get-CommitsSinceVersionBump {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
 
-    $utcNow = [DateTimeOffset]::UtcNow
-    $seed = (($utcNow.Year - 2000) * 366) + $utcNow.DayOfYear
-    $installedRevision = Get-InstalledPackageRevision -PackageName $PackageName
-    $nextRevision = [Math]::Max($seed, $installedRevision + 1)
+    $git = (Get-Command git -ErrorAction SilentlyContinue | Select-Object -First 1).Source
+    if (-not $git) {
+        throw "git not found; cannot compute commits since the last version bump."
+    }
+
+    $bumpCommit = & $git -C $RepoRoot log -1 --format=%H -- client/version.properties 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($bumpCommit)) {
+        throw "Unable to locate a commit that touched client/version.properties. Ensure the checkout has full history (fetch-depth: 0)."
+    }
+    $bumpCommit = $bumpCommit.Trim()
+
+    $countText = & $git -C $RepoRoot rev-list --count "$bumpCommit..HEAD" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git rev-list failed while counting commits since the last version bump."
+    }
+
+    return [int]$countText.Trim()
+}
+
+function New-DevMsixRevision {
+    param(
+        [string]$PackageName,
+        [string]$RepoRoot
+    )
+
+    if ($env:GITHUB_ACTIONS -eq "true") {
+        $nextRevision = Get-CommitsSinceVersionBump -RepoRoot $RepoRoot
+    } else {
+        $nextRevision = (Get-InstalledPackageRevision -PackageName $PackageName) + 1
+    }
 
     if ($nextRevision -gt 65535) {
         throw "Computed MSIX revision $nextRevision exceeds the Appx limit of 65535."
@@ -507,7 +536,7 @@ if ([string]::IsNullOrWhiteSpace($PackageVersion)) {
     $PackageVersion = Convert-ToMsixVersion -Value $VersionInfo.BaseVersion
     if ($VersionInfo.ReleaseChannel -eq "dev") {
         $versionParts = $PackageVersion.Split('.')
-        $versionParts[3] = [string](New-DevMsixRevision -PackageName $PackageName)
+        $versionParts[3] = [string](New-DevMsixRevision -PackageName $PackageName -RepoRoot $RepoRoot)
         $PackageVersion = $versionParts -join '.'
     }
 }


### PR DESCRIPTION
## Summary

Windows dev MSIX packages were failing real Microsoft Store validation with:

> Package acceptance validation error: Apps are not allowed to have a Version with a revision number other than zero specified in the app manifest.

The dev-channel `Identity Version` revision (4th component) was previously seeded from day-of-year, with a `Max(seed, installedRevision + 1)` fallback meant to bump past whatever's already installed. On GitHub Actions runners nothing is ever pre-installed, so the fallback never engaged — every dev build on the same UTC day got an identical revision, and worse, **the Store rejects any nonzero revision outright, no matter how it's computed.** There's no revision-based scheme that can ever pass Store validation for a dev build.

This moves the per-build discriminator to the Build component (3rd part) instead, driven by `GITHUB_RUN_NUMBER` (guaranteed by GitHub to strictly increase per workflow run — no wraparound risk, no git history needed). Revision is now pinned at `0` for every channel, matching what the stable (main) channel already correctly did.

## Changes

<!-- Type of change -->
Bug fix

<!-- Components -->
Windows

- `client/windows/scripts/build-msix.ps1`:
  - `Get-InstalledPackageBuildNumber` (renamed from `Get-InstalledPackageRevision`) now reads the Build component instead of Revision.
  - `Get-DevMsixBuildNumber` (replaces `New-DevMsixRevision`) uses `$env:GITHUB_RUN_NUMBER` in CI, falling back to `installed + 1` for local builds.
  - Dev-channel `PackageVersion` resolution now sets `versionParts[2]` (Build) instead of `versionParts[3]` (Revision), which stays `0`.

## Testing

- Reviewed the version-resolution logic by hand against the actual Store rejection message.
- No local Windows/pwsh environment available to execute `build-msix.ps1` directly — relying on CI (`Client Windows Checks` workflow) to validate the version-resolution step.
- Confirmed `PackageVersion` will now always have `0` as its 4th component for both `stable` and `dev` channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N36ZA4f7QteSWwVbzDyNtd