### PR TITLE
Add "Report a Bug" form to the Android client

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -3753,6 +3753,7 @@ name = "virtue-android"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "jni",
  "once_cell",
  "serde",

--- a/client/android/app/src/main/java/org/virtueinitiative/virtue/AccountEmailStore.kt
+++ b/client/android/app/src/main/java/org/virtueinitiative/virtue/AccountEmailStore.kt
@@ -1,0 +1,33 @@
+package org.virtueinitiative.virtue
+
+import android.content.Context
+
+/**
+ * Remembers the email of the signed-in account so it can prefill the bug-report form's
+ * contact-email field. Core's `AuthState`/`DeviceCredentials` don't carry the account
+ * email, so this is app-layer state, not something read from the daemon — mirrors the
+ * Windows client's `ClientState.email`.
+ */
+object AccountEmailStore {
+    private const val PREFS = "virtue_account"
+    private const val KEY_EMAIL = "email"
+
+    fun save(context: Context, email: String) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_EMAIL, email)
+            .apply()
+    }
+
+    fun load(context: Context): String? {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(KEY_EMAIL, null)
+    }
+
+    fun clear(context: Context) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .apply()
+    }
+}

--- a/client/android/app/src/main/java/org/virtueinitiative/virtue/MainActivity.kt
+++ b/client/android/app/src/main/java/org/virtueinitiative/virtue/MainActivity.kt
@@ -58,6 +58,8 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://virtueinitiative.org")))
         }
 
+        binding.reportBugLink.setOnClickListener { showReportBugDialog() }
+
         KeepAliveWorker.schedule(this)
         requestBackgroundFriendlySettings()
         refreshUi()
@@ -109,6 +111,7 @@ class MainActivity : AppCompatActivity() {
             binding.loginButton.isEnabled = true
 
             if (error == null) {
+                AccountEmailStore.save(this@MainActivity, email)
                 refreshUi()
             } else {
                 setStatus("Login failed: $error")
@@ -133,6 +136,7 @@ class MainActivity : AppCompatActivity() {
                             }
                         }
                     }
+                    AccountEmailStore.clear(this@MainActivity)
                     VirtueAccessibilityService.pause()
                     ScreenshotService.stop(this@MainActivity)
                     refreshUi()
@@ -434,6 +438,123 @@ class MainActivity : AppCompatActivity() {
         )
         doneBtn.setOnClickListener { dialog.dismiss() }
         dialog.show()
