### PR TITLE
Windows client: add "Report a Bug" form

### DIFF
--- a/client/windows/Virtue.WindowsApp.Core/Interop/IRustInteropClient.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Interop/IRustInteropClient.cs
@@ -10,4 +10,5 @@ public interface IRustInteropClient
     MonitorStatusPayload GetMonitorStatus();
     void Login(string email, string password, string? deviceName = null);
     void Logout();
+    void ReportIssue(string message, string? contactEmail, bool includeLogs);
 }

--- a/client/windows/Virtue.WindowsApp.Core/Interop/RustInteropClient.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Interop/RustInteropClient.cs
@@ -64,6 +64,13 @@ public sealed class RustInteropClient : IRustInteropClient
         ThrowIfError(error);
     }
 
+    public void ReportIssue(string message, string? contactEmail, bool includeLogs)
+    {
+        var payload = RustInteropJson.Serialize(new ReportIssueRequest(message, contactEmail, includeLogs));
+        var error = NativeMethods.virtue_windows_report_issue(payload);
+        ThrowIfError(error);
+    }
+
     private static T ReadJsonPayload<T>(IntPtr pointer)
     {
         var raw = TakeOwnedUtf8(pointer);
@@ -171,6 +178,10 @@ public sealed class RustInteropClient : IRustInteropClient
 
         [DllImport(NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr virtue_windows_logout();
+
+        [DllImport(NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr virtue_windows_report_issue(
+            [MarshalAs(UnmanagedType.LPUTF8Str)] string requestJson);
 
         [DllImport(NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void virtue_windows_free_string(IntPtr value);

--- a/client/windows/Virtue.WindowsApp.Core/Interop/RustInteropDtos.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Interop/RustInteropDtos.cs
@@ -17,3 +17,8 @@ internal sealed record LoginRequest(
     string Email,
     string Password,
     string? DeviceName);
+
+internal sealed record ReportIssueRequest(
+    string Message,
+    string? ContactEmail,
+    bool IncludeLogs);

--- a/client/windows/Virtue.WindowsApp.Core/Tray/ITrayIconHost.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/ITrayIconHost.cs
@@ -4,6 +4,7 @@ public interface ITrayIconHost : IDisposable
 {
     event EventHandler? OpenRequested;
     event EventHandler? ExitRequested;
+    event EventHandler? ReportBugRequested;
     event EventHandler? SessionLogoffObserved;
     event EventHandler? SystemShutdownObserved;
 

--- a/client/windows/Virtue.WindowsApp.Core/Tray/NullTrayIconHost.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/NullTrayIconHost.cs
@@ -4,6 +4,7 @@ public sealed class NullTrayIconHost : ITrayIconHost
 {
     public event EventHandler? OpenRequested;
     public event EventHandler? ExitRequested;
+    public event EventHandler? ReportBugRequested;
     public event EventHandler? SessionLogoffObserved;
     public event EventHandler? SystemShutdownObserved;
 
@@ -18,6 +19,8 @@ public sealed class NullTrayIconHost : ITrayIconHost
     public void RequestOpen() => OpenRequested?.Invoke(this, EventArgs.Empty);
 
     public void RequestExit() => ExitRequested?.Invoke(this, EventArgs.Empty);
+
+    public void RequestReportBug() => ReportBugRequested?.Invoke(this, EventArgs.Empty);
 
     public void RequestSessionLogoff() => SessionLogoffObserved?.Invoke(this, EventArgs.Empty);
 

--- a/client/windows/Virtue.WindowsApp.Core/Tray/TrayMenuController.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/TrayMenuController.cs
@@ -9,12 +9,14 @@ public sealed class TrayMenuController : IDisposable
         _host = host ?? BuildDefaultHost();
         _host.OpenRequested += (_, _) => OpenRequested?.Invoke(this, EventArgs.Empty);
         _host.ExitRequested += (_, _) => ExitRequested?.Invoke(this, EventArgs.Empty);
+        _host.ReportBugRequested += (_, _) => ReportBugRequested?.Invoke(this, EventArgs.Empty);
         _host.SessionLogoffObserved += (_, _) => SessionLogoffObserved?.Invoke(this, EventArgs.Empty);
         _host.SystemShutdownObserved += (_, _) => SystemShutdownObserved?.Invoke(this, EventArgs.Empty);
     }
 
     public event EventHandler? OpenRequested;
     public event EventHandler? ExitRequested;
+    public event EventHandler? ReportBugRequested;
     public event EventHandler? SessionLogoffObserved;
     public event EventHandler? SystemShutdownObserved;
 

--- a/client/windows/Virtue.WindowsApp.Core/Tray/WindowsTrayIconHost.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/WindowsTrayIconHost.cs
@@ -24,6 +24,7 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
     private const int LrLoadFromFile = 0x00000010;
     private const int IdTrayOpen = 2001;
     private const int IdTrayExit = 2002;
+    private const int IdTrayReportBug = 2003;
     private const int WindowId = 1;
     private static readonly uint WmTrayIcon = WmApp + 1;
 
@@ -44,6 +45,7 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
 
     public event EventHandler? OpenRequested;
     public event EventHandler? ExitRequested;
+    public event EventHandler? ReportBugRequested;
     public event EventHandler? SessionLogoffObserved;
     public event EventHandler? SystemShutdownObserved;
 
@@ -77,6 +79,7 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
 
         _menuHandle = CreatePopupMenu();
         _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayOpen, "Open");
+        _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayReportBug, "Report a Bug");
         _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayExit, "Exit");
 
         AddOrUpdateIcon(NimAdd);
@@ -227,6 +230,10 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
                 if (command == IdTrayOpen)
                 {
                     OpenRequested?.Invoke(this, EventArgs.Empty);
+                }
+                else if (command == IdTrayReportBug)
+                {
+                    ReportBugRequested?.Invoke(this, EventArgs.Empty);
                 }
                 else if (command == IdTrayExit)
                 {

--- a/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
+++ b/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
@@ -276,6 +276,17 @@ public sealed class SessionViewModel : INotifyPropertyChanged
         }, "Signing out...");
     }
 
+    public async Task<bool> SubmitBugReportAsync(string message, string? contactEmail, bool includeLogs)
+    {
+        var succeeded = false;
+        await RunBusyAsync(async () =>
+        {
+            await Task.Run(() => _interopClient.ReportIssue(message, contactEmail, includeLogs));
+            succeeded = true;
+        }, "Sending report...");
+        return succeeded;
+    }
+
     public async Task RefreshAsync()
     {
         await RunBusyAsync(async () =>

--- a/client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs
+++ b/client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs
@@ -312,6 +312,48 @@ public sealed class SessionViewModelTests
     }
 
     [Fact]
+    public async Task SubmitBugReportAsync_ReturnsTrueAndForwardsFieldsOnSuccess()
+    {
+        var fakeClient = new FakeRustInteropClient();
+        var viewModel = new SessionViewModel(fakeClient, "0.0.5.1234");
+
+        var result = await viewModel.SubmitBugReportAsync("Screenshots stopped uploading", "me@example.com", true);
+
+        Assert.True(result);
+        Assert.Equal(("Screenshots stopped uploading", "me@example.com", true), fakeClient.LastReportIssue);
+        Assert.Null(viewModel.ErrorText);
+    }
+
+    [Fact]
+    public async Task SubmitBugReportAsync_ReturnsFalseAndSetsErrorTextOnFailure()
+    {
+        var fakeClient = new FakeRustInteropClient
+        {
+            ReportIssueError = new InvalidOperationException("Too many requests"),
+        };
+        var viewModel = new SessionViewModel(fakeClient, "0.0.5.1234");
+
+        var result = await viewModel.SubmitBugReportAsync("Screenshots stopped uploading", null, false);
+
+        Assert.False(result);
+        Assert.Equal("Too many requests", viewModel.ErrorText);
+    }
+
+    [Fact]
+    public void TrayMenuController_RoutesReportBugEvent()
+    {
+        var host = new NullTrayIconHost();
+        var controller = new TrayMenuController(host);
+        var reportBugRaised = false;
+
+        controller.ReportBugRequested += (_, _) => reportBugRaised = true;
+
+        host.RequestReportBug();
+
+        Assert.True(reportBugRaised);
+    }
+
+    [Fact]
     public void TrayMenuController_RoutesAllSystemEvents()
     {
         var host = new NullTrayIconHost();
@@ -402,6 +444,20 @@ public sealed class SessionViewModelTests
         {
             SessionStatus = SessionStatus with { LoggedIn = false };
             MonitorStatus = MonitorStatus with { State = "signed_out", LoggedIn = false, LastError = null };
+        }
+
+        public (string Message, string? ContactEmail, bool IncludeLogs)? LastReportIssue { get; private set; }
+
+        public Exception? ReportIssueError { get; set; }
+
+        public void ReportIssue(string message, string? contactEmail, bool includeLogs)
+        {
+            if (ReportIssueError is not null)
+            {
+                throw ReportIssueError;
+            }
+
+            LastReportIssue = (message, contactEmail, includeLogs);
         }
     }
 }

--- a/client/windows/Virtue.WindowsApp/App.xaml.cs
+++ b/client/windows/Virtue.WindowsApp/App.xaml.cs
@@ -58,6 +58,7 @@ public partial class App : Application
             _trayController = new TrayMenuController();
             _trayController.OpenRequested += (_, _) => ShowMainWindow();
             _trayController.ExitRequested += async (_, _) => await RequestResidentShutdownAsync();
+            _trayController.ReportBugRequested += async (_, _) => await ShowReportBugFromTrayAsync();
             _trayController.SessionLogoffObserved += (_, _) => HandleSessionLogoff();
             _trayController.SystemShutdownObserved += (_, _) => HandleSystemShutdown();
             _trayController.Initialize();
@@ -215,6 +216,15 @@ public partial class App : Application
         _mainWindow ??= CreateMainWindow();
         _mainWindow.ShowFromTray();
         _ = _viewModel?.RefreshAsync();
+    }
+
+    private async Task ShowReportBugFromTrayAsync()
+    {
+        ShowMainWindow();
+        if (_mainWindow is not null)
+        {
+            await _mainWindow.ShowReportBugDialogAsync();
+        }
     }
 
     private MainWindow CreateMainWindow()

--- a/client/windows/Virtue.WindowsApp/MainWindow.xaml.cs
+++ b/client/windows/Virtue.WindowsApp/MainWindow.xaml.cs
@@ -232,6 +232,9 @@ public sealed partial class MainWindow : Window
         var detailsButton = CreateActionButton("Status Details");
         detailsButton.Click += StatusDetailsButton_OnClick;
 
+        var reportBugButton = CreateActionButton("Report a Bug");
+        reportBugButton.Click += async (_, _) => await ShowReportBugDialogAsync();
+
         var stopMonitoringButton = CreateActionButton("Stop Monitoring");
         stopMonitoringButton.Click += StopMonitoringButton_OnClick;
 
@@ -246,6 +249,7 @@ public sealed partial class MainWindow : Window
             Margin = new Thickness(0, 18, 0, 0),
         };
         actionRow.Children.Add(detailsButton);
+        actionRow.Children.Add(reportBugButton);
         actionRow.Children.Add(_signedInActionsPanel);
 
         var content = new StackPanel { Spacing = 8 };
@@ -482,6 +486,145 @@ public sealed partial class MainWindow : Window
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
                 MinHeight = 320,
+            },
+        };
+        ApplyDialogTheme(dialog);
+
+        if (Content is FrameworkElement root)
+        {
+            dialog.XamlRoot = root.XamlRoot;
+        }
+
+        await dialog.ShowAsync();
+    }
+
+    public async Task ShowReportBugDialogAsync()
+    {
+        var messageBox = new TextBox
+        {
+            PlaceholderText = "Describe the issue",
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            Height = 120,
+        };
+        StyleInput(messageBox);
+
+        var contactEmailBox = new TextBox
+        {
+            PlaceholderText = "Contact email (optional)",
+            Text = ViewModel.LoggedIn ? ViewModel.AccountEmail : string.Empty,
+        };
+        StyleInput(contactEmailBox);
+
+        var includeLogsCheckBox = new CheckBox
+        {
+            Content = "Include the last day of diagnostic logs",
+            IsChecked = true,
+            FontFamily = BodyFont,
+            Foreground = InkBrush,
+        };
+
+        var includeLogsCaption = new TextBlock
+        {
+            Text = "Includes timestamps, monitoring status, and error messages from the last day. " +
+                   "No screenshots or window titles are included. Known tokens are redacted automatically.",
+            TextWrapping = TextWrapping.Wrap,
+            FontFamily = BodyFont,
+            FontSize = 12,
+            Foreground = Ink3Brush,
+            Margin = new Thickness(28, 0, 0, 0),
+        };
+
+        var reportErrorTextBlock = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = DangerBrush,
+            FontFamily = BodyFont,
+            Visibility = Visibility.Collapsed,
+        };
+
+        var content = new StackPanel { Spacing = 12, Width = 420 };
+        content.Children.Add(messageBox);
+        content.Children.Add(contactEmailBox);
+        content.Children.Add(includeLogsCheckBox);
+        content.Children.Add(includeLogsCaption);
+        content.Children.Add(reportErrorTextBlock);
+
+        var dialog = new ContentDialog
+        {
+            Title = CreateDialogTitle("Report a Bug"),
+            PrimaryButtonText = "Send Report",
+            CloseButtonText = "Cancel",
+            DefaultButton = ContentDialogButton.Primary,
+            Content = content,
+        };
+        ApplyDialogTheme(dialog);
+
+        if (Content is FrameworkElement root)
+        {
+            dialog.XamlRoot = root.XamlRoot;
+        }
+
+        var reportSent = false;
+        dialog.PrimaryButtonClick += async (_, args) =>
+        {
+            var message = messageBox.Text.Trim();
+            if (string.IsNullOrEmpty(message))
+            {
+                args.Cancel = true;
+                reportErrorTextBlock.Text = "Please describe the issue.";
+                reportErrorTextBlock.Visibility = Visibility.Visible;
+                return;
+            }
+
+            var deferral = args.GetDeferral();
+            try
+            {
+                var contactEmail = contactEmailBox.Text.Trim();
+                var succeeded = await ViewModel.SubmitBugReportAsync(
+                    message,
+                    string.IsNullOrEmpty(contactEmail) ? null : contactEmail,
+                    includeLogsCheckBox.IsChecked == true);
+
+                if (!succeeded)
+                {
+                    args.Cancel = true;
+                    reportErrorTextBlock.Text = ViewModel.ErrorText ?? "Failed to send the report.";
+                    reportErrorTextBlock.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    reportSent = true;
+                }
+            }
+            finally
+            {
+                deferral.Complete();
+            }
+        };
+
+        await dialog.ShowAsync();
+
+        if (reportSent)
+        {
+            await ShowReportBugConfirmationAsync();
+        }
+    }
+
+    private async Task ShowReportBugConfirmationAsync()
+    {
+        var dialog = new ContentDialog
+        {
+            Title = CreateDialogTitle("Report Sent"),
+            CloseButtonText = "Close",
+            DefaultButton = ContentDialogButton.Close,
+            Content = new TextBlock
+            {
+                Text = "Thanks — your report was sent to the Virtue Initiative team.",
+                TextWrapping = TextWrapping.Wrap,
+                FontFamily = BodyFont,
+                Foreground = Ink2Brush,
+                Width = 380,
             },
         };
         ApplyDialogTheme(dialog);

--- a/client/windows/src/ffi.rs
+++ b/client/windows/src/ffi.rs
@@ -385,8 +385,10 @@ fn read_registry_string_value(key_path: &str, value_name: &str) -> Option<String
         }
 
         let wide: Vec<u16> = buffer[..data_size as usize]
