### PR TITLE
Fix Windows Store package identity, drop Azure signing

### DIFF
--- a/.github/workflows/client-windows.yml
+++ b/.github/workflows/client-windows.yml
@@ -1,7 +1,6 @@
 name: Client Windows Checks
 
 permissions:
-  id-token: write
   contents: write
 
 on:
@@ -100,34 +99,10 @@ jobs:
           "release_tag=$($info.ReleaseTag)" >> $env:GITHUB_OUTPUT
           "build_label=$($info.BuildLabel)" >> $env:GITHUB_OUTPUT
 
-      - name: Azure login
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Build Windows MSIX (release)
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
-        env:
-          VIRTUE_WINDOWS_PACKAGE_PUBLISHER: ${{ vars.AZURE_CODESIGN_PUBLISHER_SUBJECT }}
-        run: ./windows/scripts/build-msix.ps1 -Profile Release -Version "${{ steps.version.outputs.build_label }}" -SkipSigning
+        run: ./windows/scripts/build-msix.ps1 -Profile Release -Version "${{ steps.version.outputs.build_label }}"
         working-directory: client
-
-      - name: Sign Windows MSIX artifacts with Azure Artifact Signing
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
-        uses: azure/artifact-signing-action@v1
-        with:
-          endpoint: ${{ vars.AZURE_CODESIGN_ENDPOINT }}
-          signing-account-name: ${{ vars.AZURE_CODESIGN_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ vars.AZURE_CODESIGN_CERT_PROFILE }}
-          files-folder: ${{ github.workspace }}\client\windows\dist
-          files-folder-filter: 'Virtue.*.msix,virtue-*.msix'
-          files-folder-recurse: true
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
 
       - name: Repack Windows setup bundle
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')

--- a/client/windows/README.md
+++ b/client/windows/README.md
@@ -88,27 +88,7 @@ The packaging script also runs the managed tests before producing the MSIX artif
 
 ## Release Signing
 
-GitHub Actions release packaging uses Azure Artifact Signing with OpenID Connect.
-
-Repository secrets:
-
-- `AZURE_CLIENT_ID`
-- `AZURE_TENANT_ID`
-- `AZURE_SUBSCRIPTION_ID`
-
-Repository variables:
-
-- `AZURE_CODESIGN_ACCOUNT_NAME`
-- `AZURE_CODESIGN_ENDPOINT`
-- `AZURE_CODESIGN_CERT_PROFILE`
-
-Recommended repository variable:
-
-- `AZURE_CODESIGN_PUBLISHER_SUBJECT`
-
-The publisher-subject variable should be the exact subject used by the Artifact Signing certificate profile, for example `CN=Jane Doe` for individual signing or the exact org subject string for organization signing. The MSIX manifest publisher must match this subject exactly.
-
-The workflow builds unsigned release artifacts, signs every `.msix` under `client/windows/dist/` with `azure/artifact-signing-action`, and then recreates the setup ZIP so the embedded MSIX is signed too.
+GitHub Actions release packaging no longer uses an external signing service. The manifest's `Identity Publisher` (`client/windows/Virtue.WindowsApp/Package.appxmanifest`) must always match the publisher assigned by Partner Center for this app's Store identity, so the workflow lets `build-msix.ps1` fall back to its built-in self-signed development certificate (the same path used for PR/Debug builds) rather than overriding the publisher with an external signing cert's subject. Microsoft Store re-signs the package on ingestion, so a self-signed upload is sufficient for submission; for sideload installs the generated `.cer` in the setup bundle still needs to be trusted on the target machine as before.
 
 ## Linux-Driven Remote Windows Loop
 

--- a/client/windows/Virtue.WindowsApp/Package.appxmanifest
+++ b/client/windows/Virtue.WindowsApp/Package.appxmanifest
@@ -8,9 +8,9 @@
   xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap uap10 uap11 desktop desktop6 rescap">
-  <Identity Name="VirtueInitiative.VirtueWindows" Publisher="CN=Virtue Initiative" Version="0.0.5.0" />
+  <Identity Name="VirtueInitiative.VirtueAccountability" Publisher="CN=CE0CD9E5-E8B5-49DD-96E4-E6C5D6146BC6" Version="0.0.5.0" />
   <Properties>
-    <DisplayName>Virtue</DisplayName>
+    <DisplayName>Virtue Initiative</DisplayName>
     <PublisherDisplayName>Virtue Initiative</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
@@ -23,7 +23,7 @@
   <Applications>
     <Application Id="App" Executable="Virtue.WindowsApp.exe" EntryPoint="$targetentrypoint$">
       <uap:VisualElements
-        DisplayName="Virtue"
+        DisplayName="Virtue Initiative"
         Description="Virtue Windows desktop client"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"


### PR DESCRIPTION
## Summary

Microsoft Store package validation rejected the last submission:

> Invalid package identity name: VirtueInitiative.VirtueWindows (expected: VirtueInitiative.VirtueAccountability)
> Invalid package family name: VirtueInitiative.VirtueWindows_2betv9mrewzkg (expected: VirtueInitiative.VirtueAccountability_q0v4hvezr2m36)
> Invalid package publisher name: CN=Andrew Baumes, O=Andrew Baumes, L=Mechanicville, S=New York, C=US (expected: CN=CE0CD9E5-E8B5-49DD-96E4-E6C5D6146BC6)
> This package's manifest (Package/Properties/DisplayName) uses a display name that you have not reserved: Virtue

`Package.appxmanifest`'s `Identity` didn't match the identity Partner Center actually assigned this app. The publisher mismatch specifically traces back to CI overriding the manifest's publisher with the Azure Trusted Signing certificate's subject (`CN=Andrew Baumes, ...`), which never matched Partner Center's assigned publisher CN to begin with.

Since the Store re-signs whatever package gets uploaded, there's no need for the release build to be signed with an externally-trusted certificate at all — this drops the Azure login/Artifact Signing steps entirely and lets `build-msix.ps1` fall back to the same self-signed dev certificate it already uses for Debug/PR builds, now with the correct Partner-Center-assigned identity baked into the manifest instead of being overridden at build time.

## Changes

<!-- Type of change -->
Bug fix

<!-- Components -->
Windows

- `client/windows/Virtue.WindowsApp/Package.appxmanifest`: `Identity/Name` → `VirtueInitiative.VirtueAccountability`, `Identity/Publisher` → `CN=CE0CD9E5-E8B5-49DD-96E4-E6C5D6146BC6`, `Properties/DisplayName` and `uap:VisualElements/DisplayName` → `Virtue Initiative`
- `.github/workflows/client-windows.yml`: remove `Azure login` and `Sign Windows MSIX artifacts with Azure Artifact Signing` steps, remove the now-unneeded `id-token: write` permission and the `VIRTUE_WINDOWS_PACKAGE_PUBLISHER` override that pointed at the Azure cert subject
- `client/windows/README.md`: rewrite the "Release Signing" section to describe the new (no external signing service) flow

## Testing

- Reviewed the manifest values directly against the identity block Partner Center returned in the rejection email/dashboard.
- No local Windows/pwsh environment available — relying on CI (`Client Windows Checks` workflow) to validate the build/packaging steps still succeed with the Azure steps removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N36ZA4f7QteSWwVbzDyNtd