### PR TITLE
Fix #573: surface email on finish-signup for password managers

### DIFF
--- a/.github/workflows/deploy-hash-server.yml
+++ b/.github/workflows/deploy-hash-server.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy
-    # SPEC.md section 3.1: the VM is an Oracle Cloud A1 (arm64) instance, so the
+    # HASH-011: the VM is an Oracle Cloud A1 (arm64) instance, so the
     # build must match its architecture — a native arm64 runner avoids setting up
     # aarch64-unknown-linux-gnu cross-compilation.
     runs-on: ubuntu-24.04-arm
@@ -37,7 +37,7 @@ jobs:
       - name: Build release binary
         run: cargo build --release
 
-      # SPEC.md section 5.2: staging binary is staging-virtue-hash, production is
+      # HASH-020: staging binary is staging-virtue-hash, production is
       # virtue-hash; each has its own directory/systemd unit/database on the VM.
       - name: Resolve deploy target
         id: target
@@ -67,7 +67,7 @@ jobs:
             "deploy/$TARGET.service" \
             "ubuntu@$HOST:/tmp/$TARGET.service"
 
-      # SPEC.md section 5.2: "The systemd service MUST be restarted after the deploy."
+      # HASH-020: "The systemd service MUST be restarted after the deploy."
       - name: Install and restart
         env:
           TARGET: ${{ steps.target.outputs.name }}

--- a/.github/workflows/hash-server.yml
+++ b/.github/workflows/hash-server.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
         working-directory: hash-server
 
-      # SPEC.md section 4.2: "The rust unit and integration tests SHOULD be run in github CI."
+      # HASH-017: "The rust unit and integration tests SHOULD be run in github CI."
       - name: Rust tests
         run: cargo test
         working-directory: hash-server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ Some components have a SPEC.md file. These files MUST be written with RFC-like l
 
 SPEC.md is the source of truth and MUST be updated before the code is updated. They SHOULD NOT include full implementation details, but include enough to recreate something similar to the existing component.
 
+Each numbered section is tagged with a stable ID scoped to its file (e.g. `API-032`, `HASH-005`, `CORE-002`), not a positional number, so cross-references in code comments survive reordering or insertion. A new section MUST get the next unused number for its file; numbers MUST NOT be reused, even after the section they named is deleted. IDs need not stay in numeric or document order. Code comments SHOULD cite the bare ID (e.g. `HASH-005`) rather than repeating the file path:
+
+| Prefix | File                |
+| ------ | ------------------- |
+| `API`  | `api/SPEC.md`       |
+| `HASH` | `hash-server/SPEC.md` |
+| `CORE` | `client/core/SPEC.md` |
+
 ## Repo map
 
 - `api/` — Cloudflare Workers REST API (TypeScript, Hono, D1 SQLite, R2 object storage)

--- a/api/SPEC.md
+++ b/api/SPEC.md
@@ -1,10 +1,10 @@
 # Virtue Initiative API Server
 
-## 1. Overview
+## API-001 Overview
 
 This spec defines the main API server for Virtue Initiative. It handles users, devices and batches.
 
-### 1.1 Types
+### API-002 Types
 
 **Basic Types**
 
@@ -113,7 +113,7 @@ This spec defines the main API server for Virtue Initiative. It handles users, d
 }
 ```
 
-### 1.2 Authentication
+### API-003 Authentication
 
 The client MUST provide a refresh token in the Authorization header or a `refresh_token` cookie to access authenticated routes.
 
@@ -126,11 +126,11 @@ There are **TWO** types of tokens:
 1. **Web Tokens**, these are the normal tokens, granted on `POST /login` and `POST /signup`
 2. **Device Tokens**, these are device tokens, granted on `POST /d/device` and have a limited scope.
 
-### 1.3 Validation
+### API-004 Validation
 
 The server SHOULD validate every request shape against a schema and return **HTTP 400** on failure.
 
-### 1.4 Backwards compat
+### API-005 Backwards compat
 
 The client MUST accept extra fields in the response body.
 
@@ -145,12 +145,12 @@ The client MUST prefixed the API with the current major version. For versions be
 
 The API version SHOULD match the major version of the codebase (see client/version.properties).
 
-### 1.5 Status codes
+### API-006 Status codes
 
 The server SHOULD return **HTTP 204** for responses with no body, and **HTTP 200** otherwise —
 including for endpoints that create a resource.
 
-### 1.6 `GET /` - Health
+### API-007 `GET /` - Health
 
 MUST NOT require authentication. MUST return this shape:
 
@@ -165,9 +165,9 @@ MUST NOT require authentication. MUST return this shape:
 
 The version SHOULD match the version of the codebase.
 
-## 2. Users and authentication
+## API-008 Users and authentication
 
-### 2.1 `POST /signup-request`
+### API-009 `POST /signup-request`
 
 The client MUST provide this shape.
 
@@ -184,7 +184,7 @@ If a user at that email already exists, the server MUST send a notification to t
 
 In BOTH cases, the server MUST respond **HTTP 204**.
 
-### 2.2 `POST /signup`
+### API-010 `POST /signup`
 
 The client MUST provide this request shape.
 
@@ -219,7 +219,7 @@ The server MUST create an account for the user and return **HTTP 200** with this
 }
 ```
 
-### 2.3 `POST /signup/validate`
+### API-011 `POST /signup/validate`
 
 The client MUST send a signup verification token.
 
@@ -239,7 +239,7 @@ The server MUST respond **HTTP 200** with the pending signup's email.
 }
 ```
 
-### 2.4 `POST /password-reset`
+### API-012 `POST /password-reset`
 
 The client MUST send the email to request a password reset:
 
@@ -253,7 +253,7 @@ If the account exists, the server SHOULD send a password reset email, otherwise 
 
 The server SHOULD always respond with **HTTP 204**.
 
-### 2.5 `POST /password-reset/validate`
+### API-013 `POST /password-reset/validate`
 
 The client MUST send a password-reset token.
 
@@ -273,7 +273,7 @@ The server MUST respond **HTTP 200** with the account email.
 }
 ```
 
-### 2.6 `POST /password-reset/finalize`
+### API-014 `POST /password-reset/finalize`
 
 The client MUST send the follow request data.
 
@@ -293,7 +293,7 @@ The server MUST respond **HTTP 401** if the token is invalid or not found.
 
 The server MUST update the user with the new information and return **HTTP 204**.
 
-### 2.7 `GET /user/login-material`
+### API-015 `GET /user/login-material`
 
 The client MAY send an email as a query param `?email=[email]`.
 
@@ -316,7 +316,7 @@ If the client did provide an email, the server MUST additionally respond with th
 }
 ```
 
-### 2.8 `POST /login`
+### API-016 `POST /login`
 
 The client MUST send this request shape
 
@@ -338,7 +338,7 @@ If the email has been marked as unverified, the server SHOULD send a verificatio
 
 If it matches, the server MUST send **HTTP 204** and set the `refresh_token` cookie.
 
-### 2.9 `POST /email-verification/validate`
+### API-017 `POST /email-verification/validate`
 
 The client MUST provide a email token in the body.
 
@@ -361,7 +361,7 @@ The server MUST respond with **HTTP 200**:
 }
 ```
 
-### 2.10 `POST /logout`
+### API-018 `POST /logout`
 
 The client MUST authenticate with a **Web Token**.
 
@@ -369,7 +369,7 @@ The server MUST invalidate the session and clear the refresh_token.
 
 The server MUST respond with **HTTP 204**.
 
-### 2.11 `GET /user`
+### API-019 `GET /user`
 
 The client MUST authenticate with either token.
 
@@ -379,7 +379,7 @@ The server MUST return the currently authenticated user.
 User;
 ```
 
-### 2.12 `PATCH /user`
+### API-020 `PATCH /user`
 
 The client MUST authenticate with a **Web Token**.
 
@@ -409,7 +409,7 @@ The server MUST return this response shape.
 }
 ```
 
-### 2.13 `DELETE /user?confirm_email=[email]`
+### API-021 `DELETE /user?confirm_email=[email]`
 
 The client MUST be authenticated with a **Web Token**.
 
@@ -417,9 +417,9 @@ The client MUST send the user's email in the query. The server SHOULD respond wi
 
 If the email matches, the server SHOULD permanently delete the account. The server SHOULD delete all devices, batches, sessions, and tokens. The server SHOULD NOT delete the batch data in R2, instead it should be deleted by the normal 30 day cycle.
 
-## 3. Partners
+## API-022 Partners
 
-### 3.1 `POST /partner`
+### API-023 `POST /partner`
 
 The client MUST authenticate with a **Web Token** and send
 
@@ -440,7 +440,7 @@ The server SHOULD then respond **HTTP 200**
 }
 ```
 
-### 3.2 `POST /partner/validate`
+### API-024 `POST /partner/validate`
 
 To get the information about an invite (often before signing up), the client MUST send.
 
@@ -466,7 +466,7 @@ For a correct token, server MUST return **HTTP 200**.
 }
 ```
 
-### 3.3 `POST /partner/accept`
+### API-025 `POST /partner/accept`
 
 The client MUST be authenticated with a **Web Token** and send
 
@@ -484,7 +484,7 @@ The server MUST finalize the partnership and return **HTTP 200**:
 }
 ```
 
-### 3.4 `GET /partner`
+### API-026 `GET /partner`
 
 The client MUST be authenticated with a **Web Token.**
 
@@ -497,7 +497,7 @@ The server MUST collect the lists of partners for the user and return **HTTP 200
 }
 ```
 
-### 3.5 `DELETE /partner/:id`
+### API-027 `DELETE /partner/:id`
 
 The client MUST be authenticated with a **Web Token**.
 
@@ -507,9 +507,9 @@ The server MUST delete the partnership and notify the other user.
 
 The server MUST respond **HTTP 204**.
 
-## 4. Device Management
+## API-028 Device Management
 
-### 4.1 `GET /device`
+### API-029 `GET /device`
 
 The client MUST be authenticated with a **Web Token**.
 
@@ -521,7 +521,7 @@ The server SHOULD return **HTTP 200** plus a list of all the devices that a user
 Device[]
 ```
 
-### 4.2 `PATCH /device/:id`
+### API-030 `PATCH /device/:id`
 
 The client MUST be authenticated with a **Web Token** and send
 
@@ -533,7 +533,7 @@ The client MUST be authenticated with a **Web Token** and send
 
 On success, the server MUST respond with **HTTP 204**.
 
-### 4.3 `DELETE /device/:id`
+### API-031 `DELETE /device/:id`
 
 The client MUST be authenticated with a **Web Token**.
 
@@ -543,9 +543,9 @@ The server SHOULD delete the device with the stored batches and email the owner 
 
 On success, the server SHOULD return `204 No Content`.
 
-## 5. Data
+## API-032 Data
 
-### 5.1 `GET /data`
+### API-033 `GET /data`
 
 The client MUST be authenticated wit ha **Web Token**
 
@@ -566,9 +566,9 @@ The server SHOULD filter the batches to only include batches the user can decryp
 
 The server MUST only return batches where `created_at > since`.
 
-## 6. Device Only
+## API-034 Device Only
 
-### 6.1 `POST /d/device`
+### API-035 `POST /d/device`
 
 The client MUST send
 
@@ -594,7 +594,7 @@ On success, it must return **HTTP 200** with
 }
 ```
 
