### PR TITLE
Bundle Tesseract eng language data with the Linux client

### DIFF
--- a/client/linux/README.md
+++ b/client/linux/README.md
@@ -83,7 +83,9 @@ The client uses `XDG_CONFIG_HOME` and `XDG_STATE_HOME` when those variables are 
 
 The script bundles `libtesseract`/`liblept`/`libjpeg` into the package (instead of depending
 on the OS-provided packages, whose names — and in libjpeg's case, ABI — vary across distro
-versions) and uses `patchelf` to set their RPATH.
+versions) and uses `patchelf` to set their RPATH. It also bundles the `eng.traineddata`
+Tesseract language data file so OCR-based screenshot redaction works out of the box, without
+depending on the OS `tesseract-ocr-eng` package.
 
 ### Recommended: Docker build (widest compatibility)
 

--- a/client/linux/docker/Dockerfile
+++ b/client/linux/docker/Dockerfile
@@ -13,6 +13,7 @@ FROM rust:1-bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libleptonica-dev \
     libtesseract-dev \
+    tesseract-ocr-eng \
     libclang-dev \
     clang \
     patchelf \

--- a/client/linux/scripts/build-deb.sh
+++ b/client/linux/scripts/build-deb.sh
@@ -92,6 +92,21 @@ for soname in $BUNDLE_SONAMES; do
     patchelf --set-rpath '$ORIGIN' "$PKG_DIR/usr/lib/$PKG_NAME/$soname"
 done
 
+# Bundle the eng.traineddata Tesseract language data file the same way the
+# .so libs above are bundled, instead of depending on the OS tesseract-ocr-eng
+# package (whose path/naming is distro-versioned, e.g.
+# /usr/share/tesseract-ocr/5/tessdata vs 4.00/tessdata). We only need the
+# file dropped by that package in the build image, not a runtime dependency
+# on it. text-detection/src/linux.rs looks for a `tessdata` dir next to the
+# installed binary and points Tesseract at it when found.
+ENG_TRAINEDDATA="$(find /usr/share -name eng.traineddata 2>/dev/null | head -1)"
+if [[ -z "$ENG_TRAINEDDATA" ]]; then
+    echo "ERROR: eng.traineddata not found (is tesseract-ocr-eng installed in the build image?)" >&2
+    exit 1
+fi
+mkdir -p "$PKG_DIR/usr/lib/$PKG_NAME/tessdata"
+install -m 0644 "$ENG_TRAINEDDATA" "$PKG_DIR/usr/lib/$PKG_NAME/tessdata/eng.traineddata"
+
 # Auto-detect remaining shared library dependencies via dpkg-shlibdeps, since
 # the binary links libraries pulled in transitively by Cargo dependencies
 # (leptess/tesseract-sys) that aren't tracked anywhere else. Run it across the

--- a/client/text-detection/src/linux.rs
+++ b/client/text-detection/src/linux.rs
@@ -8,17 +8,38 @@ pub struct ScreenshotOCR {
     min_confidence: u8,
 }
 
