### PR TITLE
ios: fix TLS root store failure blocking all API requests

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2870,6 +2871,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4266,6 +4268,15 @@ checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
 dependencies = [
  "image",
  "libwebp-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -31,7 +31,7 @@ hpke = "0.13.0"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 pbkdf2 = "0.12"
 rand_core = { version = "0.9.5", features = ["os_rng"] }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "cookies", "json", "multipart", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "cookies", "json", "multipart", "rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
 rmp-serde = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/client/ios/app/Sources/MonitoringCoordinator.swift
+++ b/client/ios/app/Sources/MonitoringCoordinator.swift
@@ -143,7 +143,7 @@ final class MonitoringCoordinator: ObservableObject {
             isSigningIn = false
             if let error {
                 statusMessage = "Login failed: \(error)"
-                loginError = "Invalid username or password"
+                loginError = error
                 return
             }
             password = ""


### PR DESCRIPTION
## Human

Staging web requests were just not working from iOS, and apparently another optional addition to reqwests rust package fixes it.

## Summary

- Fixes the actual login bug reported from the first working TestFlight build: sign-in failed with a generic HTTP error, confirmed root-caused via a local simulator build against staging.

## Changes

<!-- Bug fix -->
<!-- Components: iOS -->

**Investigation**: initial report was "invalid username or password" under the Sign In button. That label turned out to be [hardcoded](client/ios/app/Sources/MonitoringCoordinator.swift) regardless of the actual error, which sent the investigation down the wrong path (spent time verifying the shared password-hashing crypto byte-for-byte against the web client's implementation — confirmed identical, not the issue). Built and ran the app locally in iOS Simulator pointed at staging (`client/.env`, gitignored) to see the real error, which was:

```
HTTP error: error sending request for url (https://staging.app.virtueinitiative.org/api/v0.1/user/login-material?email=...)
```

— failing on the very first GET request, before any credential handling. `curl` reached the same URL fine from the same Mac, and a Linux client build already logs in successfully against staging, narrowing this to something iOS-specific in the HTTP layer.

**Root cause**: [client/core/Cargo.toml](client/core/Cargo.toml) enables reqwest's `rustls-tls-native-roots` feature, which loads the OS certificate trust store via `rustls-native-certs`. This is a known-unreliable path on iOS, which doesn't expose a conventional CA bundle API the way desktop platforms do — so every HTTPS request had no trusted roots to validate against and failed silently at the transport layer.

**Fix**: added `rustls-tls-webpki-roots` (Mozilla's compiled-in root CA list, no OS lookup needed) alongside the existing feature. Additive — doesn't change trust behavior on platforms where native-roots already works, just gives iOS a reliable fallback.

**Also fixed**: [MonitoringCoordinator.swift](client/ios/app/Sources/MonitoringCoordinator.swift) was hardcoding the login error label to "Invalid username or password" no matter what the underlying error actually was, which is what masked this bug during initial troubleshooting. Now shows the real error message.

## Testing

- Verified locally: built for iOS Simulator with `client/.env` pointing `VIRTUE_DEFAULT_API_URL` at staging, launched on both iPhone 16 and iPhone 16e simulators, signed in successfully with a real staging account after this fix (failed with the exact reported error before it).
- `cargo build -p virtue-core`: passes with the new feature.
- Cross-checked the shared password-derivation crypto (`derive_password_auth`) against the web client's `derivePasswordMaterial` with an identical test vector — byte-for-byte match, confirmed not the source of any login issue.