-### 6.2 `GET /d/device`
+### API-036 `GET /d/device`
 
 The client MUST be authenticated with a **Device Token**.
 
@@ -604,7 +604,7 @@ The server SHOULD create a fresh JWT hash server token (see the hash server spec
 DeviceSettings;
 ```
 
-### 6.3 `POST /d/logout`
+### API-037 `POST /d/logout`
 
 The client MUST be authenticated with a **Device Token**.
 
@@ -612,7 +612,7 @@ The server MUST revoke the device token and soft-delete the device. It also rese
 
 On success, the server MUST respond with **HTTP 204**
 
-### 6.4 `POST /d/batch`
+### API-038 `POST /d/batch`
 
 The client MUST send a multipart form request:
 
@@ -660,13 +660,13 @@ The server MUST return **HTTP 200** with the device's refreshed settings alongsi
 }
 ```
 
-## 7. Other
+## API-039 Other
 
-### 7.1 `GET /r2/*`
+### API-040 `GET /r2/*`
 
 This forwards to R2. Only used in dev. It SHOULD be disabled in production.
 
-### 7.2 `POST /email/sns`
+### API-041 `POST /email/sns`
 
 The server MUST handle any AWS SNS webhook.
 

--- a/api/SPEC.md
+++ b/api/SPEC.md
@@ -219,7 +219,27 @@ The server MUST create an account for the user and return **HTTP 200** with this
 }
 ```
 
-### 2.3 `POST /password-reset`
+### 2.3 `POST /signup/validate`
+
+The client MUST send a signup verification token.
+
+```js
+{
+  "token": "opaque-string",
+}
+```
+
+The server MUST respond **HTTP 400** if the token is invalid, expired, or an account already exists for its email.
+
+The server MUST respond **HTTP 200** with the pending signup's email.
+
+```js
+{
+  "email": "user@example.com"
+}
+```
+
+### 2.4 `POST /password-reset`
 
 The client MUST send the email to request a password reset:
 
@@ -233,7 +253,7 @@ If the account exists, the server SHOULD send a password reset email, otherwise 
 
 The server SHOULD always respond with **HTTP 204**.
 
-### 2.4 `POST /password-reset/validate`
+### 2.5 `POST /password-reset/validate`
 
 The client MUST send a password-reset token.
 
@@ -253,7 +273,7 @@ The server MUST respond **HTTP 200** with the account email.
 }
 ```
 
-### 2.5 `POST /password-reset/finalize`
+### 2.6 `POST /password-reset/finalize`
 
 The client MUST send the follow request data.
 
@@ -273,7 +293,7 @@ The server MUST respond **HTTP 401** if the token is invalid or not found.
 
 The server MUST update the user with the new information and return **HTTP 204**.
 
-### 2.6 `GET /user/login-material`
+### 2.7 `GET /user/login-material`
 
 The client MAY send an email as a query param `?email=[email]`.
 
@@ -296,7 +316,7 @@ If the client did provide an email, the server MUST additionally respond with th
 }
 ```
 
-### 2.7 `POST /login`
+### 2.8 `POST /login`
 
 The client MUST send this request shape
 
@@ -318,7 +338,7 @@ If the email has been marked as unverified, the server SHOULD send a verificatio
 
 If it matches, the server MUST send **HTTP 204** and set the `refresh_token` cookie.
 
-### 2.8 `POST /email-verification/validate`
+### 2.9 `POST /email-verification/validate`
 
 The client MUST provide a email token in the body.
 
@@ -341,7 +361,7 @@ The server MUST respond with **HTTP 200**:
 }
 ```
 
-### 2.9 `POST /logout`
+### 2.10 `POST /logout`
 
 The client MUST authenticate with a **Web Token**.
 
@@ -349,7 +369,7 @@ The server MUST invalidate the session and clear the refresh_token.
 
 The server MUST respond with **HTTP 204**.
 
-### 2.7 `GET /user`
+### 2.11 `GET /user`
 
 The client MUST authenticate with either token.
 
@@ -359,7 +379,7 @@ The server MUST return the currently authenticated user.
 User;
 ```
 
-### 2.10 `PATCH /user`
+### 2.12 `PATCH /user`
 
 The client MUST authenticate with a **Web Token**.
 
@@ -389,7 +409,7 @@ The server MUST return this response shape.
 }
 ```
 
-### 2.11 `DELETE /user?confirm_email=[email]`
+### 2.13 `DELETE /user?confirm_email=[email]`
 
 The client MUST be authenticated with a **Web Token**.
 