+    }
+
+    private fun showReportBugDialog() {
+        val dp = resources.displayMetrics.density
+
+        val descriptionLayout = com.google.android.material.textfield.TextInputLayout(this).apply {
+            boxBackgroundMode = com.google.android.material.textfield.TextInputLayout.BOX_BACKGROUND_OUTLINE
+        }
+        val descriptionInput = com.google.android.material.textfield.TextInputEditText(descriptionLayout.context).apply {
+            hint = getString(R.string.report_bug_description_hint)
+            isSingleLine = false
+            minLines = 3
+            maxLines = 6
+        }
+        descriptionLayout.addView(descriptionInput)
+
+        val emailLayout = com.google.android.material.textfield.TextInputLayout(this).apply {
+            boxBackgroundMode = com.google.android.material.textfield.TextInputLayout.BOX_BACKGROUND_OUTLINE
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = (12 * dp).toInt() }
+        }
+        val emailInput = com.google.android.material.textfield.TextInputEditText(emailLayout.context).apply {
+            hint = getString(R.string.report_bug_contact_email_hint)
+            inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+            setText(AccountEmailStore.load(this@MainActivity).orEmpty())
+        }
+        emailLayout.addView(emailInput)
+
+        val includeLogsCheckBox = android.widget.CheckBox(this).apply {
+            text = getString(R.string.report_bug_include_logs)
+            isChecked = true
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = (14 * dp).toInt() }
+        }
+
+        val includeLogsCaption = TextView(this).apply {
+            text = getString(R.string.report_bug_include_logs_caption)
+            textSize = 12f
+            setTextColor(0xFF9C9682.toInt())
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = (4 * dp).toInt() }
+        }
+
+        val errorText = TextView(this).apply {
+            setTextColor(0xFFEF4444.toInt())
+            visibility = android.view.View.GONE
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = (10 * dp).toInt() }
+        }
+
+        val content = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            val pad = (20 * dp).toInt()
+            setPadding(pad, pad, pad, 0)
+            addView(descriptionLayout)
+            addView(emailLayout)
+            addView(includeLogsCheckBox)
+            addView(includeLogsCaption)
+            addView(errorText)
+        }
+
+        val dialog = androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle(getString(R.string.dialog_report_bug_title))
+            .setView(content)
+            .setPositiveButton(getString(R.string.btn_send_report), null)
+            .setNegativeButton(getString(R.string.dialog_cancel), null)
+            .create()
+
+        dialog.setOnShowListener {
+            val sendButton = dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE)
+            sendButton.setOnClickListener {
+                val message = descriptionInput.text?.toString()?.trim().orEmpty()
+                if (message.isEmpty()) {
+                    errorText.text = getString(R.string.report_bug_message_required)
+                    errorText.visibility = android.view.View.VISIBLE
+                    return@setOnClickListener
+                }
+
+                val contactEmail = emailInput.text?.toString()?.trim().orEmpty()
+                val includeLogs = includeLogsCheckBox.isChecked
+                val platformDetails = androidPlatformDetails()
+
+                sendButton.isEnabled = false
+                lifecycleScope.launch {
+                    val error = withContext(Dispatchers.IO) {
+                        NativeBridge.nativeReportIssue(message, contactEmail, includeLogs, platformDetails)
+                    }
+                    sendButton.isEnabled = true
+
+                    if (error == null) {
+                        dialog.dismiss()
+                        showReportSentDialog()
+                    } else {
+                        errorText.text = getString(R.string.report_bug_send_failed)
+                        errorText.visibility = android.view.View.VISIBLE
+                    }
+                }
+            }
+        }
+
+        dialog.show()
+    }
+
+    private fun showReportSentDialog() {
+        androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle(getString(R.string.dialog_report_sent_title))
+            .setMessage(getString(R.string.dialog_report_sent_message))
+            .setPositiveButton(getString(R.string.btn_done), null)
+            .show()
+    }
+
+    private fun androidPlatformDetails(): String {
+        return "Android ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT}); ${deviceName()}"
     }
 
     private fun formatTimestampMs(ms: Long): String {

--- a/client/android/app/src/main/java/org/virtueinitiative/virtue/NativeBridge.kt
+++ b/client/android/app/src/main/java/org/virtueinitiative/virtue/NativeBridge.kt
@@ -51,4 +51,10 @@ object NativeBridge {
     external fun nativeStopDaemon(): String?
     external fun nativeNoteUserStop(source: String): String?
     external fun nativeGetStatusJson(): String
+    external fun nativeReportIssue(
+        message: String,
+        contactEmail: String,
+        includeLogs: Boolean,
+        platformDetails: String
+    ): String?
 }

--- a/client/android/app/src/main/res/layout/activity_main.xml
+++ b/client/android/app/src/main/res/layout/activity_main.xml
@@ -65,6 +65,17 @@
                         android:textSize="12sp"
                         android:textColor="?attr/colorOnSurfaceVariant"
                         android:layout_marginTop="4dp" />
+
+                    <TextView
+                        android:id="@+id/reportBugLink"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/btn_report_bug"
+                        android:textSize="14sp"
+                        android:textColor="@color/virtue_forest"
+                        android:layout_marginTop="6dp"
+                        android:clickable="true"
+                        android:focusable="true" />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/client/android/app/src/main/res/values/strings.xml
+++ b/client/android/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="btn_pause_monitoring">Pause Monitoring</string>
     <string name="btn_resume_monitoring">Resume Monitoring</string>
     <string name="btn_done">Done</string>
+    <string name="btn_report_bug">Report a Bug</string>
+    <string name="btn_send_report">Send Report</string>
 
     <!-- Messages -->
     <string name="msg_sign_in_to_start">Sign in to start monitoring</string>
@@ -48,6 +50,15 @@
     <string name="dialog_resume_message">Resume monitoring on this device?</string>
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_confirm">Confirm</string>
+    <string name="dialog_report_bug_title">Report a Bug</string>
+    <string name="report_bug_description_hint">Describe the issue</string>
+    <string name="report_bug_contact_email_hint">Contact email (optional)</string>
+    <string name="report_bug_include_logs">Include the last day of diagnostic logs</string>
+    <string name="report_bug_include_logs_caption">Includes timestamps, monitoring status, and error messages from the last day. No screenshots or window titles are included. Known tokens are redacted automatically.</string>
+    <string name="report_bug_message_required">Please describe the issue.</string>
+    <string name="report_bug_send_failed">Failed to send the report.</string>
+    <string name="dialog_report_sent_title">Report Sent</string>
+    <string name="dialog_report_sent_message">Thanks — your report was sent to the Virtue Initiative team.</string>
 
     <!-- Accessibility service -->
     <string name="accessibility_service_label">Virtue Screen Monitor</string>

--- a/client/android/rust/Cargo.toml
+++ b/client/android/rust/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 virtue_core = { package = "virtue-core", path = "../../core" }
 virtue_text_detection = { package = "virtue-text-detection", path = "../../text-detection" }
 jni = "0.22"

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -500,9 +500,7 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeRepor
             .and_then(|auth| auth.device_credentials)
             .map(|creds| creds.refresh_token);
 
-        let logs = include_logs
-            .then(|| recent_logs(&core.state_dir))
-            .flatten();
+        let logs = include_logs.then(|| recent_logs(&core.state_dir)).flatten();
 
         let config = build_core_config(&core.state_dir);
         let api = HttpApiClient::new(&config)?;

--- a/client/android/rust/src/lib.rs
+++ b/client/android/rust/src/lib.rs
@@ -11,7 +11,7 @@ use jni::sys::{jboolean, jstring};
 use jni::{jni_sig, jni_str, Env, EnvUnowned, JavaVM};
 use once_cell::sync::OnceCell;
 use serde::de::DeserializeOwned;
-use virtue_core::api::HttpApiClient;
+use virtue_core::api::{BugReportRequest, HttpApiClient};
 use virtue_core::{
     AuthState, Config, CoreError, CoreResult, Daemon, DeviceSettings, LifecycleHooks, Screenshot,
     ScreenshotHooks,
@@ -474,6 +474,87 @@ pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeGetSt
             .unwrap_or_else(|_| "{}".to_string()),
         )
     })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_virtueinitiative_virtue_NativeBridge_nativeReportIssue<'l>(
