### PR TITLE
Fix the macOS DMG detach race and the worktree-blind pre-commit hook

### DIFF
--- a/client/mac/scripts/build-dmg.sh
+++ b/client/mac/scripts/build-dmg.sh
@@ -39,9 +39,24 @@ DEVICE="$(printf '%s\n' "$ATTACH_OUTPUT" | awk '/\/Volumes\// {print $1; exit}')
 MOUNT_PATH="$(printf '%s\n' "$ATTACH_OUTPUT" | awk '/\/Volumes\// {print substr($0, index($0, "/Volumes/")); exit}')"
 DISK_NAME="$(basename "$MOUNT_PATH")"
 
+# Finder closes the volume window asynchronously, so it can still hold the
+# mount for a few seconds after osascript returns and `hdiutil detach` fails
+# with "Resource busy". Retry before falling back to a forced detach.
+detach_device() {
+  local attempt
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    if hdiutil detach "$DEVICE" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "hdiutil detach ${DEVICE} still busy after 10 attempts; forcing." >&2
+  hdiutil detach "$DEVICE" -force
+}
+
 cleanup() {
   if mount | grep -q "on ${MOUNT_PATH} "; then
-    hdiutil detach "$DEVICE" >/dev/null 2>&1 || true
+    detach_device >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT
@@ -66,7 +81,8 @@ tell application "Finder"
 end tell
 EOF
 
-hdiutil detach "$DEVICE"
+sync
+detach_device
 trap - EXIT
 
 hdiutil convert "$TEMP_DMG_PATH" -format UDZO -ov -o "$DMG_PATH"

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-pushd "$(dirname $0)/../.." > /dev/null
+# `core.hooksPath` is shared by every worktree of the repo and is typically an
+# absolute path into one checkout, so this script's own location says nothing
+# about which tree is being committed. Git runs hooks from the root of the
+# working tree the commit belongs to; resolve it from git, not from $0.
+ROOT="$(git rev-parse --show-toplevel)" || exit 1
+cd "$ROOT" || exit 1
 
 # Store the current state of the git index
 commit=$(git status --porcelain)
@@ -9,13 +14,15 @@ FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 [ -z "$FILES" ] && exit 0
 
 # Prettify all selected files
-echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
-pushd client && cargo fmt --all && popd > /dev/null
+if [ -x ./node_modules/.bin/prettier ]; then
+  echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
+else
+  echo "pre-commit: ./node_modules/.bin/prettier not found in $ROOT; skipping prettier (run 'bun install')." >&2
+fi
+(cd client && cargo fmt --all)
 
 # Check if anything to be commited was changed by the formatters
 if [[ $(git status --porcelain) != "$commit" ]]; then
   echo "Code was formatted. Please review the changes and stage them before committing."
   exit 1
 fi
-
-popd > /dev/null


### PR DESCRIPTION
## Summary

Two build/tooling bugs found while working on #581, neither related to that PR's code:

1. **`client/mac/scripts/build-dmg.sh` raced Finder on detach.** The script ran `hdiutil detach` immediately after the `osascript` block, but Finder closes the volume window asynchronously and can still hold the mount when osascript returns. `hdiutil` then fails with "Resource busy" and, under `set -euo pipefail`, kills the build. This is the recurring macOS CI failure (it passed on rerun with no code change).
2. **The pre-commit hook was inert in every linked worktree.** `core.hooksPath` is shared by all worktrees and normally holds a single absolute path, so `pushd "$(dirname $0)/../.."` always landed in *that* checkout — prettier and `cargo fmt` reformatted a different tree while `git status` / `git diff --cached` read the committing worktree's index (git exports `GIT_DIR`/`GIT_INDEX_FILE` for it). The before/after comparison never saw a difference, so nothing was ever formatted or blocked outside the one checkout hooksPath points at.

## Changes

Bug fix. Components: Mac (DMG packaging), repo tooling (git hooks).

- `build-dmg.sh`: detach retries 10× at 2s intervals, falling back to `hdiutil detach -force` only if the volume is still held; the EXIT-trap cleanup goes through the same helper; `sync` before the first attempt.
- `scripts/hooks/pre-commit`: resolve the tree with `git rev-parse --show-toplevel` (which git answers per-worktree inside a hook) instead of `$0`; drop the pushd/popd pair. Prettier is skipped with a warning when the worktree has no `node_modules`, so a worktree that hasn't had `bun install` run in it degrades to an unformatted commit instead of failing on a missing binary.

## Testing

- **Hook, worktree resolution:** in a scratch repo with a linked worktree and an absolute `core.hooksPath`, a hook printing both values confirmed the bug and the fix — `$(dirname $0)/../..` resolves to the hooksPath checkout, `git rev-parse --show-toplevel` resolves to the committing worktree (verified for commits from the worktree root and from a subdirectory).
- **Hook, real script:** ran the new hook from a path outside the tree, with git's hook environment, in a worktree with no `node_modules`: it cd'd to the correct worktree, warned and skipped prettier, ran `cargo fmt --all`, exited 0.
- **Detach retry:** exercised `detach_device` against a stub `hdiutil` — succeeds on first try (1 call), succeeds after 3 busy failures (4 calls), and falls back to `-force` after 10 busy failures. `bash -n` clean on both scripts.
- The DMG path itself is unchanged apart from the detach, so macOS CI on this branch is the end-to-end check.

Note: the hook fix only takes effect in existing worktrees once the checkout that `core.hooksPath` points at is updated to a branch containing it — hooks are read from there, not from the branch being committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1qEJ2RejkXLRR7Qy3HYPm