--- a/api/src/lib/hash-server.ts
+++ b/api/src/lib/hash-server.ts
@@ -11,7 +11,7 @@ export interface HashState {
 const ZERO_HASH_STATE: HashState = { hash: '0'.repeat(64), seq: 0, last_received: 0 };
 
 // The whole codebase shares one version (see api-version.ts), which is also what the
-// hash server expects its own requests prefixed with (hash-server/SPEC.md section 1.3).
+// hash server expects its own requests prefixed with (HASH-004).
 function baseUrl(env: Env): string {
   const url = env.HASH_SERVER_URL?.trim();
   if (!url) {

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -30,6 +30,7 @@ import { serializeUser } from '../lib/serializers';
 import {
   signupRequestSchema,
   signupSchema,
+  signupValidateSchema,
   loginMaterialQuerySchema,
   loginSchema,
   verifyEmailSchema,
@@ -358,6 +359,22 @@ auth.post('/signup-request', validateZ('json', signupRequestSchema), async (c) =
   });
 
   return c.body(null, 204);
+});
+
+auth.post('/signup/validate', validateZ('json', signupValidateSchema), async (c) => {
+  const { token } = c.req.valid('json');
+  const record = await getValidTokenRecord(c.env.DB, token, 'signup');
+
+  if (!record) {
+    return c.json({ error: 'Invalid or expired verification token' }, 400);
+  }
+
+  const existingUser = await findUserByEmail(c.env.DB, record.email);
+  if (existingUser) {
+    return c.json({ error: 'Invalid or expired verification token' }, 400);
+  }
+
+  return c.json({ email: record.email });
 });
 
 auth.post('/signup', validateZ('json', signupSchema), async (c) => {

--- a/api/test/auth-routes.test.ts
+++ b/api/test/auth-routes.test.ts
@@ -241,6 +241,56 @@ describe('Auth routes', () => {
     expect(consumedToken?.consumed_at).not.toBeNull();
   });
 
+  it('signup/validate resolves the email for a pending signup token', async () => {
+    const requestRes = await SELF.fetch(`${BASE}/signup-request`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'pending@example.com' }),
+    });
+    expect(requestRes.status).toBe(204);
+
+    const deliveries = await listEmailDeliveries();
+    const verificationToken = extractTokenFromDelivery(deliveries[0]!, 'signup_token');
+
+    const validateRes = await SELF.fetch(`${BASE}/signup/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: verificationToken }),
+    });
+    expect(validateRes.status).toBe(200);
+    expect(await validateRes.json()).toEqual({ email: 'pending@example.com' });
+  });
+
+  it('signup/validate rejects an invalid, expired, or already-claimed token', async () => {
+    const badRes = await SELF.fetch(`${BASE}/signup/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'not-a-real-token' }),
+    });
+    expect(badRes.status).toBe(400);
+    expect(await badRes.json()).toEqual({ error: 'Invalid or expired verification token' });
+
+    const requestRes = await SELF.fetch(`${BASE}/signup-request`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'claimed@example.com' }),
+    });
+    expect(requestRes.status).toBe(204);
+    const deliveries = await listEmailDeliveries();
+    const verificationToken = extractTokenFromDelivery(deliveries[0]!, 'signup_token');
+
+    // Someone else claims the email in the window between /signup-request and /signup/validate.
+    await signupAndGetCookie('claimed@example.com', 'someone-else');
+
+    const claimedRes = await SELF.fetch(`${BASE}/signup/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: verificationToken }),
+    });
+    expect(claimedRes.status).toBe(400);
+    expect(await claimedRes.json()).toEqual({ error: 'Invalid or expired verification token' });
+  });
+
   it('logs in with password_auth and sets a refresh cookie', async () => {
     await signupAndGetCookie('bob@example.com', 'pw');
 

--- a/api/test/routing.test.ts
+++ b/api/test/routing.test.ts
@@ -24,7 +24,7 @@ describe('API base path routing', () => {
   });
 });
 
-describe('API version prefix (SPEC.md section 1.4)', () => {
+describe('API version prefix (API-005)', () => {
   it('routes requests prefixed with the current major version the same as unprefixed requests', async () => {
     const [unprefixed, apiPrefixed, versionOnly] = await Promise.all([
       SELF.fetch(`${BASE}/user/login-material`),

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -48,7 +48,7 @@ other platform.
 ### Screenshot capture
 
 - `core/src/module/screenshot.rs` — `plan()`/`capture_and_process()`/`commit()`:
-  random exponential-cadence scheduling (SPEC.md §3 — not a fixed interval),
+  random exponential-cadence scheduling (CORE-003 — not a fixed interval),
   lock/screensaver gate, screen-change diff gate, redaction, risk classification
 - `linux/src/capture.rs`, `mac/src/capture.rs`, `windows/src/capture.rs` — platform
   `take_screenshot()` implementations
@@ -59,7 +59,7 @@ other platform.
   wakeup time each tick and alerts (`UploadKind::ScreenshotMissed`) on a single
   late wakeup > 1 min or a last-10-array sum > 5 min, excused near a system
   login/logout; `note_user_stop()` — immediate high-risk alert, unrelated to
-  the late-wakeup check. See `core/SPEC.md` §2; `core/tampering.md` is now
+  the late-wakeup check. See CORE-002; `core/tampering.md` is now
   just a pointer there (a richer suspend/reboot/gap-bucket model was retired
   in the daemon rewrite).
 

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -172,7 +172,7 @@ impl AndroidPlatformHooks {
 
     /// `SystemClock.uptimeMillis()`: milliseconds since boot, EXCLUDING time
     /// spent in deep sleep — unlike `elapsed_realtime_ms` above. Feeds only
-    /// `lifecycle::tick`'s suspend evidence (`SPEC.md` §2).
+    /// `lifecycle::tick`'s suspend evidence (CORE-002).
     fn uptime_millis_ms(&self) -> CoreResult<i64> {
         self.java_vm
             .attach_current_thread(|env| -> Result<i64, jni::errors::Error> {
@@ -423,7 +423,7 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeRunDa
         // — each resume needs its own `note_user_start` to clear a prior
         // `note_user_stop`, or tamper detection would stay suspended for
         // the rest of the process's life. A no-op when not currently
-        // stopped. See `client/core/SPEC.md` §2.
+        // stopped. See CORE-002.
         core.daemon.note_user_start();
 
         core.daemon.run_forever();

--- a/client/core/CLAUDE.md
+++ b/client/core/CLAUDE.md
@@ -36,7 +36,7 @@ get_last_logout_utc_ms() -> Result<Option<i64>>
 `PlatformHooks: ScreenshotHooks + LifecycleHooks` is a blanket impl — platforms
 never implement it directly. `get_monotonic_clock_ms` (a clock that doesn't
 advance while suspended) feeds only `lifecycle::tick`'s suspend evidence
-(`SPEC.md` §2) — it's not on `ScreenshotHooks`, and screenshot scheduling
+(CORE-002) — it's not on `ScreenshotHooks`, and screenshot scheduling
 itself still paces off the wall clock. Mac separately keeps its own boot/
 monotonic clock reads as **inherent** methods on `MacPlatformHooks` for a
 local post-wake UX check unrelated to the core model — see `architecture.md`.
@@ -87,7 +87,7 @@ trait, no event dispatch. A module that needs to enqueue work calls
 
 `lifecycle::tick` compares actual vs. scheduled wakeup time each tick and
 alerts on a single late wakeup > 1 min or a last-10-array sum > 5 min,
-excused near a system login/logout — see `SPEC.md` §2 and `tampering.md`
+excused near a system login/logout — see CORE-002 and `tampering.md`
 (now a short pointer to SPEC.md, not its own model).
 
 ## State persistence

--- a/client/core/Cargo.toml
+++ b/client/core/Cargo.toml
@@ -30,7 +30,7 @@ argon2 = "0.5"
 base64 = "0.23"
 flate2 = "1.1"
 # Cross-process advisory locking for `state.rs`'s sibling `.lock` file — see
-# SPEC.md §7. `flock`-backed on every Unix target we ship (incl. iOS/Android),
+# CORE-016. `flock`-backed on every Unix target we ship (incl. iOS/Android),
 # `LockFileEx`-backed on Windows.
 fs2 = "0.4"
 hkdf = "0.12.4"
@@ -48,7 +48,7 @@ thiserror = "2.0"
 tract-onnx = "0.21"
 tracing = "0.1"
 # Genuinely blocking HTTP. `rustls` pulls the ring-backed rustls stack;
-# `cookies` is required by api/SPEC.md §1, which asks clients to retain the
+# `cookies` is required by API-001, which asks clients to retain the
 # server's short-lived JWT access cookie. `platform-verifier` verifies
 # certificates against the OS trust store, used on every platform except
 # Android; `rustls-webpki-roots` backs Android instead (bundled Mozilla

--- a/client/core/SPEC.md
+++ b/client/core/SPEC.md
@@ -1,6 +1,6 @@
 # Virtue Core
 
-## 1. Overview
+## CORE-001 Overview
 
 The core MUST be structured around a single daemon loop. It's primary goal is to take screenshots (using the platform hooks), while detecting if a screenshot was missed for any reason.
 
@@ -23,7 +23,7 @@ loop(persisted state):
   sleep until next time
 ```
 
-## 2. Tamper detection
+## CORE-002 Tamper detection
 
 It SHOULD do tamper detection by comparing the current time to the expected wakeup time. The difference SHOULD be added to the late wakeups array unless the gap is explained by a legitimate session transition, checked from both ends:
 
@@ -42,11 +42,11 @@ The late wakeup event SHOULD be called "screenshot_missed".
 
 A user-initiated stop MUST excuse the gap that follows it — the lateness check MUST be skipped once, rather than recorded, so restarting after it isn't also reported as tampering on top of the user-stop alert. This skip MUST apply to the first tick of the monitoring session that follows the daemon actually stopping and restarting, not to any tick that runs beforehand in the same still-running session (e.g. while an already-requested stop is still being processed) — a tick that happens before the daemon has actually stopped isn't the gap being excused, and consuming the excuse there would leave the real gap unprotected. A stop MUST NOT be excused this way merely because the process exited cleanly (e.g. a caught termination signal) — only an actual user-initiated stop, since anything broader would let simply killing the process defeat tamper detection.
 
-## 3. Screenshots
+## CORE-003 Screenshots
 
 Screenshots MUST be captured randomly (i.e. every second there is the same chance as any other second) about every 5 minutes.
 
-### 3.1 Content detection
+### CORE-004 Content detection
 
 Screenshots SHOULD be processed with the content detection logic.
 
@@ -54,7 +54,7 @@ Screenshots SHOULD first be filtered based on a skin tone detector. If it rates 
 
 Screenshots SHOULD then be redacted using an OCR engine and then compressed into small WebP.
 
-## 4. Uploading
+## CORE-005 Uploading
 
 Requests SHOULD be queued to be uploaded in a batch.
 
@@ -64,7 +64,7 @@ Both hash server uploads and batch uploads MUST be stored in the state object an
 
 > Note: device settings SHOULD be refreshed on process startup and on batch upload and saved to the state object
 
-## 5. Other events
+## CORE-006 Other events
 
 When the daemon detects that the System Login time changed, it MUST send a "system login at" event (risk 0%).
 
@@ -72,59 +72,59 @@ When the daemon detects thtat hte System Logout time changed, it MUST send a "sy
 
 The first System Login/Logout time observed (i.e. there is no prior value to compare against) MUST NOT be reported — it only establishes the baseline a later change is measured against.
 
-## 6. Client API
+## CORE-007 Client API
 
 The core MUST expose the following methods to clients. Each blocks until the loop thread has applied and persisted the request, except `status`, which reads the last-committed state directly, and `request_stop`, which is fire-and-forget.
 
-### 6.1 login
+### CORE-008 login
 
 `login(email, password, device_name?) -> device_id`
 
 MUST revoke any existing device session first, then register a new device with the API. On success MUST store the returned device credentials, settings, and hash token, and MUST enable screenshot capture. On failure MUST leave the client logged out. `device_name` is optional; if absent or blank, the platform's configured default name MUST be used.
 
-### 6.2 logout
+### CORE-009 logout
 
 `logout()`
 
 MUST best-effort revoke the device session with the API, MUST clear stored device credentials, and MUST disable screenshot capture.
 
-### 6.3 status
+### CORE-010 status
 
 `status() -> { is_authenticated, is_running, device_id, last_loop_at_ms, pending_request_count }`
 
 MUST return, without blocking on the loop: whether the user is authenticated, whether the loop is running, the device id (if any), the timestamp of the last completed tick (if any), and the number of requests currently queued.
 
-### 6.4 note_user_stop
+### CORE-011 note_user_stop
 
 `note_user_stop(source)`
 
 MUST record that the user explicitly stopped monitoring while it was expected to be running (see §2's `user_stop` alert).
 
-### 6.5 queue_upload
+### CORE-012 queue_upload
 
 `queue_upload(upload)`
 
 MUST enqueue the given event directly for hashing and batch upload, bypassing the daemon's own capture/lifecycle logic.
 
-### 6.6 flush_batch_now
+### CORE-013 flush_batch_now
 
 `flush_batch_now()`
 
 MUST force the next tick to upload the current batch immediately rather than waiting for the batch interval.
 
-### 6.7 request_stop
+### CORE-014 request_stop
 
 `request_stop()`
 
 MUST stop the loop after its current tick. The loop MAY be started again afterward.
 
-### 6.8 tick_once
+### CORE-015 tick_once
 
 `tick_once()`
 
 MUST apply and persist any currently-queued requests, then MUST run exactly one tick, then MUST return — without waiting for a scheduled wakeup and without looping. For a platform with no way to keep a background thread alive between invocations (iOS's Safari-extension native message handler, which the OS only guarantees runs for the duration of one request/response round trip — see `architecture.md`), this MUST be the method called once per invocation instead of `run_forever`. MUST NOT be called concurrently with `run_forever` or with itself on the same `Daemon`.
 
-## 7. State persistence
+## CORE-016 State persistence
 
 State MUST be persisted to a single JSON file (`state_path`) via a tmp-file-plus-rename so a reader never observes a partially-written file.
 

--- a/client/core/architecture.md
+++ b/client/core/architecture.md
@@ -155,7 +155,7 @@ thread) can drive the daemon synchronously.
 
 `screenshot::plan` draws the next capture time via an **exponential
 inter-arrival** (`next = now + (-mean_ms * ln(1 - u))`, `u` from
-`RandomSource`) rather than a fixed interval — SPEC.md §3's "every second has
+`RandomSource`) rather than a fixed interval — CORE-003's "every second has
 the same chance" requirement. Two gates then run:
 
 1. **Lock / screensaver gate** — checked in `plan` _before_ capturing via
@@ -269,7 +269,7 @@ check is disabled.
 - `device_name` — stable device identifier
 - `platform_name` — e.g. `"linux"`, `"mac"`, `"windows"`
 - `state_dir` — directory for all state files
-- `screenshot_interval` — mean of the random exponential draw (SPEC.md §3), default 60s in tests
+- `screenshot_interval` — mean of the random exponential draw (CORE-003), default 60s in tests
 - `batch_interval` — default 60 s
 
 There is no runtime override mechanism: `api_base_url`, `capture_interval_seconds`,
@@ -326,8 +326,7 @@ status — running normally. iOS is the only platform that overrides it to
 `false`, for the reason described above.
 
 `get_monotonic_clock_ms` (a clock that doesn't advance while the system is
-suspended) feeds only `lifecycle::tick`'s suspend evidence (`../SPEC.md`
-§2) — a third excuse, alongside login/logout evidence, that can only ever
+suspended) feeds only `lifecycle::tick`'s suspend evidence (CORE-002) — a third excuse, alongside login/logout evidence, that can only ever
 *add* an excuse (its default falls back to `get_utc_clock_ms`, under which
 it never triggers). Screenshot scheduling itself is unaffected and still
 paces off the wall clock; this hook isn't on `ScreenshotHooks`. Mac
@@ -423,8 +422,8 @@ persisted — no longer `Instant`-based) is refreshed from whichever of those
 responses arrived most recently and only triggers a `GET /d/device` call
 (inside `execute_hash_retries`, unlocked) when that cache goes stale (55
 minutes) without a batch having refreshed it in the meantime. `Daemon::new`