+/// The bundled `.deb` vendors `eng.traineddata` at `usr/lib/<pkg>/tessdata/`,
+/// alongside the vendored `.so`s (see `client/linux/scripts/build-deb.sh`),
+/// where `<pkg>` is the same name as the installed binary (`usr/bin/<pkg>`).
+/// When no explicit data path was given, prefer that bundled directory over
+/// Tesseract's compiled-in system default so a clean install doesn't depend
+/// on an OS `tesseract-ocr-eng` package. Falls back to `None` (system
+/// default) for dev/test binaries with no such bundle next to them.
+fn bundled_tessdata_dir() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let bin_name = exe.file_name()?;
+    let dir = exe
+        .parent()?
+        .parent()?
+        .join("lib")
+        .join(bin_name)
+        .join("tessdata");
+    dir.is_dir().then_some(dir)
+}
+
+fn resolve_data_path(explicit: Option<PathBuf>) -> Option<PathBuf> {
+    explicit.or_else(bundled_tessdata_dir)
+}
+
 impl ScreenshotOCR {
     pub fn new(options: OcrOptions) -> Result<Self, OcrError> {
         let lang = options.language.as_deref().unwrap_or("eng");
-        let data_path_str = options
-            .tesseract_data_path
-            .as_deref()
-            .and_then(|p| p.to_str());
+        let data_path = resolve_data_path(options.tesseract_data_path);
+        let data_path_str = data_path.as_deref().and_then(|p| p.to_str());
         leptess::LepTess::new(data_path_str, lang).map_err(|e| OcrError::Init(e.to_string()))?;
         Ok(Self {
             lang: lang.to_string(),
-            data_path: options.tesseract_data_path,
+            data_path,
             min_confidence: options.min_word_confidence,
         })
     }


### PR DESCRIPTION
## Summary

- Fixes #586
- Bundles the english langage tessaract OCR data with the deb file instead of relying on the system install
- AI tested it and it worked 

## AI

Fixes #586. OCR-based screenshot redaction on Linux was silently disabled on a clean install: `eng.traineddata` ships in a separate OS package (`tesseract-ocr-eng`) that the `.deb` never installs or depends on. Tesseract init failed, `load_ocr()` caught the error and returned `None`, and screenshots were uploaded **unredacted** with only a daemon-side `tracing::warn!` that no end user ever sees.

The `.deb` already vendors `libtesseract.so.5` and its transitive shared-lib deps directly to avoid depending on distro-specific OS Tesseract packages (see the long comment in `build-deb.sh`). This applies the same philosophy to the language data file.

## Changes

<!-- Type of change: Bug fix -->
<!-- Components: Linux -->

- `client/linux/docker/Dockerfile`: install `tesseract-ocr-eng` in the build image so `eng.traineddata` is available to copy at build time (not installed at runtime).
- `client/linux/scripts/build-deb.sh`: locate `eng.traineddata` dynamically (`find /usr/share -name eng.traineddata`, since the path is distro/version-specific) and bundle it into `usr/lib/$PKG_NAME/tessdata/eng.traineddata`, mirroring how the vendored `.so`s are placed. Fails the build loudly if the file isn't found.
- `client/text-detection/src/linux.rs`: when no explicit `tesseract_data_path` is given, look for a `tessdata` dir next to the installed binary (`usr/lib/<bin_name>/tessdata`) and use it if present; otherwise fall back to Tesseract's system default, preserving current dev/test behavior.
- `client/linux/README.md`: one-line mention of the bundled tessdata alongside the existing bundled-library note.

No change to `screenshot.rs::load_ocr()` — its warning stays as defense-in-depth for any other cause of missing tessdata (e.g. a corrupted install).

## Testing

- `cargo check`/`cargo test` pass for `virtue-text-detection` and `virtue-core` (dev/test binaries have no bundled `tessdata` dir next to them, so this exercises the fallback-to-system-default path; 8 passed, 1 ignored).
- Built the `.deb` natively (`client/linux/scripts/build-deb.sh`) and confirmed via `dpkg-deb -c` that it contains `usr/lib/virtue/tessdata/eng.traineddata`.
- Uninstalled `tesseract-ocr-eng`/`tesseract-ocr` from the dev machine entirely (confirmed no `eng.traineddata` left anywhere on the system), installed the built `.deb`, and ran OCR against a real generated test image using a small harness that mimics the installed `usr/bin/<name>` + `usr/lib/<name>/tessdata` layout — OCR correctly recognized the text using only the bundled data file, no OS Tesseract language package present.
- Confirmed the fallback path fails cleanly (`OcrError::Init`, caught upstream) rather than panicking when no bundled or system tessdata is available at all.
- Reinstalled `tesseract-ocr-eng`/`tesseract-ocr` to restore the dev machine afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154hEsrKyTWUzja3px3bwEx