### PR TITLE
Mac client: add "Report a Bug" form

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -3851,6 +3851,7 @@ name = "virtue-mac-ffi"
 version = "0.0.8"
 dependencies = [
  "anyhow",
+ "chrono",
  "once_cell",
  "serde_json",
  "virtue-core",

--- a/client/mac/VirtueMac.xcodeproj/project.pbxproj
+++ b/client/mac/VirtueMac.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5188731D1EEC6BD5A5FFAF29 /* MonitoringCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC65E353F74300A665CAF36 /* MonitoringCoordinator.swift */; };
 		59CF74E58D6F876BC06C0E9D /* VirtueMacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41804153F1E76D2C46B7E251 /* VirtueMacApp.swift */; };
 		7FD43B539BE365F6C475A652 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72020BD32DBCC1A5559326B6 /* ApplicationServices.framework */; };
+		905CCFBCB7514CAA1814974C /* ReportBugSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECCC2D9A726133E6F5F5EE4 /* ReportBugSheet.swift */; };
 		F07E6593210A054AA700AB65 /* StatusSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF53D4E18246A0144F67A054 /* StatusSheet.swift */; };
 		FAA5A585CF46E803782F70E5 /* NativeBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2AC02ABF6297F0C75A1FDA /* NativeBridge.swift */; };
 /* End PBXBuildFile section */
@@ -26,6 +27,7 @@
 		694D4847EBC1A16DB15D473D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		72020BD32DBCC1A5559326B6 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ApplicationServices.framework; sourceTree = "<group>"; };
 		CF53D4E18246A0144F67A054 /* StatusSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSheet.swift; sourceTree = "<group>"; };
+		DECCC2D9A726133E6F5F5EE4 /* ReportBugSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportBugSheet.swift; sourceTree = "<group>"; };
 		FEC65E353F74300A665CAF36 /* MonitoringCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitoringCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -67,6 +69,7 @@
 				055BD2FE6FCEDDEC3BE4C0AF /* ContentView.swift */,
 				FEC65E353F74300A665CAF36 /* MonitoringCoordinator.swift */,
 				3C2AC02ABF6297F0C75A1FDA /* NativeBridge.swift */,
+				DECCC2D9A726133E6F5F5EE4 /* ReportBugSheet.swift */,
 				CF53D4E18246A0144F67A054 /* StatusSheet.swift */,
 				41804153F1E76D2C46B7E251 /* VirtueMacApp.swift */,
 			);
@@ -199,6 +202,7 @@
 				11B013F0E56013B1C6C6EC60 /* ContentView.swift in Sources */,
 				5188731D1EEC6BD5A5FFAF29 /* MonitoringCoordinator.swift in Sources */,
 				FAA5A585CF46E803782F70E5 /* NativeBridge.swift in Sources */,
+				905CCFBCB7514CAA1814974C /* ReportBugSheet.swift in Sources */,
 				F07E6593210A054AA700AB65 /* StatusSheet.swift in Sources */,
 				59CF74E58D6F876BC06C0E9D /* VirtueMacApp.swift in Sources */,
 			);