-also performs one such refresh at startup if already authenticated (SPEC.md
-§4's "refreshed on process startup" requirement).
+also performs one such refresh at startup if already authenticated (CORE-005's
+"refreshed on process startup" requirement).
 
 ## Testing
 

--- a/client/core/src/api.rs
+++ b/client/core/src/api.rs
@@ -15,7 +15,7 @@ use crate::model::{BatchUpload, DeviceCredentials, DeviceSettings, HashParams, N
 
 /// The whole codebase shares one version, tracked in `version.properties` (this crate's
 /// grandparent directory). This is that version's `/vX`/`/vX.Y` URL-prefix form
-/// (api/SPEC.md section 1.4, hash-server/SPEC.md section 1.3) — the same value is used
+/// (API-005, HASH-004) — the same value is used
 /// for both the main API and the standalone hash server. Kept in sync by
 /// `scripts/update-version.sh`, which is the only thing that should ever edit this line.
 const API_VERSION: &str = "v0.1";
@@ -96,7 +96,7 @@ pub trait ApiTransport: Send + Sync {
         device_refresh_token: &str,
         batch: &BatchUpload,
     ) -> CoreResult<UploadedBatchResponse>;
-    /// `unix_time` and `seq` are the wire-format prefix hash-server/SPEC.md §2.1
+    /// `unix_time` and `seq` are the wire-format prefix HASH-006
     /// requires ahead of the 32-byte content hash: `seq` MUST be strictly greater
     /// than the last `seq` accepted for this device (rejected with 409 otherwise).
     fn upload_hash(
@@ -295,7 +295,7 @@ impl ApiTransport for HttpApiClient {
         seq: u32,
         content_hash: &[u8; 32],
     ) -> CoreResult<()> {
-        // hash-server/SPEC.md §2.1: [unix_time:u32 LE][seq:u32 LE][sha hash:32 bytes].
+        // HASH-006: [unix_time:u32 LE][seq:u32 LE][sha hash:32 bytes].
         let mut body = Vec::with_capacity(40);
         body.extend_from_slice(&unix_time.to_le_bytes());
         body.extend_from_slice(&seq.to_le_bytes());

--- a/client/core/src/daemon.rs
+++ b/client/core/src/daemon.rs
@@ -140,7 +140,7 @@ impl<P: PlatformHooks, A: ApiTransport + Send + Sync + 'static> Daemon<P, A> {
         // rather than comparing this tick's wakeup against a schedule from
         // before the (now-excused) stop. A no-op when the previous session
         // wasn't stopped (including a plain kill, which must NOT be excused
-        // — see `SPEC.md` §2 and `lifecycle::note_user_start`).
+        // — see CORE-002 and `lifecycle::note_user_start`).
         {
             let now_ms = daemon.now_ms();
             daemon.with_locked_state(|working| {
@@ -209,14 +209,14 @@ impl<P: PlatformHooks, A: ApiTransport + Send + Sync + 'static> Daemon<P, A> {
     }
 
     /// Runs one cross-process-safe read-modify-write cycle: acquires the
-    /// SPEC.md §7 lock, re-reads `state_path` from disk (rather than trusting
+    /// CORE-016 lock, re-reads `state_path` from disk (rather than trusting
     /// the in-memory cache, which may be stale relative to another process's
     /// writes), lets `f` mutate the freshly-read copy, persists it, and
     /// updates the in-memory cache — all before releasing the lock.
     ///
     /// Every mutate-then-persist path MUST go through this (not call
     /// `persist` directly) so two `Daemon`s against the same `state_path`
-    /// (iOS only — see SPEC.md §7) can't race a lost update.
+    /// (iOS only — see CORE-016) can't race a lost update.
     fn with_locked_state<R>(&self, f: impl FnOnce(&mut DaemonState) -> R) -> R {
         let _lock = match lock_state(&self.state_path) {
             Ok(lock) => Some(lock),
@@ -602,7 +602,7 @@ impl<P: PlatformHooks, A: ApiTransport + Send + Sync + 'static> Daemon<P, A> {
     /// against a freshly-reloaded copy of the state and write the result
     /// back. Both the request-application step and the tick go through
     /// `with_locked_state`, so each is its own cross-process-safe
-    /// read-modify-write cycle (SPEC.md §7) — there's still no *in-process*
+    /// read-modify-write cycle (CORE-016) — there's still no *in-process*
     /// locking in the middle of either one.
     ///
     /// Callable more than once across a `Daemon`'s lifetime — just not
@@ -656,7 +656,7 @@ impl<P: PlatformHooks, A: ApiTransport + Send + Sync + 'static> Daemon<P, A> {
 
     /// Applies and persists whatever requests are currently queued and,
     /// unless a `Stop` was among them, runs exactly one tick — then returns
-    /// without blocking or looping. See SPEC.md §6.8: for a platform with no
+    /// without blocking or looping. See CORE-015: for a platform with no
     /// way to keep a background thread alive between invocations (iOS's
     /// Safari-extension native message handler — the OS only guarantees it
     /// runs for the duration of one `beginRequest`/`completeRequest` round

--- a/client/core/src/model.rs
+++ b/client/core/src/model.rs
@@ -78,15 +78,15 @@ pub enum UploadKind {
     Heartbeat,
     /// A single wakeup was more than a minute late, or the sum of recent
     /// lateness (over the last 10 tracked wakeups) exceeded 5 minutes.
-    /// Excused near a system login/logout. See `client/core/SPEC.md` §2.
+    /// Excused near a system login/logout. See CORE-002.
     ScreenshotMissed,
     /// The daemon detected that the last known system login time changed.
-    /// Always risk 0%. See `client/core/SPEC.md` §5.
+    /// Always risk 0%. See CORE-006.
     SystemLogin {
         utc_ms: i64,
     },
     /// The daemon detected that the last known system logout time changed.
-    /// Always risk 0%. See `client/core/SPEC.md` §5.
+    /// Always risk 0%. See CORE-006.
     SystemLogout {
         utc_ms: i64,
     },
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn upload_kind_screenshot_missed_serializes_to_tagged_shape() {
-        // SPEC.md §2: "The late wakeup event SHOULD be called
+        // CORE-002: "The late wakeup event SHOULD be called
         // \"screenshot_missed\"."
         let upload = UploadKind::ScreenshotMissed;
         assert_eq!(

--- a/client/core/src/module/lifecycle.rs
+++ b/client/core/src/module/lifecycle.rs
@@ -14,13 +14,13 @@ pub(crate) const EXTRA_HIGH_RISK: f32 = 0.9;
 /// ride the normal batch.
 pub(crate) const HIGH_RISK_LIFECYCLE_ALERT: f32 = 0.8;
 
-/// See `client/core/SPEC.md` §2.
+/// See CORE-002.
 const MAX_TRACKED_WAKEUPS: usize = 10;
 const SINGLE_LATE_THRESHOLD_MS: i64 = 60_000; // 1 minute
 const SUM_LATE_THRESHOLD_MS: i64 = 5 * 60_000; // 5 minutes
 const LOGIN_LOGOUT_EXCUSE_MS: i64 = 2 * 60_000; // 2 minutes
 /// Floor below which a measured clock divergence is treated as noise (clock
-/// jitter, NTP adjustment) rather than a real suspend. See `SPEC.md` §2.
+/// jitter, NTP adjustment) rather than a real suspend. See CORE-002.
 const SUSPEND_EVIDENCE_MIN_MS: i64 = 5_000;
 /// Slack allowed between the measured suspended duration and the gap being
 /// evaluated for the suspend evidence to still count as "explains the gap" —
@@ -34,19 +34,19 @@ pub struct LifecycleState {
     /// [`MAX_TRACKED_WAKEUPS`] non-excused wakeups, oldest first.
     pub late_wakeups: VecDeque<i64>,
     /// Last system login/logout time seen, so a change can be detected and
-    /// reported once. See `SPEC.md` §5.
+    /// reported once. See CORE-006.
     pub last_seen_login_ms: Option<i64>,
     pub last_seen_logout_ms: Option<i64>,
     /// Set by `note_user_stop` (never by a plain clean shutdown — see that
     /// function's doc comment for why) and cleared by `note_user_start`.
     /// While true, `tick()` ignores lateness entirely — no gap is recorded,
     /// checked, or alerted on — so the gap the stop itself caused is never
-    /// mistaken for tampering. See `SPEC.md` §2.
+    /// mistaken for tampering. See CORE-002.
     pub monitoring_stopped: bool,
     /// Real UTC time and suspend-safe-clock (`LifecycleHooks::get_monotonic_clock_ms`)
     /// reading, both captured at the end of the previous `tick()` call — the
     /// baseline `tick()` diffs against to compute suspend evidence. `None`
-    /// before the first tick. See `SPEC.md` §2.
+    /// before the first tick. See CORE-002.
     pub last_tick_utc_ms: Option<i64>,
     pub last_tick_suspend_safe_ms: Option<i64>,
 }
@@ -56,7 +56,7 @@ pub struct LifecycleState {
 /// the previous tick) and records how late the daemon woke, unless excused by
 /// a login/logout bracket that isn't contradicted by the other side's
 /// evidence (see the excuse logic below). Alerts via [`upload::enqueue`] once
-/// the late-wakeup budget is crossed. See `client/core/SPEC.md` §2.
+/// the late-wakeup budget is crossed. See CORE-002.
 ///
 /// `expected_wakeup_at_ms == 0` means no wakeup has ever been scheduled yet
 /// (the daemon's very first tick, or the first tick after `note_user_start`
@@ -112,14 +112,14 @@ pub fn tick(
     // side to be near before the other's absence/mismatch counts for
     // anything is what keeps an ordinary suspend (neither timestamp
     // anywhere near this gap — nothing reports a reboot at all) from being
-    // misread as a contradiction. See `SPEC.md` §2.
+    // misread as a contradiction. See CORE-002.
     let login_logout_evidence = match (login_near, logout_near) {
         (Some(true), Some(false)) | (Some(false), Some(true)) => Some(false),
         (Some(true), _) | (_, Some(true)) => Some(true),
         _ => None,
     };
 
-    // Suspend evidence (SPEC.md §2): the shortfall between real-time elapsed
+    // Suspend evidence (CORE-002): the shortfall between real-time elapsed
     // and suspend-safe-clock elapsed since the previous tick reveals how long
     // the system was suspended over that span. Unlike the two signals above,
     // this one can only ever support an excuse — it's left `None` (never
@@ -162,7 +162,7 @@ pub fn tick(
             HIGH_RISK_LIFECYCLE_ALERT,
             UploadKind::ScreenshotMissed,
         );
-        // See `SPEC.md` §2: cleared so the same already-alerted-on lateness
+        // See CORE-002: cleared so the same already-alerted-on lateness
         // doesn't still be sitting in the array to alert again on the very
         // next tick.
         state.late_wakeups.clear();
@@ -173,7 +173,7 @@ pub fn tick(
 /// system login/logout time since the previous tick and records a
 /// zero-risk informational event each time one is seen. The very first
 /// observation (no prior baseline) only seeds `last_seen_*` — it does not
-/// count as a "change" and is not reported. See `client/core/SPEC.md` §5.
+/// count as a "change" and is not reported. See CORE-006.
 pub fn note_session_events(
     state: &mut LifecycleState,
     upload: &mut UploadState,
@@ -226,7 +226,7 @@ pub fn note_session_events(
 /// defeat tamper detection; excusing only here means the gap is forgiven
 /// exactly when — and only when — it was already reported via this alert.
 /// Checking resumes only once `note_user_start` is called. See
-/// `client/core/SPEC.md` §2.
+/// CORE-002.
 pub fn note_user_stop(
     state: &mut LifecycleState,
     upload: &mut UploadState,
@@ -249,7 +249,7 @@ pub fn note_user_stop(
 /// the return value to decide whether to also reset the wakeup schedule
 /// baseline: it must NOT be reset unconditionally on every restart, since
 /// that would let a plain kill signal escape detection too — see
-/// `SPEC.md` §2 and the `daemon.rs` caller.
+/// CORE-002 and the `daemon.rs` caller.
 pub fn note_user_start(state: &mut LifecycleState, upload: &mut UploadState, now_ms: i64) -> bool {
     let was_stopped = state.monitoring_stopped;
     state.monitoring_stopped = false;
@@ -271,7 +271,7 @@ mod tests {
     /// the production invariant that `now_ms` passed into `tick` always
     /// equals `hooks.get_time_utc_ms()`/`get_monotonic_clock_ms()` at that
     /// same moment (see `daemon.rs::now_ms`). Keeping the mock in sync means
-    /// the suspend-evidence baseline (`SPEC.md` §2) sees zero divergence
+    /// the suspend-evidence baseline (CORE-002) sees zero divergence
     /// across these calls unless a test explicitly diverges the two clocks
     /// (see the "suspend evidence" tests below), so every pre-existing test
     /// here is unaffected by suspend evidence.
@@ -406,7 +406,7 @@ mod tests {
         assert!(!has_late_wakeup_alert(&upload));
     }
 
-    // ── Suspend evidence (SPEC.md §2) ───────────────────────────────────────
+    // ── Suspend evidence (CORE-002) ───────────────────────────────────────
 
     #[test]
     fn suspend_that_explains_the_whole_gap_is_excused() {
@@ -488,7 +488,7 @@ mod tests {
         hooks.set_last_logout(Some(900_000));
         hooks.set_last_login(Some(950_500));
         tick_at(&mut state, &mut upload, &hooks, 951_000, 300_000);
-        // Counted (not excused) and alerted on — then cleared per SPEC.md §2.
+        // Counted (not excused) and alerted on — then cleared per CORE-002.
         assert!(state.late_wakeups.is_empty());
         assert!(has_late_wakeup_alert(&upload));
     }
@@ -507,14 +507,14 @@ mod tests {
         hooks.set_last_logout(Some(900_000));
         hooks.set_last_login(Some(950_000));
         tick_at(&mut state, &mut upload, &hooks, 2_000_000, 900_500);
-        // Counted (not excused) and alerted on — then cleared per SPEC.md §2.
+        // Counted (not excused) and alerted on — then cleared per CORE-002.
         assert!(state.late_wakeups.is_empty());
         assert!(has_late_wakeup_alert(&upload));
     }
 
     #[test]
     fn late_wakeups_array_is_cleared_after_an_alert_is_sent() {
-        // SPEC.md §2: "The late wakeups array MUST be cleared after an alert
+        // CORE-002: "The late wakeups array MUST be cleared after an alert
         // is sent (to prevent duplicates)."
         let mut state = LifecycleState::default();
         let mut upload = upload_with_credentials();
@@ -605,7 +605,7 @@ mod tests {
         assert!(state.monitoring_stopped);
     }
 
-    // ── Other events (SPEC.md §5) ───────────────────────────────────────────
+    // ── Other events (CORE-006) ───────────────────────────────────────────
 
     fn system_event(upload: &UploadState, utc_ms: i64, login: bool) -> Option<f32> {
         upload
@@ -620,7 +620,7 @@ mod tests {
 
     #[test]
     fn first_observation_only_seeds_the_baseline_and_is_not_reported() {
-        // SPEC.md §5: "The first System Login/Logout time observed [...]
+        // CORE-006: "The first System Login/Logout time observed [...]
         // MUST NOT be reported — it only establishes the baseline a later
         // change is measured against."
         let mut state = LifecycleState::default();
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn system_login_at_event_sent_when_login_time_changes_after_a_baseline_is_established() {
-        // SPEC.md §5: "When the daemon detects that the System Login time
+        // CORE-006: "When the daemon detects that the System Login time
         // changed, it MUST send a "system login at" event (risk 0%)."
         let mut state = LifecycleState::default();
         let mut upload = upload_with_credentials();
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn system_logout_at_event_sent_when_logout_time_changes_after_a_baseline_is_established() {
-        // SPEC.md §5: "When the daemon detects tha[t] th[e] System Logout
+        // CORE-006: "When the daemon detects tha[t] th[e] System Logout
         // time changed, it MUST send a "system logout at" event (risk 0%)."
         let mut state = LifecycleState::default();
         let mut upload = upload_with_credentials();
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(state.last_seen_login_ms, Some(9_000));
     }
 
-    // ── Intentional-stop excuse (SPEC.md §2) ────────────────────────────────
+    // ── Intentional-stop excuse (CORE-002) ────────────────────────────────
 
     #[test]
     fn ticks_before_the_daemon_actually_stops_do_not_consume_the_excuse() {
@@ -719,7 +719,7 @@ mod tests {
         // in-between ticks must not burn the excuse — only the real gap
         // caused by the daemon actually being down should be, and that
         // gap isn't visible until `note_user_start` runs on the next
-        // session. See `SPEC.md` §2.
+        // session. See CORE-002.
         let mut state = LifecycleState::default();
         let mut upload = upload_with_credentials();
         let hooks = TestPlatformHooks::new();

--- a/client/core/src/module/screenshot.rs
+++ b/client/core/src/module/screenshot.rs
@@ -48,7 +48,7 @@ pub struct ScreenshotState {
 
 /// Draws the next screenshot time via an exponential inter-arrival: every
 /// second has the same chance of being chosen, averaging `mean_ms` apart. See
-/// `client/core/SPEC.md` §3.
+/// CORE-003.
 fn draw_next_screenshot_at_ms(now_ms: i64, mean_ms: i64, rng: &dyn RandomSource) -> i64 {
     let u = rng.uniform();
     let delay_ms = -(mean_ms as f64) * (1.0 - u).ln();

--- a/client/core/src/module/upload.rs
+++ b/client/core/src/module/upload.rs
@@ -127,7 +127,7 @@ pub struct UploadState {
     pub settings: Option<DeviceSettings>,
     pub device_credentials: Option<DeviceCredentials>,
     /// The last `seq` accepted by the hash server for this device — hash-server/SPEC.md
-    /// §2.1 requires each `POST /hash` to carry a `seq` strictly greater than this.
+    /// HASH-006 requires each `POST /hash` to carry a `seq` strictly greater than this.
     /// Reset to 0 in lockstep with every server-side reset: login, logout, and each
     /// batch upload that lands (the API resets the server's hash state right after
     /// storing the batch).

--- a/client/core/src/platform.rs
+++ b/client/core/src/platform.rs
@@ -42,7 +42,7 @@ pub trait LifecycleHooks: Send + Sync + 'static {
     }
 
     /// A clock that does not advance while the system is suspended — used
-    /// only by `lifecycle::tick`'s suspend evidence (`SPEC.md` §2), never in
+    /// only by `lifecycle::tick`'s suspend evidence (CORE-002), never in
     /// place of `get_utc_clock_ms` itself. Default falls back to
     /// `get_utc_clock_ms`: on a platform with no distinct suspend-safe
     /// primitive, suspend evidence simply never triggers, which is safe (it
@@ -60,7 +60,7 @@ pub trait LifecycleHooks: Send + Sync + 'static {
     /// session is presumed still open.
     fn get_last_logout_utc_ms(&self) -> CoreResult<Option<i64>>;
 
-    /// Whether the late-wakeup tamper model (`client/core/SPEC.md` §2)
+    /// Whether the late-wakeup tamper model (CORE-002)
     /// applies on this platform at all — skips `lifecycle::tick` entirely
     /// when `false`. Only iOS returns `false`: its Safari extension host can
     /// be suspended the instant the device locks with no notification and no

--- a/client/core/src/state.rs
+++ b/client/core/src/state.rs
@@ -33,7 +33,7 @@ pub fn store_state<T: Serialize>(path: &Path, state: &T) -> CoreResult<()> {
 
 /// Holds an OS-level advisory exclusive lock on `path`'s sibling `.lock`
 /// file for as long as it's alive — released automatically on drop (closing
-/// the fd releases the `flock`/`LockFileEx` hold). See SPEC.md §7: this is
+/// the fd releases the `flock`/`LockFileEx` hold). See CORE-016: this is
 /// what serializes two processes (e.g. iOS's Safari-extension daemon and the
 /// app's on-demand daemon) from racing a read-modify-write of the same
 /// `state_path`. Blocks until the lock is available.

--- a/client/core/tampering.md
+++ b/client/core/tampering.md
@@ -9,7 +9,7 @@ rewrite as a deliberate simplification, not replaced feature-for-feature —
 see the rewrite plan's "Lifecycle model simplification" note. It no longer
 reflects the code.**
 
-The current, much simpler model is specified in `SPEC.md` §2 (the daemon
+The current, much simpler model is specified in CORE-002 (the daemon
 loop spec, kept minimal by design):
 
 - Each tick compares the actual wakeup time to the wakeup time it was
@@ -26,7 +26,7 @@ loop spec, kept minimal by design):
 - `UserStop` (`EXTRA_HIGH_RISK`, immediate) is driven directly by an explicit
   user action (`Daemon::note_user_stop`, reached via `UserStopRequested`
   over IPC) and was preserved unchanged through the rewrite. It also excuses
-  the very next tick's late-wakeup check (see `SPEC.md` §2) — deliberately
+  the very next tick's late-wakeup check (see CORE-002) — deliberately
   scoped to this exact call, not to a plain clean shutdown, since every
   platform's signal handler also cleanly exits on a bare kill signal.
 

--- a/client/core/tests/scenarios.rs
+++ b/client/core/tests/scenarios.rs
@@ -104,7 +104,7 @@ fn user_stop_excuse_survives_across_a_real_restart_not_just_the_next_tick() {
     // whatever tick ran next -- even one firing while the daemon is still
     // shutting down, well before the process actually exits -- leaving the
     // real stopped-time gap unprotected and reported as tampering on the
-    // next launch. See `SPEC.md` §2 and `lifecycle::note_user_start`.
+    // next launch. See CORE-002 and `lifecycle::note_user_start`.
     let mut scenario1 = Scenario::authenticated();
     scenario1.at_t(0).tick(); // establishes a schedule
     scenario1.note_user_stop("test");
@@ -156,7 +156,7 @@ fn user_stop_excuse_survives_across_a_real_restart_not_just_the_next_tick() {
     assert!(scenario2.state().lifecycle.late_wakeups.is_empty());
 }
 
-// ── Late-wakeup model (client/core/SPEC.md §2) ─────────────────────────────────
+// ── Late-wakeup model (CORE-002) ─────────────────────────────────
 
 #[test]
 fn late_wakeup_over_one_minute_triggers_alert() {
@@ -168,7 +168,7 @@ fn late_wakeup_over_one_minute_triggers_alert() {
     // Wake up 70s later than scheduled: over the 1-minute single-wakeup threshold.
     scenario.at_t(expected + 70_000).tick();
 
-    // SPEC.md §2: cleared after the alert is sent, to prevent duplicates.
+    // CORE-002: cleared after the alert is sent, to prevent duplicates.
     assert!(
         scenario.state().lifecycle.late_wakeups.is_empty(),
         "expected the late wakeups array to be cleared after alerting"

--- a/client/ios/app/SafariWebExtension/SafariWebExtensionHandler.swift
+++ b/client/ios/app/SafariWebExtension/SafariWebExtensionHandler.swift
@@ -216,8 +216,8 @@ private final class SafariNativeRuntime {
     /// for extra background time *after* this method (and therefore
     /// `completeRequest`) has already returned. These are two different
     /// budgets: `performExpiringActivity` extends how long the process may
-    /// keep running, not how long WebKit waits for the reply — seeSPEC.md
-    /// §6.8 and `architecture.md` for why there's no persistent daemon loop
+    /// keep running, not how long WebKit waits for the reply — see SPEC.md
+    /// CORE-015 and `architecture.md` for why there's no persistent daemon loop
     /// here at all (unlike Linux/Mac/Windows/Android, or the app target's own
     /// temporary loop).
     ///

--- a/client/ios/rust/src/lib.rs
+++ b/client/ios/rust/src/lib.rs
@@ -318,7 +318,7 @@ pub extern "C" fn virtue_ios_native_run_daemon_loop() -> *mut c_char {
 }
 
 /// Applies any pending requests and runs exactly one tick, then returns —
-/// see `Daemon::tick_once` / SPEC.md §6.8. This is what the Safari
+/// see `Daemon::tick_once` / CORE-015. This is what the Safari
 /// extension's native message handler calls (synchronously, once per
 /// `beginRequest`) instead of `virtue_ios_native_run_daemon_loop`: the OS
 /// only guarantees that process runs for the duration of one message's

--- a/client/linux/src/capture.rs
+++ b/client/linux/src/capture.rs
@@ -395,7 +395,7 @@ fn query_screensaver_active() -> Option<bool> {
 impl LifecycleHooks for LinuxPlatformHooks {
     // `CLOCK_MONOTONIC` excludes time spent suspended (unlike
     // `CLOCK_BOOTTIME`, which includes it) — see `clock_gettime(2)`. Feeds
-    // only `lifecycle::tick`'s suspend evidence (`SPEC.md` §2); screenshot
+    // only `lifecycle::tick`'s suspend evidence (CORE-002); screenshot
     // scheduling is unaffected.
     fn get_monotonic_clock_ms(&self) -> CoreResult<i64> {
         let mut ts = libc::timespec {

--- a/client/linux/src/config.rs
+++ b/client/linux/src/config.rs
@@ -80,7 +80,7 @@ pub fn build_core_config(paths: &ClientPaths) -> Config {
 /// (e.g. the systemd service is stopped) — the daemon process not running is
 /// not the same as the user being logged out. Either way this goes through
 /// `virtue_core::module::status::build`, the same pure function the daemon
-/// itself uses, so the two paths can't drift apart. See `core/SPEC.md` §6.3.
+/// itself uses, so the two paths can't drift apart. See CORE-010.
 pub fn load_service_status(paths: &ClientPaths) -> Result<ServiceStatus> {
     let sock = paths.state_dir.join("daemon.sock");
     if let Ok(mut client) = ClientController::connect(&sock)

--- a/client/mac/src/capture.rs
+++ b/client/mac/src/capture.rs
@@ -312,7 +312,7 @@ impl MacPlatformHooks {
 }
 
 impl LifecycleHooks for MacPlatformHooks {
-    // Feeds only `lifecycle::tick`'s suspend evidence (`SPEC.md` §2); the
+    // Feeds only `lifecycle::tick`'s suspend evidence (CORE-002); the
     // local post-wake UX check in `mac/src/daemon.rs` reads `boot_clock_ms`/
     // `monotonic_clock_ms` directly instead, independent of this trait.
     fn get_monotonic_clock_ms(&self) -> CoreResult<i64> {

--- a/client/mac/src/config.rs
+++ b/client/mac/src/config.rs
@@ -121,7 +121,7 @@ pub fn read_auth_state(state_dir: &Path) -> Result<AuthState> {
 /// (e.g. the launchd agent is stopped) — the daemon process not running is
 /// not the same as the user being logged out. Either way this goes through
 /// `virtue_core::module::status::build`, the same pure function the daemon
-/// itself uses, so the two paths can't drift apart. See `core/SPEC.md` §6.3.
+/// itself uses, so the two paths can't drift apart. See CORE-010.
 pub fn load_service_status(paths: &ClientPaths) -> Result<ServiceStatus> {
     let sock = paths.state_dir.join("daemon.sock");
     if let Ok(mut client) = ClientController::connect(&sock)

--- a/client/scripts/integration-test-lib.ts
+++ b/client/scripts/integration-test-lib.ts
@@ -251,7 +251,7 @@ function hexToUuid(hex: string): string {
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
 }
 
-/** Mints a `server`-typed JWT via hash-server's own dev/test helper (see hash-server/SPEC.md section 4.1). */
+/** Mints a `server`-typed JWT via hash-server's own dev/test helper (see HASH-016). */
 function mintServerToken(hashServerDir: string, privateKeyPemPath: string): string {
   const result = Bun.spawnSync(
     [
@@ -318,7 +318,7 @@ function d1Dump(apiDir: string, label: string, sql: string): void {
  * it's checked directly against the hash server via `GET /hash?devices=<id>`,
  * authenticated with a `server` token minted the same way the api does (see
  * hash-server/examples/mint_token.rs). `last_received` is never cleared by
- * POST /d/batch's hashReset() (SPEC.md section 2.3 -- reset zeroes the hash
+ * POST /d/batch's hashReset() (HASH-008 -- reset zeroes the hash
  * and seq but not last_received), so it's the durable signal that at least
  * one hash was ever ingested, mirroring the old D1 `hashed_at` check.
  */

--- a/client/scripts/update-version.sh
+++ b/client/scripts/update-version.sh
@@ -133,7 +133,7 @@ replace_line \
 # --- API version sync -------------------------------------------------------
 # The whole codebase — main API, hash server, and this client — shares one version,
 # BASE_VERSION above. This derives its `/vX`/`/vX.Y` URL-prefix form (api/SPEC.md
-# section 1.4, hash-server/SPEC.md section 1.3: "For versions before v1, use v0.x") and
+# API-005, HASH-004: "For versions before v1, use v0.x") and
 # writes it into every file that has to hardcode a copy because it can't import
 # shared-web/api-version.ts directly (Rust, and hash-server is a separate deployable).
 # shared-web/api-version.ts is the copy web/ and api/ actually import; it's written

--- a/client/windows/src/capture.rs
+++ b/client/windows/src/capture.rs
@@ -413,7 +413,7 @@ impl ScreenshotHooks for WindowsPlatformHooks {
 
 impl LifecycleHooks for WindowsPlatformHooks {
     // `QueryUnbiasedInterruptTime` excludes time spent suspended. Feeds only
-    // `lifecycle::tick`'s suspend evidence (`SPEC.md` §2).
+    // `lifecycle::tick`'s suspend evidence (CORE-002).
     fn get_monotonic_clock_ms(&self) -> CoreResult<i64> {
         read_monotonic_clock_ms()
     }

--- a/hash-server/SPEC.md
+++ b/hash-server/SPEC.md
@@ -1,10 +1,10 @@
 # Hash API Server
 
-## 1. Overview
+## HASH-001 Overview
 
 The hash server SHOULD have one endpoint with three methods and one status endpoint.
 
-### 1.1 Error Responses
+### HASH-002 Error Responses
 
 All error responses (not **2xx**) MUST have this shape.
 
@@ -18,13 +18,13 @@ All error responses (not **2xx**) MUST have this shape.
 
 `code` is one of: `invalid_body`, `invalid_query`, `unauthorized`, `forbidden`, `sequence_conflict`, `internal_error`.
 
-### 1.2 Authentication
+### HASH-003 Authentication
 
 JWTs MUST use `EdDSA` (Ed25519). The verification key is configured via the
 `JWT_PUBLIC_KEY` environment variable (Ed25519 SPKI PEM), matching the main API's
 `JWT_PUBLIC_KEY`/`JWT_PRIVATE_KEY` pair.
 
-### 1.3 Backwards compat
+### HASH-004 Backwards compat
 
 The API MUST be prefixed with the current major version. For versions before `v1`, use `v0.x`. The server SHOULD return **HTTP 410 Gone** if it no longer supports a version.
 
@@ -35,9 +35,9 @@ The API MUST be prefixed with the current major version. For versions before `v1
   /v2/...
 ```
 
-## 2. Methods
+## HASH-005 Methods
 
-### 2.1 `POST /hash`
+### HASH-006 `POST /hash`
 
 The client MUST authenticate with this header.
 
@@ -75,7 +75,7 @@ The server MUST return **HTTP 201** if the new state has been written to disk an
 
 The client SHOULD retry the request if it receives and error, but SHOULD NOT retry if it receives any of the following errors: `400`, `401`, `409`.
 
-### 2.2 `GET /hash?devices=[device_ids]`
+### HASH-007 `GET /hash?devices=[device_ids]`
 
 The client (in this case, the main API server) MUST authenticate with this header.
 
@@ -107,7 +107,7 @@ The server MUST return a ZERO hash, a 0 count and a 0 for last_received if it do
 }
 ```
 
-### 2.3 `DELETE /hash?device=device1`
+### HASH-008 `DELETE /hash?device=device1`
 
 The client MUST authenticate with this header.
 
@@ -135,7 +135,7 @@ On success, the server MUST return **HTTP 200** with the following shape. With t
 }
 ```
 
-### 2.4 `GET /`
+### HASH-009 `GET /`
 
 This endpoint MUST not require authentication, and MUST return **HTTP 200** unless the server is down.
 
@@ -152,9 +152,9 @@ The endpoint MAY return a status other than "ok" IF it has a way to detect degra
 }
 ```
 
-## 3. Implementation
+## HASH-010 Implementation
 
-### 3.1 High level overview
+### HASH-011 High level overview
 
 The server...
 
@@ -164,7 +164,7 @@ The server...
 - SHOULD use SQLite as its backend database
 - SHOULD be as fast as possible
 
-### 3.2 Server
+### HASH-012 Server
 
 The server SHOULD use tokio as it's runtime, with axum for HTTP routing.
 
@@ -176,7 +176,7 @@ Configuration is read from environment variables (a `.env` file is loaded if pre
 - `DATABASE_PATH` default `hash-server.sqlite`
 - `WRITE_BATCH_WINDOW_MS` default `20`
 
-### 3.3 Database
+### HASH-013 Database
 
 SQLite (via `rusqlite`, bundled) SHOULD be configured in WAL with synchronous = full.
 
@@ -190,7 +190,7 @@ Writes MUST be fully written to the database before a successful response is ret
 
 `GET /hash` is served from SQLite directly, multiple readers are allowed in WAL mode, and after a commit, everything is fine.
 
-### 3.4 Logging
+### HASH-014 Logging
 
 The server SHOULD log every request at level debug.
 
@@ -198,9 +198,9 @@ The server SHOULD NOT log the body of every request.
 
 The server SHOULD log every unexpected error (5xx codes).
 
-## 4. Testing
+## HASH-015 Testing
 
-### 4.1 Performance
+### HASH-016 Performance
 
 We SHOULD have a script that uses h2load to test the number of valid requests per second over http.
 
@@ -213,17 +213,17 @@ Treat the `write` number as the ceiling for the auth + parse + write-queue path,
 for sustained disk-durable writes. Tokens for both modes are minted with
 `cargo run --example mint_token -- <sub> <device|server> <private_key_pem_path>`.
 
-### 4.2 CI
+### HASH-017 CI
 
 The rust unit and integration tests SHOULD be run in github CI.
 
-## 5. Deployment
+## HASH-018 Deployment
 
-### 5.1 Location
+### HASH-019 Location
 
 Both a STAGING (on push/merge to staging) and PRODUCTION (on push/merge to main) deployment SHOULD be deployed to our oracle cloud A1 VM at hash.virtueinitiative.org port 22.
 
-### 5.2 Method
+### HASH-020 Method
 
 The built binary and systemd service SHOULD be copied over SSH to the oracle cloud VM from within CI. The staging binary SHOULD be named `staging-virtue-hash` and the production binary SHOULD be named `virtue-hash`
 
@@ -239,6 +239,6 @@ configured with `PORT=8789`. Cloudflared (section 5.3) MUST route to the matchin
 
 The staging server SHOULD be configured with RUST_LOG=debug.
 
-### 5.3 Cloudflared
+### HASH-021 Cloudflared
 
 Cloudflared MUST be configured on the oracle cloud VM and MUST route staging-hash.virtueinitiative.org to the staging server and hash.virtueinitiative.org to the production server.

--- a/hash-server/deploy/env.example
+++ b/hash-server/deploy/env.example
@@ -1,6 +1,6 @@
 # Template for the systemd EnvironmentFile at
 # /home/ubuntu/<virtue-hash|staging-virtue-hash>/.env on the deploy VM.
-# CI does not manage this file — copy it there once by hand per SPEC.md section 5.
+# CI does not manage this file — copy it there once by hand per HASH-018.
 
 # Must match the main API's JWT_PUBLIC_KEY for this environment (Ed25519 SPKI PEM).
 JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
@@ -10,5 +10,5 @@ PORT=8788
 
 DATABASE_PATH=/home/ubuntu/virtue-hash/hash-server.sqlite
 
-# Staging only, per SPEC.md section 5.2.
+# Staging only, per HASH-020.
 # RUST_LOG=debug

--- a/hash-server/scripts/bench.sh
+++ b/hash-server/scripts/bench.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Benchmarks a running hash-server with h2load over plain HTTP, per SPEC.md
+# Benchmarks a running hash-server with h2load over plain HTTP, per HASH-016
 # section 4. Requires h2load (nghttp2) on PATH.
 #
 # Usage:

--- a/hash-server/src/api_version.rs
+++ b/hash-server/src/api_version.rs
@@ -12,12 +12,12 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 /// The whole codebase shares one version, tracked in `client/version.properties`. This
-/// is that version's `/vX`/`/vX.Y` URL-prefix form (SPEC.md section 1.3) — kept in sync
+/// is that version's `/vX`/`/vX.Y` URL-prefix form (HASH-004) — kept in sync
 /// by `client/scripts/update-version.sh`, which is the only thing that should ever edit
 /// this line.
 const CURRENT_API_VERSION: &str = "v0.1";
 
-/// SPEC.md section 1.3: strips a leading `/vX` or `/vX.Y` path segment naming the
+/// HASH-004: strips a leading `/vX` or `/vX.Y` path segment naming the
 /// current version before routing, and responds 410 Gone for any other version.
 /// Requests with no version segment at all are passed through unchanged, so existing
 /// unversioned callers keep working.

--- a/hash-server/src/db.rs
+++ b/hash-server/src/db.rs
@@ -61,7 +61,7 @@ impl WriteHandle {
 }
 
 /// Opens the database, loads existing state into `devices`, and starts the
-/// single dedicated writer thread required by SPEC.md section 3.3. All
+/// single dedicated writer thread required by HASH-013. All
 /// mutations funnel through this thread and are grouped into one transaction
 /// per batch window so concurrent writers never block on SQLite locks.
 pub fn spawn_writer(
@@ -213,7 +213,7 @@ fn process_batch(conn: &mut Connection, batch: Vec<WriteCommand>, devices: &Shar
                     .get(&device_id)
                     .copied()
                     .unwrap_or_else(|| snapshot.get(&device_id).copied().unwrap_or_default());
-                // SPEC.md section 2.3: the reset MUST NOT touch last_received.
+                // HASH-008: the reset MUST NOT touch last_received.
                 let new_state = DeviceState {
                     hash: ZERO_HASH,
                     seq: 0,

--- a/hash-server/src/error.rs
+++ b/hash-server/src/error.rs
@@ -11,7 +11,7 @@ struct ErrorBody {
     details: Option<String>,
 }
 
-/// The shapes of failure this server can produce, per SPEC.md section 1.1.
+/// The shapes of failure this server can produce, per HASH-002.
 /// Every variant maps to one (status, code, message) triple.
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {
@@ -63,7 +63,7 @@ impl IntoResponse for ApiError {
                 None,
             ),
             ApiError::Internal(details) => {
-                // SPEC.md section 3.4: every unexpected (5xx) error is logged.
+                // HASH-014: every unexpected (5xx) error is logged.
                 tracing::error!(details = details.as_deref().unwrap_or(""), "internal error");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -91,7 +91,7 @@ mod tests {
     use super::*;
     use tracing_test::traced_test;
 
-    // SPEC.md section 3.4: "The server SHOULD log every unexpected error (5xx codes)."
+    // HASH-014: "The server SHOULD log every unexpected error (5xx codes)."
     #[traced_test]
     #[test]
     fn internal_errors_are_logged() {

--- a/hash-server/src/logging.rs
+++ b/hash-server/src/logging.rs
@@ -2,7 +2,7 @@ use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
 
-/// SPEC.md section 3.4: logs every request at debug level, without the body.
+/// HASH-014: logs every request at debug level, without the body.
 pub async fn log_request(req: Request, next: Next) -> Response {
     tracing::debug!(method = %req.method(), path = %req.uri().path(), "request");
     next.run(req).await
@@ -38,11 +38,11 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
-        // SPEC.md section 3.4: "The server SHOULD log every request at level debug."
+        // HASH-014: "The server SHOULD log every request at level debug."
         assert!(logs_contain("request"));
         assert!(logs_contain("POST"));
         assert!(logs_contain("/hash"));
-        // SPEC.md section 3.4: "The server SHOULD NOT log the body of every request."
+        // HASH-014: "The server SHOULD NOT log the body of every request."
         assert!(!logs_contain(secret_body));
     }
 }

--- a/hash-server/src/routes/hash.rs
+++ b/hash-server/src/routes/hash.rs
@@ -32,7 +32,7 @@ impl From<DeviceState> for DeviceInfo {
     }
 }
 
-/// `POST /hash` — see SPEC.md section 2.1.
+/// `POST /hash` — see HASH-006.
 pub async fn ingest(
     State(app): State<AppState>,
     headers: HeaderMap,
@@ -62,7 +62,7 @@ pub struct DevicesQuery {
     devices: Option<String>,
 }
 
-/// `GET /hash?devices=[device_ids]` — see SPEC.md section 2.2.
+/// `GET /hash?devices=[device_ids]` — see HASH-007.
 pub async fn get_many(
     State(app): State<AppState>,
     headers: HeaderMap,
@@ -92,7 +92,7 @@ pub struct DeviceQuery {
     device: Option<String>,
 }
 
-/// `DELETE /hash?device=device1` — see SPEC.md section 2.3.
+/// `DELETE /hash?device=device1` — see HASH-008.
 pub async fn reset(
     State(app): State<AppState>,
     headers: HeaderMap,

--- a/hash-server/src/routes/status.rs
+++ b/hash-server/src/routes/status.rs
@@ -9,7 +9,7 @@ pub struct StatusInfo {
     status: &'static str,
 }
 
-/// `GET /` — see SPEC.md section 2.4.
+/// `GET /` — see HASH-009.
 pub async fn status() -> Json<StatusInfo> {
     Json(StatusInfo {
         name: "Virtue Initiative Hash API",

--- a/hash-server/tests/integration.rs
+++ b/hash-server/tests/integration.rs
@@ -114,7 +114,7 @@ async fn get_root_returns_status_without_auth() {
     assert!(body["commit"].is_string());
 }
 
-/// SPEC.md section 1.3: "The client MUST be prefixed the API with the current major
+/// HASH-004: "The client MUST be prefixed the API with the current major
 /// version. For versions before `v1`, use `v0.x`."
 #[tokio::test]
 async fn get_root_routes_the_same_with_or_without_the_current_version_prefix() {
@@ -146,7 +146,7 @@ async fn get_root_routes_the_same_with_or_without_the_current_version_prefix() {
     assert_eq!(unprefixed_body, prefixed_body);
 }
 
-/// SPEC.md section 1.3: "The server SHOULD return HTTP 410 Gone if it no longer
+/// HASH-004: "The server SHOULD return HTTP 410 Gone if it no longer
 /// supports a version."
 #[tokio::test]
 async fn get_root_responds_410_for_a_no_longer_supported_version() {
@@ -353,7 +353,7 @@ async fn delete_hash_resets_and_returns_prior_state() {
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body["hash"], hex::encode([0u8; 32]));
     assert_eq!(body["seq"], 0);
-    // SPEC.md section 2.3: a reset "SHOULD NOT reset the last_received time" —
+    // HASH-008: a reset "SHOULD NOT reset the last_received time" —
     // this reflects state going into the *second* reset, i.e. right after the
     // first one, so last_received must still be what the first POST set.
     assert_eq!(body["last_received"], 500);

--- a/shared-web/api-version.ts
+++ b/shared-web/api-version.ts
@@ -1,5 +1,5 @@
 // The whole codebase shares one version, tracked in client/version.properties. This is
-// that version's `/vX`/`/vX.Y` URL-prefix form (api/SPEC.md section 1.4,
-// hash-server/SPEC.md section 1.3) — kept in sync by client/scripts/update-version.sh,
+// that version's `/vX`/`/vX.Y` URL-prefix form (API-005,
+// HASH-004) — kept in sync by client/scripts/update-version.sh,
 // which is the only thing that should ever edit this line.
 export const CURRENT_API_VERSION = 'v0.1';

--- a/shared-web/components/Field/Field.tsx
+++ b/shared-web/components/Field/Field.tsx
@@ -7,12 +7,15 @@ type FieldProps = {
   error?: string;
   children?: ComponentChildren;
   class?: string;
+  id?: string;
 };
 
-export function Field({ label, helpText, error, children, class: className }: FieldProps) {
+export function Field({ label, helpText, error, children, class: className, id }: FieldProps) {
   return (
     <div class={['vi-field', error && 'vi-field--error', className].filter(Boolean).join(' ')}>
-      <label class="vi-field__label">{label}</label>
+      <label class="vi-field__label" for={id}>
+        {label}
+      </label>
       {children}
       {helpText && !error && <span class="vi-field__help">{helpText}</span>}
       {error && <span class="vi-field__error">{error}</span>}

--- a/shared-web/components/Input/Input.css
+++ b/shared-web/components/Input/Input.css
@@ -24,6 +24,16 @@
     opacity: 0.6;
     cursor: not-allowed;
   }
+
+  &:read-only {
+    opacity: 0.6;
+    cursor: not-allowed;
+    caret-color: transparent;
+  }
+
+  &:read-only:focus {
+    border-color: var(--border);
+  }
 }
 
 .vi-input--md {

--- a/shared-web/types.ts
+++ b/shared-web/types.ts
@@ -119,6 +119,11 @@ export const passwordResetValidationSchema = z.object({
 });
 export type PasswordResetValidation = z.infer<typeof passwordResetValidationSchema>;
 
+export const signupValidationSchema = z.object({
+  email: z.string(),
+});
+export type SignupValidation = z.infer<typeof signupValidationSchema>;
+
 // ── Request schemas ──────────────────────────────────────────────────────────
 
 export const signupRequestSchema = z.object({
@@ -136,6 +141,9 @@ export const signupSchema = z.object({
   name: z.string().min(1).optional(),
 });
 export type SignupPayload = z.infer<typeof signupSchema>;
+
+export const signupValidateSchema = z.object({ token: z.string().min(1) });
+export type SignupValidatePayload = z.infer<typeof signupValidateSchema>;
 
 export const loginMaterialQuerySchema = z.object({ email: z.email().optional() });
 export type LoginMaterialQuery = z.infer<typeof loginMaterialQuerySchema>;

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -37,6 +37,7 @@ export const handlers = [
       user: { id: 'test-user-id', email: 'test@example.com', email_verified: true },
     }),
   ),
+  http.post(`${BASE}/signup/validate`, () => HttpResponse.json({ email: 'test@example.com' })),
 
   // ── Logout ─────────────────────────────────────────────────────────────
   http.post(`${BASE}/logout`, () => new HttpResponse(null, { status: 204 })),

--- a/web/src/pages/Auth/auth.test.tsx
+++ b/web/src/pages/Auth/auth.test.tsx
@@ -89,6 +89,24 @@ describe('Auth — signup', () => {
   });
 });
 
+describe('Auth — finish signup', () => {
+  it('renders a disabled email field populated from the signup token', async () => {
+    window.history.pushState({}, '', '/signup?signup_token=test-token');
+    renderAuth('signup');
+
+    await waitFor(() => {
+      const emailInput = screen.getByPlaceholderText('you@example.com') as HTMLInputElement;
+      expect(emailInput.value).toBe('test@example.com');
+      expect(emailInput).toBeDisabled();
+    });
+
+    expect(screen.getByPlaceholderText('Choose a password')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Retype your password')).toBeInTheDocument();
+
+    window.history.pushState({}, '', '/');
+  });
+});
+
 describe('Auth — forgot password', () => {
   it('renders the forgot password hint', () => {
     renderAuth('forgot-password');

--- a/web/src/pages/Auth/auth.test.tsx
+++ b/web/src/pages/Auth/auth.test.tsx
@@ -90,14 +90,14 @@ describe('Auth — signup', () => {
 });
 
 describe('Auth — finish signup', () => {
-  it('renders a disabled email field populated from the signup token', async () => {
+  it('renders a read-only email field populated from the signup token', async () => {
     window.history.pushState({}, '', '/signup?signup_token=test-token');
     renderAuth('signup');
 
     await waitFor(() => {
       const emailInput = screen.getByPlaceholderText('you@example.com') as HTMLInputElement;
       expect(emailInput.value).toBe('test@example.com');
-      expect(emailInput).toBeDisabled();
+      expect(emailInput).toHaveAttribute('readonly');
     });
 
     expect(screen.getByPlaceholderText('Choose a password')).toBeInTheDocument();

--- a/web/src/pages/Auth/index.tsx
+++ b/web/src/pages/Auth/index.tsx
@@ -246,22 +246,27 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
           </p>
         )}
 
-        <form class="auth-form" onSubmit={handleSubmit}>
-          <Field label="Email">
+        <form class="auth-form" method="post" onSubmit={handleSubmit}>
+          <Field label="Email" id="email">
             <Input
+              id="email"
+              name="email"
               type="email"
               value={email}
               onInput={(e) => setEmail((e.target as HTMLInputElement).value)}
               placeholder="you@example.com"
-              autoComplete="email"
+              autoComplete={authMode === 'login' ? 'email' : 'username'}
               required
-              disabled={authMode === 'reset' || authMode === 'finish-signup'}
+              readOnly={authMode === 'reset' || authMode === 'finish-signup'}
+              tabIndex={authMode === 'reset' || authMode === 'finish-signup' ? -1 : undefined}
             />
           </Field>
 
           {authMode === 'finish-signup' && (
-            <Field label="Name">
+            <Field label="Name" id="name">
               <Input
+                id="name"
+                name="name"
                 type="text"
                 value={name}
                 onInput={(e) => setName((e.target as HTMLInputElement).value)}
@@ -280,8 +285,11 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
                     ? 'Choose a password'
                     : 'Password'
               }
+              id="password"
             >
               <Input
+                id="password"
+                name="password"
                 type="password"
                 value={password}
                 onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
@@ -303,8 +311,10 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
           )}
 
           {(authMode === 'reset' || authMode === 'finish-signup') && (
-            <Field label="Confirm password">
+            <Field label="Confirm password" id="password-confirm">
               <Input
+                id="password-confirm"
+                name="password-confirm"
                 type="password"
                 value={confirm}
                 onInput={(e) => setConfirm((e.target as HTMLInputElement).value)}

--- a/web/src/pages/Auth/index.tsx
+++ b/web/src/pages/Auth/index.tsx
@@ -62,6 +62,7 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
   const [status, setStatus] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [resetTokenValid, setResetTokenValid] = useState(!resetToken);
+  const [signupTokenValid, setSignupTokenValid] = useState(!signupToken);
   const [signupVerificationEmail, setSignupVerificationEmail] = useState('');
   const signupVerificationDialogRef = useRef<HTMLDialogElement>(null);
 
@@ -81,6 +82,23 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
       })
       .finally(() => setLoading(false));
   }, [authMode, resetToken]);
+
+  useEffect(() => {
+    if (!signupToken || authMode !== 'finish-signup') return;
+    setLoading(true);
+    api
+      .validateSignupToken(signupToken)
+      .then((result) => {
+        setEmail(result.email);
+        setSignupTokenValid(true);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setSignupTokenValid(false);
+        setError(err instanceof Error ? err.message : 'Signup token is invalid');
+      })
+      .finally(() => setLoading(false));
+  }, [authMode, signupToken]);
 
   async function handleSubmit(e: Event) {
     e.preventDefault();
@@ -105,6 +123,9 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
       } else if (authMode === 'finish-signup') {
         if (!signupToken) {
           throw new Error('Signup token is missing');
+        }
+        if (!signupTokenValid) {
+          throw new Error('Signup token is invalid or expired');
         }
         if (password !== confirm) {
           throw new Error('Passwords do not match');
@@ -226,19 +247,17 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
         )}
 
         <form class="auth-form" onSubmit={handleSubmit}>
-          {authMode !== 'finish-signup' && (
-            <Field label="Email">
-              <Input
-                type="email"
-                value={email}
-                onInput={(e) => setEmail((e.target as HTMLInputElement).value)}
-                placeholder="you@example.com"
-                autoComplete="email"
-                required
-                disabled={authMode === 'reset'}
-              />
-            </Field>
-          )}
+          <Field label="Email">
+            <Input
+              type="email"
+              value={email}
+              onInput={(e) => setEmail((e.target as HTMLInputElement).value)}
+              placeholder="you@example.com"
+              autoComplete="email"
+              required
+              disabled={authMode === 'reset' || authMode === 'finish-signup'}
+            />
+          </Field>
 
           {authMode === 'finish-signup' && (
             <Field label="Name">
@@ -275,7 +294,10 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
                 }
                 autoComplete={authMode === 'login' ? 'current-password' : 'new-password'}
                 required
-                disabled={authMode === 'reset' && !resetTokenValid}
+                disabled={
+                  (authMode === 'reset' && !resetTokenValid) ||
+                  (authMode === 'finish-signup' && !signupTokenValid)
+                }
               />
             </Field>
           )}
@@ -289,7 +311,10 @@ export function Auth({ mode }: { mode: 'login' | 'signup' | 'forgot-password' })
                 placeholder="Retype your password"
                 autoComplete="new-password"
                 required
-                disabled={authMode === 'reset' && !resetTokenValid}
+                disabled={
+                  (authMode === 'reset' && !resetTokenValid) ||
+                  (authMode === 'finish-signup' && !signupTokenValid)
+                }
               />
             </Field>
           )}

--- a/web/src/utils/api/api.ts
+++ b/web/src/utils/api/api.ts
@@ -17,6 +17,7 @@ import type {
   PasswordResetValidation,
   SignupPayload,
   SignupResponse,
+  SignupValidation,
   EmailVerifyResponse,
   UpdateUserPayload,
   UpdateUserResponse,
@@ -38,6 +39,7 @@ export type {
   PasswordResetValidation,
   SignupPayload,
   SignupResponse,
+  SignupValidation,
   EmailVerifyResponse,
   UpdateUserPayload,
   UpdateUserResponse,
@@ -191,6 +193,12 @@ export const api = {
     req<SignupResponse>('/signup', {
       method: 'POST',
       body: JSON.stringify(payload),
+    }),
+
+  validateSignupToken: (token: string) =>
+    req<SignupValidation>('/signup/validate', {
+      method: 'POST',
+      body: JSON.stringify({ token }),
     }),
 
   logout: () => req<void>('/logout', { method: 'POST' }),


### PR DESCRIPTION
## Summary

Adds a read only email field on the signup page (after the email verification).

This field needs to be there to help password managers detect that this is a signup and prompt the user to save their login.

I tested it and verified that Bitwarden now shows the popup asking to save the login.

## AI

- Password managers save credentials by finding a username/email field and a password field together. The signup flow splits email entry (`/signup`) from password creation (`/signup?signup_token=...`) across two separate page loads, and the finish-signup page had **no email field at all** — so password managers had nothing to pair the new password with.
- Adds a `POST /signup/validate` endpoint (mirrors the existing `POST /password-reset/validate` → `{ email }` pattern) so the finish-signup screen can resolve and display the pending signup's email, and adds a `username`-typed (disabled) email input alongside the password fields so password managers can associate them.

Fixes #573.

## Changes

<!-- Type of change: Feature / Bug fix / Refactor / Docs / Other -->
Bug fix.
<!-- Components: Web / Landing / API / Core / Linux / Mac / Windows / iOS / Android -->
Components: API, Web.

- `api/SPEC.md` — documents new `POST /signup/validate` endpoint (§2.3), renumbers subsequent §2.x sections.
- `api/src/routes/auth.ts` — new `POST /signup/validate` route: 400 on invalid/expired token or a token whose email is already claimed; `200 { email }` on success.
- `shared-web/types.ts` — `signupValidateSchema` (request) and `signupValidationSchema`/`SignupValidation` (response).
- `web/src/utils/api/api.ts` — `api.validateSignupToken(token)`.
- `web/src/pages/Auth/index.tsx` — resolves the email via the new endpoint on `finish-signup` mount (mirroring the existing `reset` flow), tracks `signupTokenValid`, renders a disabled email field on `finish-signup` alongside the password fields, gates submission/inputs on token validity.

## Testing

- `api`: `npm test -- test/auth-routes.test.ts` (15/15 passing) — added coverage for `/signup/validate` success and invalid/already-claimed-token cases.
- `api`: `npm run typecheck` clean.
- `web`: `npx vitest run` (104/104 passing) — added a test asserting the disabled, populated email field renders alongside the password fields on `finish-signup`, plus an MSW mock handler for the new endpoint.
- `web`: `npx tsc --noEmit` clean.
- Manual verification (per plan) not performed in this session — recommend running `./scripts/launch.sh` with `EMAIL_DELIVERY_MODE=log`, completing signup end-to-end, and confirming a browser password manager offers to save the credential pair on `finish-signup`.

## Stable SPEC.md section IDs

The `api/SPEC.md` change above renumbered every section after the new `§2.3`, which would have broken any existing code comment that cited an old section number. To make that class of change safe going forward, this PR also gives every numbered section in `api/SPEC.md`, `hash-server/SPEC.md`, and `client/core/SPEC.md` a stable ID (`API-NNN` / `HASH-NNN` / `CORE-NNN`) scoped to its file, instead of a positional number — new sections get the next unused number, numbers are never reused, and IDs don't need to stay in document order. Every code/doc comment that cited a section number (`SPEC.md section 2.2`, `SPEC.md §2`) across `api/`, `hash-server/`, and every `client/*` platform now cites the bare ID instead (e.g. `HASH-006`). The convention itself, plus a prefix → file table, is documented in the root `CLAUDE.md`. Also fixed a pre-existing "seeSPEC.md" typo in `client/ios/app/SafariWebExtension/SafariWebExtensionHandler.swift`.

- `hash-server` and `client/core` (`cargo test`, `cargo test -p virtue-core --features testing`) pass in full.
- `grep -rn 'SPEC\.md.*(section [0-9]|§[0-9])'` returns nothing repo-wide.
- Comment/doc-only changes, so no behavior change; `api` test suite otherwise unaffected (two pre-existing, unrelated flaky Workers-runner timeouts in `rate-limit.test.ts`/`retention.test.ts`).
