### PR TITLE
macos: sign and notarize release DMGs in CI, drop personal Developer ID references

### DIFF
--- a/.github/workflows/client-macos.yml
+++ b/.github/workflows/client-macos.yml
@@ -72,15 +72,20 @@ jobs:
       # `if:` guards below are false and CODESIGN_IDENTITY/DEVELOPMENT_TEAM
       # stay at their ad-hoc defaults.
       - name: Import signing certificate into CI keychain
-        if: >
-          github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') &&
-          secrets.MACOS_DIST_CERTIFICATE_P12_BASE64 != ''
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
         env:
           MACOS_DIST_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_DIST_CERTIFICATE_P12_BASE64 }}
           MACOS_DIST_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DIST_CERTIFICATE_PASSWORD }}
           IOS_CI_KEYCHAIN_PASSWORD: ${{ secrets.IOS_CI_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
+          # The `secrets` context can't be referenced in a step `if:`, so the
+          # "is the cert secret set yet" check has to live here instead.
+          if [[ -z "$MACOS_DIST_CERTIFICATE_P12_BASE64" ]]; then
+            echo "MACOS_DIST_CERTIFICATE_P12_BASE64 not set; skipping cert import (ad-hoc signing fallback)."
+            exit 0
+          fi
+
           KEYCHAIN_PATH="$RUNNER_TEMP/virtue-macos-ci.keychain-db"
           CERT_PATH="$RUNNER_TEMP/virtue-macos-dist.p12"
 
@@ -92,7 +97,11 @@ jobs:
           security import "$CERT_PATH" -P "$MACOS_DIST_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$IOS_CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
 
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/"//g')
+          EXISTING_KEYCHAINS="$(security list-keychains -d user | sed 's/"//g')"
+          # Intentionally unquoted: security expects each existing keychain
+          # path as a separate argument, not one combined string.
+          # shellcheck disable=SC2086
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING_KEYCHAINS
           security default-keychain -s "$KEYCHAIN_PATH"
 
           rm -f "$CERT_PATH"

--- a/.github/workflows/client-macos.yml
+++ b/.github/workflows/client-macos.yml
@@ -65,14 +65,67 @@ jobs:
       - name: Add Intel cross-compilation target
         run: rustup target add x86_64-apple-darwin
 
+      # Release builds (push to main/staging) sign with the real Developer ID
+      # Application identity and notarize, so downloaded DMGs open with no
+      # Gatekeeper block. PR builds and forks (no access to the cert secret)
+      # fall back to ad-hoc signing/no notarization automatically, since the
+      # `if:` guards below are false and CODESIGN_IDENTITY/DEVELOPMENT_TEAM
+      # stay at their ad-hoc defaults.
+      - name: Import signing certificate into CI keychain
+        if: >
+          github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') &&
+          secrets.MACOS_DIST_CERTIFICATE_P12_BASE64 != ''
+        env:
+          MACOS_DIST_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_DIST_CERTIFICATE_P12_BASE64 }}
+          MACOS_DIST_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DIST_CERTIFICATE_PASSWORD }}
+          IOS_CI_KEYCHAIN_PASSWORD: ${{ secrets.IOS_CI_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/virtue-macos-ci.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/virtue-macos-dist.p12"
+
+          echo "$MACOS_DIST_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$IOS_CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$IOS_CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$MACOS_DIST_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$IOS_CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/"//g')
+          security default-keychain -s "$KEYCHAIN_PATH"
+
+          rm -f "$CERT_PATH"
+          echo "MACOS_SIGNING_READY=1" >> "$GITHUB_ENV"
+
+      - name: Prepare notarization API key
+        if: env.MACOS_SIGNING_READY == '1'
+        env:
+          IOS_ASC_API_KEY_P8_BASE64: ${{ secrets.IOS_ASC_API_KEY_P8_BASE64 }}
+          IOS_ASC_KEY_ID: ${{ secrets.IOS_ASC_KEY_ID }}
+        run: |
+          set -euo pipefail
+          ASC_API_KEY_PATH="$RUNNER_TEMP/AuthKey_${IOS_ASC_KEY_ID}.p8"
+          echo "$IOS_ASC_API_KEY_P8_BASE64" | base64 --decode > "$ASC_API_KEY_PATH"
+          echo "ASC_API_KEY_PATH=$ASC_API_KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Build macOS universal app bundle and DMG
         run: ./mac/scripts/build-dmg.sh
         working-directory: client
         env:
-          # CI has no access to a real Developer ID identity; build-app.sh
-          # otherwise now defaults to one for local dev (see its comments).
-          CODESIGN_IDENTITY: '-'
-          DEVELOPMENT_TEAM: ''
+          # Falls back to ad-hoc signing (CI has no access to a real Developer
+          # ID identity) unless the import step above ran and set these.
+          CODESIGN_IDENTITY: ${{ env.MACOS_SIGNING_READY == '1' && 'Developer ID Application' || '-' }}
+          DEVELOPMENT_TEAM: ${{ env.MACOS_SIGNING_READY == '1' && secrets.IOS_TEAM_ID || '' }}
+          ASC_KEY_ID: ${{ env.MACOS_SIGNING_READY == '1' && secrets.IOS_ASC_KEY_ID || '' }}
+          ASC_ISSUER_ID: ${{ env.MACOS_SIGNING_READY == '1' && secrets.IOS_ASC_ISSUER_ID || '' }}
+          # ASC_API_KEY_PATH comes from the "Prepare notarization API key" step via GITHUB_ENV
+
+      - name: Clean up CI keychain
+        if: always() && env.MACOS_SIGNING_READY == '1'
+        run: |
+          security delete-keychain "$RUNNER_TEMP/virtue-macos-ci.keychain-db" || true
+          rm -f "${ASC_API_KEY_PATH:-}"
 
       - name: Resolve version info
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')

--- a/client/ios/scripts/run-on-device.sh
+++ b/client/ios/scripts/run-on-device.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DERIVED_DATA_PATH="$IOS_DIR/.derived-data-device"
-TEAM_ID="${TEAM_ID:-6277E5UTS9}"
+TEAM_ID="${TEAM_ID:-Y2Z8ZS4D33}"
 BUNDLE_ID="${BUNDLE_ID:-org.virtueinitiative.virtueios}"
 DEVICE_UDID="${DEVICE_UDID:-}"
 

--- a/client/mac/scripts/build-app.sh
+++ b/client/mac/scripts/build-app.sh
@@ -53,8 +53,11 @@ APP_ROOT="target/macos/${APP_NAME}"
 # Invalid" once a real Team ID has ever been registered for this bundle ID,
 # since the ad-hoc signature has no Team ID to satisfy that check). CI has no
 # access to this identity, so it must override both vars to "-"/"" explicitly.
-CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application: Jeffrey Baumes (6277E5UTS9)}"
-DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-6277E5UTS9}"
+# "Developer ID Application" (with no name/team suffix) matches whichever such
+# identity is present in the local signer's keychain, so this doesn't need to
+# hardcode any one developer's name.
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-Developer ID Application}"
+DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-Y2Z8ZS4D33}"
 
 case "$ARCH" in
   universal)