--- a/client/mac/app/Sources/ContentView.swift
+++ b/client/mac/app/Sources/ContentView.swift
@@ -7,6 +7,8 @@ struct ContentView: View {
     @State private var showStopConfirmation = false
     @State private var showLogoutConfirmation = false
     @State private var showStatusSheet = false
+    @State private var showReportBugSheet = false
+    @State private var showReportBugConfirmation = false
 
     var body: some View {
         ScrollView {
@@ -24,6 +26,16 @@ struct ContentView: View {
         .background(VirtueBrand.bg)
         .sheet(isPresented: $showStatusSheet) {
             StatusSheet(coordinator: coordinator)
+        }
+        .sheet(isPresented: $showReportBugSheet) {
+            ReportBugSheet(coordinator: coordinator) {
+                showReportBugConfirmation = true
+            }
+        }
+        .alert("Report Sent", isPresented: $showReportBugConfirmation) {
+            Button("OK") {}
+        } message: {
+            Text("Thanks — your report was sent to the Virtue Initiative team.")
         }
         .alert("Stop monitoring and quit?", isPresented: $showStopConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -92,6 +104,11 @@ struct ContentView: View {
                 HStack(spacing: 10) {
                     Button("Status Details") {
                         showStatusSheet = true
+                    }
+                    .buttonStyle(VirtueButtonStyle())
+
+                    Button("Report a Bug") {
+                        showReportBugSheet = true
                     }
                     .buttonStyle(VirtueButtonStyle())
 

--- a/client/mac/app/Sources/MonitoringCoordinator.swift
+++ b/client/mac/app/Sources/MonitoringCoordinator.swift
@@ -30,6 +30,7 @@ final class MonitoringCoordinator: ObservableObject {
     @Published private(set) var isSigningOut: Bool = false
     @Published private(set) var loginError: String?
     @Published private(set) var deviceId: String = "<none>"
+    @Published private(set) var accountEmail: String?
 
     @Published private(set) var daemonStatus: DaemonStatus = .stopped
     @Published private(set) var unexpectedStopMessage: String?
@@ -147,6 +148,23 @@ final class MonitoringCoordinator: ObservableObject {
             }.value
             isSigningOut = false
             refreshSessionState()
+        }
+    }
+
+    /// Submits a bug report, invoking `completion` with `nil` on success or an
+    /// error message on failure. Off-main like every other native call that
+    /// touches the network/daemon.
+    func submitBugReport(
+        message: String,
+        contactEmail: String?,
+        includeLogs: Bool,
+        completion: @escaping (String?) -> Void
+    ) {
+        Task {
+            let error = await Task.detached(priority: .userInitiated) {
+                NativeBridge.reportIssue(message: message, contactEmail: contactEmail, includeLogs: includeLogs)
+            }.value
+            completion(error)
         }
     }
 
@@ -305,6 +323,7 @@ final class MonitoringCoordinator: ObservableObject {
     private func refreshSessionState() {
         loggedIn = NativeBridge.isLoggedIn()
         deviceId = NativeBridge.getDeviceId() ?? "<none>"
+        accountEmail = NativeBridge.getAccountEmail()
     }
 
     private func refreshPermissionPhase() {

--- a/client/mac/app/Sources/NativeBridge.swift
+++ b/client/mac/app/Sources/NativeBridge.swift
@@ -13,11 +13,21 @@ private func virtue_mac_native_login(
 @_silgen_name("virtue_mac_native_logout")
 private func virtue_mac_native_logout() -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("virtue_mac_native_report_issue")
+private func virtue_mac_native_report_issue(
+    _ message: UnsafePointer<CChar>?,
+    _ contactEmail: UnsafePointer<CChar>?,
+    _ includeLogs: Bool
+) -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("virtue_mac_native_is_logged_in")
 private func virtue_mac_native_is_logged_in() -> Bool
 
 @_silgen_name("virtue_mac_native_get_device_id")
 private func virtue_mac_native_get_device_id() -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("virtue_mac_native_get_account_email")
+private func virtue_mac_native_get_account_email() -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("virtue_mac_native_get_status_json")
 private func virtue_mac_native_get_status_json() -> UnsafeMutablePointer<CChar>?
@@ -108,6 +118,16 @@ enum NativeBridge {
         }
     }
 
+    static func reportIssue(message: String, contactEmail: String?, includeLogs: Bool) -> String? {
+        callReturningError {
+            message.withCString { messageCString in
+                withOptionalCString(contactEmail) { contactEmailCString in
+                    virtue_mac_native_report_issue(messageCString, contactEmailCString, includeLogs)
+                }
+            }
+        }
+    }
+
     static func isLoggedIn() -> Bool {
         virtue_mac_native_is_logged_in()
     }
@@ -118,6 +138,10 @@ enum NativeBridge {
 
     static func getStatusJson() -> String? {
         consumeOptionalString(virtue_mac_native_get_status_json())
+    }
+
+    static func getAccountEmail() -> String? {
+        consumeOptionalString(virtue_mac_native_get_account_email())
     }
 
     static func pollDaemonStatus() -> DaemonStatus {
@@ -201,5 +225,15 @@ enum NativeBridge {
         _ call: () -> UnsafeMutablePointer<CChar>?
     ) -> String? {
         consumeOptionalString(call())
+    }
+
+    private static func withOptionalCString<Result>(
+        _ value: String?,
+        _ body: (UnsafePointer<CChar>?) -> Result
+    ) -> Result {
+        guard let value else {
+            return body(nil)
+        }
+        return value.withCString(body)
     }
 }

--- a/client/mac/app/Sources/ReportBugSheet.swift
+++ b/client/mac/app/Sources/ReportBugSheet.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import VirtueKit
+
+/// "Report a Bug" form, ported from the Windows client's `ShowReportBugDialogAsync`:
+/// a message box, an optional contact email (pre-filled when signed in), and an
+/// opt-out "include logs" checkbox with the same disclosure text.
+struct ReportBugSheet: View {
+    @ObservedObject var coordinator: MonitoringCoordinator
+    let onSent: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var message: String = ""
+    @State private var contactEmail: String = ""
+    @State private var includeLogs = true
+    @State private var isSending = false
+    @State private var errorText: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Report a Bug")
+                    .font(.headline)
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                .disabled(isSending)
+            }
+            .padding()
+
+            VStack(alignment: .leading, spacing: VirtueSpacing.s3) {
+                TextEditor(text: $message)
+                    .padding(.top, 10)
+                    .padding(.leading, 1)
+                    .frame(height: 120)
+                    .overlay(alignment: .topLeading) {
+                        if message.isEmpty {
+                            Text("Describe the issue")
+                                .foregroundStyle(VirtueBrand.textMuted)
+                                .padding(.top, 8)
+                                .padding(.leading, 5)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                    .padding(4)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VirtueRadius.button)
+                            .stroke(VirtueBrand.border)
+                    )
+
+                TextField("Contact email (optional)", text: $contactEmail)
+                    .textFieldStyle(.roundedBorder)
+
+                Toggle("Include the last two days of diagnostic logs", isOn: $includeLogs)
+
+                Text(
+                    "Includes timestamps, monitoring status, and error messages. " +
+                    "No screenshots or window titles are included. Known tokens are redacted automatically."
+                )
+                .font(.footnote)
+                .foregroundStyle(VirtueBrand.textMuted)
+
+                if let errorText {
+                    Text(errorText)
+                        .font(.subheadline)
+                        .foregroundStyle(VirtueBrand.danger)
+                }
+
+                Button(isSending ? "Sending…" : "Send Report") {
+                    send()
+                }
+                .buttonStyle(VirtueButtonStyle(prominent: true))
+                .disabled(isSending || message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding([.horizontal, .bottom])
+        }
+        .frame(width: 420)
+        .onAppear {
+            if contactEmail.isEmpty {
+                contactEmail = coordinator.accountEmail ?? ""
+            }
+        }
+    }
+
+    private func send() {
+        let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMessage.isEmpty else {
+            errorText = "Please describe the issue."
+            return
+        }
+
+        let trimmedEmail = contactEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        errorText = nil
+        isSending = true
+        coordinator.submitBugReport(
+            message: trimmedMessage,
+            contactEmail: trimmedEmail.isEmpty ? nil : trimmedEmail,
+            includeLogs: includeLogs
+        ) { error in
+            isSending = false
+            if let error {
+                errorText = error
+                return
+            }
+            dismiss()
+            onSent()
+        }
+    }
+}

--- a/client/mac/rust/Cargo.toml
+++ b/client/mac/rust/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["staticlib"]
 anyhow = "1"
 virtue_core = { package = "virtue-core", path = "../../core" }
 virtue_mac_platform = { package = "virtue-mac", path = ".." }
+chrono = { version = "0.4", features = ["clock"] }
 once_cell = "1"
 serde_json = "1"

--- a/client/mac/rust/src/lib.rs
+++ b/client/mac/rust/src/lib.rs
@@ -1,13 +1,16 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use anyhow::{Context, Result, anyhow};
 use once_cell::sync::OnceCell;
 use virtue_core::AuthState;
 use virtue_core::ipc::ClientController;
 use virtue_mac_platform::capture::{has_screen_capture_access, request_screen_capture_access};
-use virtue_mac_platform::config::{ClientPaths, ClientState, read_auth_state, save_state};
+use virtue_mac_platform::config::{
+    ClientPaths, ClientState, build_core_config, read_auth_state, save_state,
+};
 use virtue_mac_platform::launch_agent;
 
 static CORE: OnceCell<MacCore> = OnceCell::new();
@@ -80,6 +83,129 @@ pub extern "C" fn virtue_mac_native_logout() -> *mut c_char {
     into_c_result(result)
 }
 
+/// Submits `POST /bug-report` (API-042). `contact_email` is treated as unset
+/// when blank. Reads the device's refresh token straight off disk, same
+/// disk-fallback approach Linux/Windows use, so a report can be attributed to
+/// this device even when the resident daemon isn't reachable over IPC;
+/// gathers macOS version info via `sw_vers`; and, when `include_logs` is
+/// true, reads/redacts/trims the last two days of the daemon's own
+/// rotated log files (`paths.logs_dir`) for the optional attachment.
+#[unsafe(no_mangle)]
+pub extern "C" fn virtue_mac_native_report_issue(
+    message: *const c_char,
+    contact_email: *const c_char,
+    include_logs: bool,
+) -> *mut c_char {
+    let result = (|| -> Result<()> {
+        let core = core()?;
+        let message = c_string_or_empty(message).trim().to_string();
+        if message.is_empty() {
+            return Err(anyhow!("message is required"));
+        }
+        let contact_email = c_string_or_empty(contact_email);
+        let contact_email =
+            (!contact_email.trim().is_empty()).then(|| contact_email.trim().to_string());
+
+        let bearer_token = local_auth_state(core)
+            .device_credentials
+            .map(|creds| creds.refresh_token);
+
+        let platform_details = mac_platform_details();
+        let logs = include_logs.then(|| recent_logs(&core.paths)).flatten();
+
+        let config = build_core_config(&core.paths);
+        let api = virtue_core::api::HttpApiClient::new(&config)?;
+        api.report_issue(
+            bearer_token.as_deref(),
+            &virtue_core::api::BugReportRequest {
+                message: &message,
+                contact_email: contact_email.as_deref(),
+                platform: "macos",
+                app_version: virtue_core::BUILD_LABEL,
+                platform_details: Some(&platform_details),
+            },
+            logs.as_deref(),
+        )
+        .context("failed to submit bug report")?;
+        Ok(())
+    })();
+    into_c_result(result)
+}
+
+/// Best-effort "ProductName ProductVersion (Build BuildVersion)" string via
+/// `sw_vers`, e.g. `"macOS 14.5 (Build 23F79)"`. Falls back to a fixed
+/// placeholder on any error, mirroring the Windows client's registry-read
+/// fallback in `windows_platform_details`.
+fn mac_platform_details() -> String {
+    let product_name = sw_vers("-productName");
+    let product_version = sw_vers("-productVersion");
+    let build_version = sw_vers("-buildVersion");
+
+    let mut parts = Vec::new();
+    if let Some(product_name) = product_name {
+        parts.push(product_name);
+    }
+
+    let version_part = match (product_version, build_version) {
+        (Some(version), Some(build)) => Some(format!("{version} (Build {build})")),
+        (Some(version), None) => Some(version),
+        (None, Some(build)) => Some(format!("Build {build}")),
+        (None, None) => None,
+    };
+    if let Some(version_part) = version_part {
+        parts.push(version_part);
+    }
+
+    if parts.is_empty() {
+        "macOS (unknown version)".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+fn sw_vers(flag: &str) -> Option<String> {
+    Command::new("sw_vers")
+        .arg(flag)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Best-effort last two days of this device's daemon logs: today's and (if
+/// present) yesterday's daily-rotated log file from `paths.logs_dir` (see
+/// `daemon::init_logging`), redacted (`virtue_core::api::redact_secrets`) and
+/// trimmed to the API's attachment size cap, keeping the most recent bytes.
+fn recent_logs(paths: &ClientPaths) -> Option<Vec<u8>> {
+    let today = chrono::Local::now().date_naive();
+    let mut combined = String::new();
+
+    for date in [today, today - chrono::Duration::days(1)] {
+        let file_name = format!(
+            "{}.{}.log",
+            virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix,
+            date.format("%Y-%m-%d")
+        );
+        if let Ok(contents) = std::fs::read_to_string(paths.logs_dir.join(file_name)) {
+            combined.push_str(&contents);
+        }
+    }
+
+    if combined.is_empty() {
+        return None;
+    }
+
+    let redacted = virtue_core::api::redact_secrets(&combined);
+    let mut logs = redacted.into_bytes();
+    if logs.len() > virtue_core::api::MAX_LOG_ATTACHMENT_BYTES {
+        let start = logs.len() - virtue_core::api::MAX_LOG_ATTACHMENT_BYTES;
+        logs.drain(0..start);
+    }
+    Some(logs)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn virtue_mac_native_is_logged_in() -> bool {
     core()
@@ -94,6 +220,18 @@ pub extern "C" fn virtue_mac_native_get_device_id() -> *mut c_char {
         .and_then(|c| local_auth_state(c).device_credentials)
         .map(|d| d.device_id);
     optional_string_to_c(device_id)
+}
+
+/// The email address of the currently signed-in account, persisted to
+/// `ui_state_file` at login (see `virtue_mac_native_login`), or null when
+/// signed out. Used to pre-fill the "Report a Bug" contact-email field.
+#[unsafe(no_mangle)]
+pub extern "C" fn virtue_mac_native_get_account_email() -> *mut c_char {
+    let email = core()
+        .ok()
+        .and_then(|c| virtue_mac_platform::config::load_state(&c.paths.ui_state_file).ok())
+        .and_then(|state| state.email);
+    optional_string_to_c(email)
 }
 
 /// Returns a JSON-serialized `ServiceStatus` (caller frees with
@@ -297,6 +435,6 @@ fn optional_string_to_c(value: Option<String>) -> *mut c_char {
 fn into_c_result(result: Result<()>) -> *mut c_char {
     match result {
         Ok(()) => std::ptr::null_mut(),
-        Err(err) => string_to_c(err.to_string()),
+        Err(err) => string_to_c(format!("{err:#}")),
     }
 }

--- a/client/mac/src/daemon.rs
+++ b/client/mac/src/daemon.rs
@@ -22,9 +22,10 @@ const LOCAL_SUSPEND_MIN_MS: i64 = 5_000;
 type MacDaemon = Daemon<MacPlatformHooks, HttpApiClient>;
 
 /// Installs the process-wide `tracing` subscriber, writing daily-rotated
-/// plain-text logs to `paths.logs_dir` (`~/Library/Logs/virtue.log`). The
-/// returned guard must be kept alive for the life of the process — dropping
-/// it stops the background writer thread that flushes buffered log lines.
+/// plain-text logs to `paths.logs_dir` (`~/Library/Logs/virtue.<date>.log`).
+/// The returned guard must be kept alive for the life of the process —
+/// dropping it stops the background writer thread that flushes buffered log
+/// lines.
 ///
 /// A launchd stdout/stderr redirect (see `launch_agent.rs`) remains as a
 /// fallback safety net for output emitted before this installs, or panics
@@ -43,24 +44,45 @@ pub fn init_logging(paths: &ClientPaths) -> tracing_appender::non_blocking::Work
         eprintln!("failed to prune old logs: {err}");
     }
 
-    let file_appender = tracing_appender::rolling::daily(
-        &paths.logs_dir,
-        virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix,
-    );
-    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+    // Matches the Windows client's `Builder` usage: an explicit `.log` suffix
+    // (the plain `rolling::daily` constructor leaves the filename extensionless,
+    // e.g. `virtue.2026-08-22` with no suffix at all).
+    let file_appender = tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::DAILY)
+        .filename_prefix(virtue_core::logging::DEFAULT_FILE_LOG_POLICY.file_name_prefix)
+        .filename_suffix("log")
+        .build(&paths.logs_dir);
 
     let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         tracing_subscriber::EnvFilter::new(virtue_core::logging::default_filter_directive(cfg!(
             debug_assertions
         )))
     });
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(non_blocking)
-        .with_ansi(false)
-        .init();
 
-    guard
+    match file_appender {
+        Ok(file_appender) => {
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .init();
+            guard
+        }
+        Err(err) => {
+            eprintln!(
+                "failed to open log file in {}: {err}",
+                paths.logs_dir.display()
+            );
+            let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stderr());
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .init();
+            guard
+        }
+    }
 }
 
 pub fn run_daemon(paths: &ClientPaths) -> Result<()> {


### PR DESCRIPTION
## AI;DR

<img width="611" height="798" alt="image" src="https://github.com/user-attachments/assets/48a30c10-3b5d-4990-b7ef-2710399f5d27" />

<img width="611" height="798" alt="image" src="https://github.com/user-attachments/assets/7ecb54de-ecff-4524-8c3b-55c98d29db86" />

## Summary

Adds a "Report a Bug" entry point to the macOS SwiftUI client, matching the Windows client's form (#599) and reusing the same platform-agnostic `virtue_core::api::{BugReportRequest, HttpApiClient::report_issue, redact_secrets, MAX_LOG_ATTACHMENT_BYTES}` helpers Linux and Windows already use.

## Changes

**Type of change:** Feature
**Components:** Mac

- `client/mac/rust/src/lib.rs`: new `virtue_mac_native_report_issue` FFI export. Reads the device's refresh token off `event_state.json` (same disk-fallback approach Linux/Windows use) so signed-in reports carry device identity; gathers macOS version info via `sw_vers`; and reads/redacts/trims the last two days of the daemon's own rotated log files (`recent_logs`) for the optional attachment. Also adds `virtue_mac_native_get_account_email` so the UI can pre-fill the contact-email field for signed-in users.
- `client/mac/rust/src/lib.rs`: `into_c_result` now formats errors with `{err:#}` (the full `anyhow` causal chain) instead of `err.to_string()` (only the outermost context message), matching Windows — found while debugging an anonymous submission that surfaced only "failed to submit bug report" with no indication of the real cause.
- `client/mac/src/daemon.rs`: `init_logging` switches from the bare `tracing_appender::rolling::daily` constructor to the same `Builder` Windows uses with an explicit `.log` filename suffix. Mac's log files were previously extensionless (`virtue.2026-08-22`); the new FFI's log-attachment lookup expects `virtue.<date>.log` like Windows, and this makes that actually true instead of silently finding nothing.
- SwiftUI (`Virtue.WindowsApp` equivalent — `VirtueMac` target): new `ReportBugSheet.swift` form (description, optional contact email pre-filled when signed in, an opt-out "include logs" toggle with the required disclosure text) and a matching "Report a Bug" button next to "Status Details" in `ContentView.swift`, routed through a new `MonitoringCoordinator.submitBugReport` and `NativeBridge.reportIssue`/`getAccountEmail`.
- `client/mac/VirtueMac.xcodeproj/project.pbxproj`: regenerated via `xcodegen` to pick up the new `ReportBugSheet.swift` source file.

## Testing

- `cargo check` / `cargo clippy -p virtue-mac -p virtue-mac-ffi -- -D warnings` / `cargo fmt -p virtue-mac -p virtue-mac-ffi -- --check` all pass clean.
- Built the full signed DMG locally (`scripts/build-dmg.sh --arch x86_64 --profile debug`) and manually tested the "Report a Bug" flow end to end in the running app (signed out), including the logs-attached path after fixing the log-file-extension mismatch — confirmed working.