### PR TITLE
Paginate GET /data and drain pages in the web cache worker

### DIFF
--- a/api/SPEC.md
+++ b/api/SPEC.md
@@ -529,13 +529,14 @@ On success, the server SHOULD return `204 No Content`.
 
 The client MUST be authenticated wit ha **Web Token**
 
-The client MAY send `?since=DateTime` to only receive batches since that time.
+The client MAY send `?since=DateTime` to only receive batches since that time. The client MAY provide `?since=0` to get all batches.
 
 The server MUST collect the user, partners, and batches and return them in this shape.
 
 ```js
 {
   "batches": BatchData[],
+  "batches_complete": true,
   "watching": PartnerInfo[],
   "watchers": PartnerInfo[],
   "user": User,
@@ -543,6 +544,8 @@ The server MUST collect the user, partners, and batches and return them in this 
 ```
 
 The server SHOULD filter the batches to only include batches the user can decrypt.
+
+The server MAY return a subset of the batches and mark "batches_complete": false. The server MUST return oldest batches first.
 
 The server MUST only return batches where `created_at > since`.
 

--- a/api/src/lib/db.ts
+++ b/api/src/lib/db.ts
@@ -572,7 +572,11 @@ export async function createBatch(
     .run();
 }
 
-export async function listBatches(db: D1Database, ownerIds: string[], filters: { since?: number }) {
+export async function listBatches(
+  db: D1Database,
+  ownerIds: string[],
+  filters: { since?: number; limit?: number },
+) {
   if (ownerIds.length === 0) {
     return [];
   }
@@ -588,6 +592,11 @@ export async function listBatches(db: D1Database, ownerIds: string[], filters: {
   }
 
   query += ' ORDER BY created_at ASC';
+
+  if (filters.limit !== undefined) {
+    query += ' LIMIT ?';
+    params.push(filters.limit);
+  }
 
   return allWithUuidFields<{
     id: string;

--- a/api/src/routes/data.ts
+++ b/api/src/routes/data.ts
@@ -27,6 +27,10 @@ const listDataSchema = z.object({
   since: z.coerce.number().int().nonnegative().optional().default(0),
 });
 
+// Cap the number of batches returned per request so a viewer with a very long history
+// can't produce an unbounded response; the client is expected to page through with `since`.
+export const DATA_BATCH_PAGE_LIMIT = 500;
+
 data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), async (c) => {
   const userId = c.get('sub');
   const { since } = c.req.valid('query');
@@ -42,7 +46,12 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
     return c.json({ error: 'Not found' }, 404);
   }
 
-  const batches = await listBatches(c.env.DB, ownerIds, { since });
+  const fetchedBatches = await listBatches(c.env.DB, ownerIds, {
+    since,
+    limit: DATA_BATCH_PAGE_LIMIT + 1,
+  });
+  const batchesComplete = fetchedBatches.length <= DATA_BATCH_PAGE_LIMIT;
+  const batches = fetchedBatches.slice(0, DATA_BATCH_PAGE_LIMIT);
 
   return c.json({
     batches: batches
@@ -65,6 +74,7 @@ data.get('/', authenticateWebSession(), validateZ('query', listDataSchema), asyn
         };
       })
       .filter((item) => item !== null),
+    batches_complete: batchesComplete,
     user: serializeUser(user),
     watching: serializeWatching(incoming),
     watchers: serializeWatchers(owned),

--- a/api/test/data.test.ts
+++ b/api/test/data.test.ts
@@ -12,6 +12,8 @@ import {
 } from './helpers';
 import { installHashServerMock, seedHashState } from './hash-server-mock';
 import { CURRENT_API_VERSION } from '../src/lib/api-version';
+import { createBatch } from '../src/lib/db';
+import { DATA_BATCH_PAGE_LIMIT } from '../src/routes/data';
 
 beforeAll(() => {
   fetchMock.activate();
@@ -90,6 +92,7 @@ describe('Data and device API routes', () => {
         encrypted_key: string;
         created_at: number;
       }>;
+      batches_complete: boolean;
       user: { id: string; email: string };
       watching: unknown[];
       watchers: unknown[];
@@ -100,6 +103,7 @@ describe('Data and device API routes', () => {
       encrypted_key: Buffer.from('owner-envelope').toString('base64'),
     });
     expect(data.batches[0]?.created_at).toEqual(expect.any(Number));
+    expect(data.batches_complete).toBe(true);
     expect(data.user).toMatchObject({ id: userId, email: 'alice@example.com' });
     expect(data.watching).toEqual([]);
     expect(data.watchers).toEqual([]);
@@ -169,6 +173,104 @@ describe('Data and device API routes', () => {
       Buffer.from('partner-envelope').toString('base64'),
     );
     expect(partnerData.watching[0]?.user.email).toBe('owner@example.com');
+  });
+
+  it('?since=0 returns every batch as complete when the backlog exactly fills the page limit', async () => {
+    const { cookie: userCookie, userId } = await signupAndGetCookie('since-zero@example.com');
+    const device = await createDeviceForUser('since-zero@example.com', 'password123');
+
+    const baseTime = 1710000000000;
+    for (let i = 0; i < DATA_BATCH_PAGE_LIMIT; i += 1) {
+      const id = `00000000-0000-4000-9100-${i.toString(16).padStart(12, '0')}`;
+      await createBatch(env.DB, {
+        id,
+        user_id: userId,
+        device_id: device.id,
+        url: `https://example.com/batch-${i}.enc`,
+        start_time: baseTime + i,
+        end_time: baseTime + i,
+        end_hash: `hash-${i}`,
+        access_keys: JSON.stringify({ [userId]: `key-${i}` }),
+        version: CURRENT_API_VERSION,
+        created_at: baseTime + i,
+      });
+    }
+
+    const res = await SELF.fetch(`${BASE}/data?since=0`, { headers: authHeaders(userCookie) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      batches: Array<{ encrypted_key: string }>;
+      batches_complete: boolean;
+    };
+    expect(body.batches).toHaveLength(DATA_BATCH_PAGE_LIMIT);
+    expect(body.batches_complete).toBe(true);
+
+    // Omitting `since` entirely defaults to 0 and MUST behave identically.
+    const defaultedRes = await SELF.fetch(`${BASE}/data`, { headers: authHeaders(userCookie) });
+    expect(defaultedRes.status).toBe(200);
+    const defaultedBody = (await defaultedRes.json()) as {
+      batches: Array<{ encrypted_key: string }>;
+      batches_complete: boolean;
+    };
+    expect(defaultedBody.batches).toEqual(body.batches);
+    expect(defaultedBody.batches_complete).toBe(true);
+  });
+
+  it('pages a backlog larger than the per-request batch limit, oldest first', async () => {
+    const { cookie: userCookie, userId } = await signupAndGetCookie('pagination@example.com');
+    const device = await createDeviceForUser('pagination@example.com', 'password123');
+
+    const backlogSize = DATA_BATCH_PAGE_LIMIT + 20;
+    const baseTime = 1710000000000;
+    for (let i = 0; i < backlogSize; i += 1) {
+      const id = `00000000-0000-4000-9000-${i.toString(16).padStart(12, '0')}`;
+      await createBatch(env.DB, {
+        id,
+        user_id: userId,
+        device_id: device.id,
+        url: `https://example.com/batch-${i}.enc`,
+        start_time: baseTime + i,
+        end_time: baseTime + i,
+        end_hash: `hash-${i}`,
+        access_keys: JSON.stringify({ [userId]: `key-${i}` }),
+        version: CURRENT_API_VERSION,
+        created_at: baseTime + i,
+      });
+    }
+
+    const firstPageRes = await SELF.fetch(`${BASE}/data?since=0`, {
+      headers: authHeaders(userCookie),
+    });
+    expect(firstPageRes.status).toBe(200);
+    const firstPage = (await firstPageRes.json()) as {
+      batches: Array<{ created_at: number; encrypted_key: string }>;
+      batches_complete: boolean;
+    };
+    expect(firstPage.batches).toHaveLength(DATA_BATCH_PAGE_LIMIT);
+    expect(firstPage.batches_complete).toBe(false);
+    expect(firstPage.batches.map((b) => b.encrypted_key)).toEqual(
+      Array.from({ length: DATA_BATCH_PAGE_LIMIT }, (_, i) => `key-${i}`),
+    );
+    const createdAts = firstPage.batches.map((b) => b.created_at);
+    expect(createdAts).toEqual([...createdAts].sort((a, b) => a - b));
+
+    const cursor = firstPage.batches[firstPage.batches.length - 1]!.created_at;
+    const secondPageRes = await SELF.fetch(`${BASE}/data?since=${cursor}`, {
+      headers: authHeaders(userCookie),
+    });
+    expect(secondPageRes.status).toBe(200);
+    const secondPage = (await secondPageRes.json()) as {
+      batches: Array<{ created_at: number; encrypted_key: string }>;
+      batches_complete: boolean;
+    };
+    expect(secondPage.batches).toHaveLength(backlogSize - DATA_BATCH_PAGE_LIMIT);
+    expect(secondPage.batches_complete).toBe(true);
+    expect(secondPage.batches.map((b) => b.encrypted_key)).toEqual(
+      Array.from(
+        { length: backlogSize - DATA_BATCH_PAGE_LIMIT },
+        (_, i) => `key-${DATA_BATCH_PAGE_LIMIT + i}`,
+      ),
+    );
   });
 
   it('rejects a batch upload whose metadata is missing the required event_counts object', async () => {

--- a/shared-web/types.ts
+++ b/shared-web/types.ts
@@ -100,6 +100,7 @@ export type PartnerRelationships = z.infer<typeof partnerRelationshipsSchema>;
 
 export const dataPageSchema = z.object({
   batches: z.array(batchSchema),
+  batches_complete: z.boolean(),
   user: userSchema,
   watching: z.array(partnerInfoSchema),
   watchers: z.array(partnerInfoSchema),

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -76,6 +76,12 @@ export const handlers = [
 
   // ── Data ───────────────────────────────────────────────────────────────
   http.get(`${BASE}/data`, () =>
-    HttpResponse.json({ batches: [], user: TEST_USER, watching: [], watchers: [] }),
+    HttpResponse.json({
+      batches: [],
+      batches_complete: true,
+      user: TEST_USER,
+      watching: [],
+      watchers: [],
+    }),
   ),
 ];

--- a/web/src/utils/cache/worker.ts
+++ b/web/src/utils/cache/worker.ts
@@ -387,6 +387,11 @@ const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const DECRYPT_CONCURRENCY = 24;
 // Frequent counts-only progress ticks for a smooth status-line counter.
 const PROGRESS_THROTTLE_MS = 250;
+// Safety cap on how many /data pages a single fetchAndDecrypt call will drain before
+// yielding — guards against a pathological server response that never sets
+// batches_complete. At the server's page size this is a generous backlog; anything left
+// over is picked up by the next fetch trigger.
+const MAX_DATA_PAGES_PER_FETCH = 50;
 // Coarser interval for shipping the actual newly-decrypted logs as a delta, so logs fill in
 // progressively during a long sync without re-sending (and re-querying) the whole growing
 // result set each time. Only events materialized since the previous flush cross postMessage.
@@ -514,23 +519,56 @@ async function fetchAndDecrypt(targetUserId: string): Promise<void> {
   };
 
   try {
-    const since = sqlGetSince(viewerId, targetUserId);
-    console.log('[cache-worker] fetching /data since=', since, 'for', targetUserId);
-    const [page, deviceOwners] = await Promise.all([fetchData({ since }), fetchDeviceOwners()]);
-    // /data no longer filters by owner server-side — scope this target's slice
-    // of the bundled response down to batches from devices it actually owns.
-    const scopedBatches = page.batches.filter(
-      (batch) => deviceOwners.get(batch.device_id) === targetUserId,
-    );
-    console.log(
-      '[cache-worker] /data returned',
-      page.batches.length,
-      'batches,',
-      scopedBatches.length,
-      'in scope for',
-      targetUserId,
-    );
-    sqlMergeDataPage(viewerId, targetUserId, { ...page, batches: scopedBatches });
+    const deviceOwnersPromise = fetchDeviceOwners();
+    let since = sqlGetSince(viewerId, targetUserId);
+    let complete = false;
+    let pageCount = 0;
+    while (!complete) {
+      pageCount++;
+      console.log(
+        '[cache-worker] fetching /data since=',
+        since,
+        'for',
+        targetUserId,
+        'page',
+        pageCount,
+      );
+      const [page, deviceOwners] = await Promise.all([fetchData({ since }), deviceOwnersPromise]);
+      // /data no longer filters by owner server-side — scope this target's slice
+      // of the bundled response down to batches from devices it actually owns.
+      const scopedBatches = page.batches.filter(
+        (batch) => deviceOwners.get(batch.device_id) === targetUserId,
+      );
+      console.log(
+        '[cache-worker] /data returned',
+        page.batches.length,
+        'batches,',
+        scopedBatches.length,
+        'in scope for',
+        targetUserId,
+        'complete=',
+        page.batches_complete,
+      );
+      sqlMergeDataPage(viewerId, targetUserId, { ...page, batches: scopedBatches });
+      complete = page.batches_complete;
+      // Advance by every batch in the bundled page, not just this target's slice: /data
+      // bundles all owners the viewer can decrypt into one paged response, so the limit
+      // that trips batches_complete=false may be driven by another target's backlog.
+      // Using only scopedBatches here could leave `since` stuck and loop forever.
+      for (const batch of page.batches) {
+        if (batch.created_at > since) since = batch.created_at;
+      }
+      if (!complete && pageCount >= MAX_DATA_PAGES_PER_FETCH) {
+        console.warn(
+          '[cache-worker] /data pagination exceeded',
+          MAX_DATA_PAGES_PER_FETCH,
+          'pages for',
+          targetUserId,
+          '- stopping early, remainder will be picked up on the next fetch',
+        );
+        break;
+      }
+    }
   } catch (err) {
     console.warn('[cache-worker] fetch failed for', targetUserId, err);
     serveAll();


### PR DESCRIPTION
## Summary

- `GET /data` now caps batches per response at 500 (oldest-first) and returns `batches_complete` so callers know whether more remain beyond the `since` cursor, per the updated `api/SPEC.md`.
- The web cache worker's `fetchAndDecrypt` now loops on `/data` until `batches_complete` is `true` instead of only ever consuming the first page, so a viewer with a large backlog (first-time sync, long-offline device) actually catches up in one pass instead of trickling in 500 batches per reload.

## Changes

Type of change: Feature (spec-driven)
Components: API, Web

- `api/SPEC.md`: documents `?since=0` (all batches), `batches_complete` response field, and the server's pagination allowance.
- `api/src/lib/db.ts`: `listBatches` accepts an optional `limit`.
- `api/src/routes/data.ts`: fetches `limit+1` rows to detect completeness, slices to the 500-row page, adds `batches_complete` to the response.
- `shared-web/types.ts`: `dataPageSchema` gains `batches_complete: z.boolean()`.
- `web/src/mocks/handlers.ts`: MSW `/data` mock updated to match.
- `web/src/utils/cache/worker.ts`: `fetchAndDecrypt` loops on `/data` while `batches_complete` is `false`, cursoring off the full bundled page (not just the batches scoped to the current target, since `/data` bundles every owner a viewer can decrypt into one paged response — cursoring off only the scoped slice could leave `since` stuck). Capped at 50 pages per fetch as a defensive backstop.

## Testing

- [x] `api`: `npm run typecheck` and `npx vitest run` (67 tests) pass, including new tests for pagination (`DATA_BATCH_PAGE_LIMIT`-sized backlog, over-limit backlog split across two pages oldest-first, and `?since=0` vs. omitted `since` returning identical results at the exact page-limit boundary).
- [x] `web`: `npm run typecheck` and `npx vitest run` (102 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N36ZA4f7QteSWwVbzDyNtd