--- a/client/mac/scripts/build-dmg.sh
+++ b/client/mac/scripts/build-dmg.sh
@@ -74,13 +74,27 @@ hdiutil convert "$TEMP_DMG_PATH" -format UDZO -ov -o "$DMG_PATH"
 rm -rf "$STAGING_DIR" "$TEMP_DMG_PATH"
 echo "Built ${DMG_PATH}"
 
-# Notarize + staple. Skipped for local/dev builds (adhoc-signed apps can't be
-# notarized): only runs when a notarytool keychain profile is configured.
+# Notarize + staple. Skipped for ad-hoc-signed builds (Apple rejects those
+# outright). Two credential sources are supported:
+#   - NOTARY_PROFILE: a `notarytool store-credentials` keychain profile,
+#     for local/dev use where the profile is registered once ahead of time.
+#   - ASC_KEY_ID/ASC_ISSUER_ID/ASC_API_KEY_PATH: an App Store Connect API key
+#     passed directly, for CI where there's no persistent keychain to store
+#     a profile in.
 if [[ -n "${NOTARY_PROFILE:-}" ]]; then
   echo "Submitting ${DMG_PATH} for notarization (profile: ${NOTARY_PROFILE})..."
   xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
   xcrun stapler staple "$DMG_PATH"
   echo "Notarized and stapled ${DMG_PATH}"
+elif [[ -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" && -n "${ASC_API_KEY_PATH:-}" ]]; then
+  echo "Submitting ${DMG_PATH} for notarization (API key: ${ASC_KEY_ID})..."
+  xcrun notarytool submit "$DMG_PATH" \
+    --key "$ASC_API_KEY_PATH" \
+    --key-id "$ASC_KEY_ID" \
+    --issuer "$ASC_ISSUER_ID" \
+    --wait
+  xcrun stapler staple "$DMG_PATH"
+  echo "Notarized and stapled ${DMG_PATH}"
 else
-  echo "NOTARY_PROFILE not set; skipping notarization."
+  echo "No notarization credentials set (NOTARY_PROFILE or ASC_KEY_ID/ASC_ISSUER_ID/ASC_API_KEY_PATH); skipping notarization."
 fi


### PR DESCRIPTION
## Summary

Downloaded macOS beta builds are currently ad-hoc signed with no notarization, so Gatekeeper hard-blocks them ("Apple cannot check it for malicious software") for testers. This wires the Virtue Initiative Developer ID Application certificate and notarization into CI, mirroring the iOS TestFlight pipeline's CI-keychain pattern, and removes the hardcoded personal Developer ID identity/team that build-app.sh and run-on-device.sh defaulted to.

## Changes

Type of change: Feature (CI/infra)
Components: Mac, iOS (default team ID only)

- `.github/workflows/client-macos.yml`: on push to `main`/`staging`, imports the org Developer ID Application cert into an ephemeral CI keychain (reusing `IOS_CI_KEYCHAIN_PASSWORD`), notarizes the built DMG via `notarytool` using the reused `IOS_ASC_*` App Store Connect API key and `IOS_TEAM_ID`, then tears the keychain down. Falls back to today's ad-hoc signing/no notarization automatically on PR builds or if the new cert secrets aren't set.
- `client/mac/scripts/build-dmg.sh`: notarization now also accepts an API key passed directly (`ASC_KEY_ID`/`ASC_ISSUER_ID`/`ASC_API_KEY_PATH`), alongside the existing local `NOTARY_PROFILE` keychain-profile flow.
- `client/mac/scripts/build-app.sh`, `client/ios/scripts/run-on-device.sh`: replaced the hardcoded `Jeffrey Baumes (6277E5UTS9)` personal Developer ID identity/team defaults with the org team (`Y2Z8ZS4D33`) / a generic identity match.

New repo secrets added: `MACOS_DIST_CERTIFICATE_P12_BASE64`, `MACOS_DIST_CERTIFICATE_PASSWORD`.

## Testing

- `bash -n` on both modified shell scripts.
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Not yet validated against a real push to `staging`/`main` — the signing/notarization path only runs on `push`, not `pull_request`, so this PR's own checks will exercise the ad-hoc fallback only. Expect to iterate on the first real push, similar to how the iOS TestFlight pipeline (#564–#568) needed a few follow-up fixes once each step got far enough to hit the next real error.