### PR TITLE
Added canonical URLs to fix Google Search indexing

### DIFF
--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -7,6 +7,7 @@ import preact from '@astrojs/preact';
 import mermaid from 'astro-mermaid';
 
 export default defineConfig({
+  site: 'https://virtueinitiative.org',
   trailingSlash: 'never',
   build: {
     format: 'file',

--- a/landing/src/components/CanonicalLink.astro
+++ b/landing/src/components/CanonicalLink.astro
@@ -1,0 +1,20 @@
+---
+// Self-referencing canonical, built from the route path against the fixed
+// production origin in astro.config.mjs `site`, so staging/preview builds still
+// canonicalize to the one indexable URL per page.
+//
+// build.format: 'file' makes Astro.url.pathname reflect the on-disk output path
+// (e.g. `/download.html`, `/index.html`) rather than the served route, so strip
+// the file suffix back to the clean, trailingSlash:'never' URL (e.g. `/download`,
+// `/`) that Cloudflare actually serves.
+let pathname = Astro.url.pathname;
+if (pathname.endsWith('/index.html')) {
+  pathname = pathname.slice(0, -'index.html'.length);
+} else if (pathname.endsWith('.html')) {
+  pathname = pathname.slice(0, -'.html'.length);
+}
+
+const canonicalURL = new URL(pathname, Astro.site);
+---
+
+<link rel="canonical" href={canonicalURL} />

--- a/landing/src/layouts/HelpLayout.astro
+++ b/landing/src/layouts/HelpLayout.astro
@@ -1,4 +1,5 @@
 ---
+import CanonicalLink from '../components/CanonicalLink.astro';
 import HelpSidebarNav from '../components/HelpSidebarNav.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
@@ -22,6 +23,7 @@ const rootLinks = [{ label: 'Help', href: '/help' }, ...helpSidebar];
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <NoindexMeta />
+    <CanonicalLink />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/landing/src/layouts/SiteLayout.astro
+++ b/landing/src/layouts/SiteLayout.astro
@@ -1,4 +1,5 @@
 ---
+import CanonicalLink from '../components/CanonicalLink.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import NoindexMeta from '../components/NoindexMeta.astro';
@@ -19,6 +20,7 @@ const title = pageTitle ? `${pageTitle} - The Virtue Initiative` : 'The Virtue I
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <NoindexMeta />
+    <CanonicalLink />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
Google search console was complaining that there were multiple URLs with the same content. This was due to lacking redirects (http -> https) and not having a canonical meta tag.