-            .chunks_exact(2)
-            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|pair| u16::from_le_bytes(*pair))
             .collect();
         let value = String::from_utf16_lossy(&wide);
         let trimmed = value.trim_end_matches('\0').trim();

--- a/client/windows/src/ffi.rs
+++ b/client/windows/src/ffi.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
-use crate::config::{ClientPaths, default_device_name};
+use crate::config::{ClientPaths, build_core_config, default_device_name};
 use crate::resident_monitor::{self, MonitorStatusSnapshot};
 use crate::session::{SessionManager, SessionStatus};
 
@@ -167,6 +167,14 @@ struct LoginRequest {
     device_name: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct ReportIssueRequest {
+    message: String,
+    contact_email: Option<String>,
+    include_logs: bool,
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn virtue_windows_init() -> *mut c_char {
     into_error_ptr((|| {
@@ -217,6 +225,205 @@ pub extern "C" fn virtue_windows_logout() -> *mut c_char {
         manager.logout_blocking()?;
         Ok(())
     })())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn virtue_windows_report_issue(request_json: *const c_char) -> *mut c_char {
+    into_error_ptr((|| {
+        let request_json = c_string_or_empty(request_json);
+        let request: ReportIssueRequest = serde_json::from_str(&request_json)
+            .context("failed parsing report-issue request json")?;
+
+        let message = request.message.trim().to_string();
+        if message.is_empty() {
+            return Err(anyhow!("message is required"));
+        }
+
+        let paths = ensure_paths_initialized()?;
+
+        // Read the device refresh token straight off disk, same disk-fallback
+        // approach the Linux `report-issue` command uses, so a report can be
+        // attributed to this device even when the resident daemon isn't
+        // running (or hasn't finished starting up yet).
+        let state: virtue_core::DaemonState =
+            virtue_core::load_state(&paths.state_dir.join("event_state.json")).unwrap_or_default();
+        let bearer_token = state
+            .auth
+            .device_credentials
+            .map(|creds| creds.refresh_token);
+
+        let platform_details = windows_platform_details();
+        let logs = request.include_logs.then(|| recent_logs(&paths)).flatten();
+
+        let config = build_core_config(&paths);
+        let api = virtue_core::api::HttpApiClient::new(&config)?;
+        api.report_issue(
+            bearer_token.as_deref(),
+            &virtue_core::api::BugReportRequest {
+                message: &message,
+                contact_email: request.contact_email.as_deref(),
+                platform: "windows",
+                app_version: virtue_core::BUILD_LABEL,
+                platform_details: Some(&platform_details),
+            },
+            logs.as_deref(),
+        )
+        .context("failed to submit bug report")?;
+
+        Ok(())
+    })())
+}
+
+/// Best-effort "ProductName; DisplayVersion (Build CurrentBuildNumber)" string
+/// read from `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`, e.g.
+/// `"Windows 11 Pro; 23H2 (Build 22631)"`. Falls back to a fixed placeholder
+/// on any registry error, mirroring the Linux client's `"unknown"` fallback
+/// in `linux_platform_details`.
+#[cfg(target_os = "windows")]
+fn windows_platform_details() -> String {
+    let product_name = read_registry_string_value(
+        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+        "ProductName",
+    );
+    let display_version = read_registry_string_value(
+        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+        "DisplayVersion",
+    )
+    .or_else(|| {
+        read_registry_string_value(
+            "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+            "ReleaseId",
+        )
+    });
+    let build_number = read_registry_string_value(
+        "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+        "CurrentBuildNumber",
+    );
+
+    let mut parts = Vec::new();
+    if let Some(product_name) = product_name {
+        parts.push(product_name);
+    }
+
+    let version_part = match (display_version, build_number) {
+        (Some(version), Some(build)) => Some(format!("{version} (Build {build})")),
+        (Some(version), None) => Some(version),
+        (None, Some(build)) => Some(format!("Build {build}")),
+        (None, None) => None,
+    };
+    if let Some(version_part) = version_part {
+        parts.push(version_part);
+    }
+
+    if parts.is_empty() {
+        "Windows (unknown version)".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn windows_platform_details() -> String {
+    "Windows (unknown version)".to_string()
+}
+
+/// Reads a single `REG_SZ` value under `HKLM\<key_path>`, or `None` on any
+/// error (missing key/value, wrong type, non-UTF-16 data).
+#[cfg(target_os = "windows")]
+fn read_registry_string_value(key_path: &str, value_name: &str) -> Option<String> {
+    use windows::Win32::System::Registry::{
+        HKEY, HKEY_LOCAL_MACHINE, KEY_READ, RegCloseKey, RegOpenKeyExW, RegQueryValueExW,
+    };
+    use windows::core::PCWSTR;
+
+    let key_path_wide: Vec<u16> = format!("{key_path}\0").encode_utf16().collect();
+    let value_name_wide: Vec<u16> = format!("{value_name}\0").encode_utf16().collect();
+
+    unsafe {
+        let mut hkey = HKEY::default();
+        let open_result = RegOpenKeyExW(
+            HKEY_LOCAL_MACHINE,
+            PCWSTR::from_raw(key_path_wide.as_ptr()),
+            Some(0),
+            KEY_READ,
+            &mut hkey,
+        );
+        if open_result.is_err() {
+            return None;
+        }
+
+        // Grow-and-retry: query the required size first, then fetch into a
+        // buffer of exactly that size (values here are short, so one retry
+        // at most is expected in practice).
+        let mut data_size = 0u32;
+        let size_result = RegQueryValueExW(
+            hkey,
+            PCWSTR::from_raw(value_name_wide.as_ptr()),
+            None,
+            None,
+            None,
+            Some(&mut data_size),
+        );
+        if size_result.is_err() || data_size == 0 {
+            let _ = RegCloseKey(hkey);
+            return None;
+        }
+
+        let mut buffer = vec![0u8; data_size as usize];
+        let query_result = RegQueryValueExW(
+            hkey,
+            PCWSTR::from_raw(value_name_wide.as_ptr()),
+            None,
+            None,
+            Some(buffer.as_mut_ptr()),
+            Some(&mut data_size),
+        );
+        let _ = RegCloseKey(hkey);
+
+        if query_result.is_err() {
+            return None;
+        }
+
+        let wide: Vec<u16> = buffer[..data_size as usize]
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        let value = String::from_utf16_lossy(&wide);
+        let trimmed = value.trim_end_matches('\0').trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    }
+}
+
+/// Best-effort last day of this device's operational logs: today's and (if
+/// present) yesterday's daily-rotated log file from `paths.log_dir` (see
+/// `init_logging`), redacted (`virtue_core::api::redact_secrets`) and trimmed
+/// to the API's attachment size cap, keeping the most recent bytes.
+fn recent_logs(paths: &ClientPaths) -> Option<Vec<u8>> {
+    let today = chrono::Local::now().date_naive();
+    let mut combined = String::new();
+
+    for date in [today, today - chrono::Duration::days(1)] {
+        let file_name = format!(
+            "{}.{}.log",
+            virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix,
+            date.format("%Y-%m-%d")
+        );
+        if let Ok(contents) = std::fs::read_to_string(paths.log_dir.join(file_name)) {
+            combined.push_str(&contents);
+        }
+    }
+
+    if combined.is_empty() {
+        return None;
+    }
+
+    let redacted = virtue_core::api::redact_secrets(&combined);
+    let mut logs = redacted.into_bytes();
+    if logs.len() > virtue_core::api::MAX_LOG_ATTACHMENT_BYTES {
+        let start = logs.len() - virtue_core::api::MAX_LOG_ATTACHMENT_BYTES;
+        logs.drain(0..start);
+    }
+    Some(logs)
 }
 
 #[unsafe(no_mangle)]
@@ -387,5 +594,47 @@ mod tests {
         assert!(json.get("loggedIn").is_some());
         assert!(json.get("pendingRequestCount").is_some());
         assert!(json.get("lastError").is_some());
+    }
+
+    #[test]
+    fn report_issue_returns_a_useful_error_string_for_empty_message() {
+        let _guard = test_lock().lock().expect("test lock");
+        let request = c_value(r#"{"message":"   "}"#);
+        let error = ptr_to_string(virtue_windows_report_issue(request.as_ptr()));
+        assert_eq!(error, "message is required");
+    }
+
+    #[test]
+    fn windows_platform_details_is_never_empty() {
+        assert!(!windows_platform_details().is_empty());
+    }
+
+    #[test]
+    fn recent_logs_returns_none_when_no_log_files_exist() {
+        let _guard = test_lock().lock().expect("test lock");
+        let paths = temporary_paths("recent-logs-none");
+        paths.ensure_dirs().expect("ensure dirs");
+
+        assert!(recent_logs(&paths).is_none());
+    }
+
+    #[test]
+    fn recent_logs_redacts_secrets_and_returns_todays_log() {
+        let _guard = test_lock().lock().expect("test lock");
+        let paths = temporary_paths("recent-logs-present");
+        paths.ensure_dirs().expect("ensure dirs");
+
+        let today = chrono::Local::now().date_naive().format("%Y-%m-%d");
+        let file_name = format!("virtue.{today}.log");
+        std::fs::write(
+            paths.log_dir.join(file_name),
+            "auth failed: token wst_AbCdEf123456ghijklmnop rejected\n",
+        )
+        .expect("write log file");
+
+        let logs = recent_logs(&paths).expect("logs should be present");
+        let text = String::from_utf8(logs).expect("logs should be utf8");
+        assert!(!text.contains("wst_"));
+        assert!(text.contains("[redacted]"));
     }
 }


### PR DESCRIPTION
## Summary

Adds a Report a Bug button to windows.


<img width="714" height="572" alt="image" src="https://github.com/user-attachments/assets/ec787ca5-4690-443e-a266-cb67defe7ed3" />

<img width="533" height="463" alt="image" src="https://github.com/user-attachments/assets/ea52cdd3-4905-4e8b-af04-f49e94a4cf81" />
<img width="470" height="230" alt="image" src="https://github.com/user-attachments/assets/b829cfe8-70d1-44a9-b5db-18d90152c10d" />

<img width="844" height="420" alt="image" src="https://github.com/user-attachments/assets/56af9efd-0348-4e40-8c44-78f30cd47582" />




## AI

Adds a "Report a Bug" entry point to the Windows WinUI client, wired to the
`POST /bug-report` endpoint (API-042) that was already merged to `staging`
(the Linux client already has an equivalent `virtue report-issue` command).

## Changes

**Type of change:** Feature
**Components:** Windows

- `client/windows/src/ffi.rs`: new `virtue_windows_report_issue` FFI export.
  Reuses the platform-agnostic `virtue_core::api::{BugReportRequest,
  HttpApiClient::report_issue, redact_secrets, MAX_LOG_ATTACHMENT_BYTES}`
  helpers already shared with Linux. Reads the device's refresh token off
  `event_state.json` (same disk-fallback approach Linux uses) so signed-in
  reports carry device identity; gathers Windows version info from the
  registry (`windows_platform_details`); and reads/redacts/trims the last
  two days of the app's own rotated log files (`recent_logs`) for the
  optional attachment.
- WinUI app (`Virtue.WindowsApp`, `Virtue.WindowsApp.Core`): new "Report a
  Bug" button on the main window (next to Status Details) and a matching
  tray-menu entry, both opening a `ContentDialog` form (description,
  optional contact email pre-filled when signed in, an opt-out "include
  logs" checkbox with the required user-facing warning text per API-042).
  Routed through a new `SessionViewModel.SubmitBugReportAsync` and the new
  `IRustInteropClient.ReportIssue` interop call.
- Tests: new Rust FFI unit tests (empty-message validation, platform
  details, log redaction/trimming) and new `SessionViewModelTests` /
  `TrayMenuController` coverage for the new view-model method and tray
  event routing.

## Testing

- `cargo check` / `cargo clippy -p virtue-windows -- -D warnings` / `cargo
  fmt --check` all pass clean, cross-compiled to `x86_64-pc-windows-gnu`
  (no Windows execution environment available where these were run, so the
  new Rust tests are compile-verified there but not executed).
- Built the full MSIX on the `virtue-win11` build VM via
  `scripts/remote-windows-build.sh --mode msix`, installed it, and
  confirmed the app launches.
- Manual in-app testing of the new "Report a Bug" flow (signed-in vs.
  anonymous, logs on/off, submission against the local dev API) is still
  outstanding — flagged as a draft PR pending that pass.