+    mut unowned_env: EnvUnowned<'l>,
+    _class: JClass<'l>,
+    message: JString<'l>,
+    contact_email: JString<'l>,
+    include_logs: jboolean,
+    platform_details: JString<'l>,
+) -> jstring {
+    native_result(&mut unowned_env, |_env| -> Result<()> {
+        let message: String = message.to_string();
+        let message = message.trim().to_string();
+        if message.is_empty() {
+            return Err(anyhow!("message is required"));
+        }
+        let contact_email: String = contact_email.to_string();
+        let contact_email = (!contact_email.is_empty()).then_some(contact_email);
+        let platform_details: String = platform_details.to_string();
+
+        let core = core()?;
+        let bearer_token = read_auth_state(&core.state_dir)
+            .and_then(|auth| auth.device_credentials)
+            .map(|creds| creds.refresh_token);
+
+        let logs = include_logs
+            .then(|| recent_logs(&core.state_dir))
+            .flatten();
+
+        let config = build_core_config(&core.state_dir);
+        let api = HttpApiClient::new(&config)?;
+        api.report_issue(
+            bearer_token.as_deref(),
+            &BugReportRequest {
+                message: &message,
+                contact_email: contact_email.as_deref(),
+                platform: "android",
+                app_version: virtue_core::BUILD_LABEL,
+                platform_details: Some(&platform_details),
+            },
+            logs.as_deref(),
+        )
+        .context("failed to submit bug report")?;
+
+        Ok(())
+    })
+}
+
+/// Best-effort last day of this device's operational logs: today's and (if
+/// present) yesterday's daily-rotated log file from `<state_dir>/logs` (see
+/// `init_logging`), redacted (`virtue_core::api::redact_secrets`) and trimmed
+/// to the API's attachment size cap, keeping the most recent bytes. Mirrors
+/// the Windows/Linux `report-issue` helpers of the same name.
+fn recent_logs(state_dir: &Path) -> Option<Vec<u8>> {
+    let log_dir = state_dir.join("logs");
+    let today = chrono::Local::now().date_naive();
+    let mut combined = String::new();
+
+    for date in [today, today - chrono::Duration::days(1)] {
+        let file_name = format!(
+            "{}.{}.log",
+            virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix,
+            date.format("%Y-%m-%d")
+        );
+        if let Ok(contents) = fs::read_to_string(log_dir.join(file_name)) {
+            combined.push_str(&contents);
+        }
+    }
+
+    if combined.is_empty() {
+        return None;
+    }
+
+    let redacted = virtue_core::api::redact_secrets(&combined);
+    let mut logs = redacted.into_bytes();
+    if logs.len() > virtue_core::api::MAX_LOG_ATTACHMENT_BYTES {
+        let start = logs.len() - virtue_core::api::MAX_LOG_ATTACHMENT_BYTES;
+        logs.drain(0..start);
+    }
+    Some(logs)
 }
 
 pub fn is_interactive(env: &mut Env) -> jni::errors::Result<bool> {


### PR DESCRIPTION
## AI;DR

Adds a report a bug button to Android.

<img width="389" height="321" alt="image" src="https://github.com/user-attachments/assets/e58ba367-823f-42b5-94d7-b3f346c3c8bc" />

<img width="367" height="558" alt="image" src="https://github.com/user-attachments/assets/fb872392-d8cd-491a-8e9c-75a370766511" />

<img width="389" height="243" alt="image" src="https://github.com/user-attachments/assets/5c986816-ec09-4e40-b048-4ae90e2e9de2" />

## Summary

- Adds a "Report a Bug" entry point to the Android client, mirroring the Windows implementation (`windows-bug-report-form` branch).
- The header card now has an always-visible "Report a Bug" link that opens a dialog collecting a required description, an optional contact email (prefilled from the signed-in account, if any), and an opt-out checkbox for including the last day of redacted diagnostic logs (same privacy caption as Windows).
- On submit, the report is sent via a new `nativeReportIssue` JNI entry point that reuses the shared Rust core bug-report helpers (`BugReportRequest`, `redact_secrets`, `MAX_LOG_ATTACHMENT_BYTES`, `HttpApiClient::report_issue`) — no bug-report logic is reimplemented, only the JNI boundary and log-file gathering are new.
- Adds `AccountEmailStore` (SharedPreferences-backed) to remember the signed-in account's email at the app layer, mirroring Windows' `ClientState.email`, since core's `AuthState`/`DeviceCredentials` don't carry the account email.

## Changes

Type of change: Feature
Components: Android

## Testing

- `cargo ndk -t arm64-v8a check` in `client/android/rust` — compiles clean.
- `./gradlew :app:compileDebugKotlin` — compiles clean.
- Built and installed the debug APK on the `virtue_api35` emulator (`va install`); app launches successfully. Have not yet manually exercised the new dialog/submission flow end-to-end against a live backend.