### PR TITLE
Windows client: auto-install Store updates at a safe point

### DIFF
--- a/client/windows/README.md
+++ b/client/windows/README.md
@@ -174,6 +174,41 @@ Remote logs are always written locally under:
 - The app registers a per-user Scheduled Task (`VirtueResidentWatchdog`, every 1 minute — Task Scheduler's floor for a repeating trigger, confirmed against `schtasks.exe` on this repo's `virtue-win11` VM: a sub-minute `Interval` is rejected as out of range even via an XML task definition) at startup that relaunches `Virtue.WindowsApp.exe` if it isn't running, covering accidental crashes/hangs. The app's existing single-instance redirect makes each periodic relaunch attempt a no-op while the app is already running, so the task doesn't need its own "is it running" check, and the relaunch comes back into the tray quietly (same as the startup task). Tray `Exit` deletes the task first so a deliberate exit isn't resurrected. Windows' Application Recovery and Restart API (`RegisterApplicationRestart`) was tried first but does not automatically relaunch MSIX-packaged apps (confirmed both by community reports and by testing on this repo's `virtue-win11` VM: registration succeeds and WER correctly reports the crash/hang, but no relaunch follows), hence the Scheduled Task instead. See `Virtue.WindowsApp.Core/Interop/RestartWatchdog.cs` and `Virtue.WindowsApp/App.xaml.cs`. The `client/core` late-wakeup tamper threshold (`client/core/SPEC.md` §2) was raised from 1 to 2 minutes so a normal ~1-minute watchdog relaunch doesn't itself trip the tamper alert.
 - `client/core` is intentionally unchanged by this architecture; Windows-specific behavior lives under `client/windows/`.
 
+## Store Update Handling
+
+`StoreUpdateManager` (`Virtue.WindowsApp/Update/StoreUpdateManager.cs`) checks the Microsoft
+Store for package updates every 4 hours via `StoreContext.GetAppAndOptionalStorePackageUpdatesAsync`,
+and if one is found, downloads/stages it in the background via
+`RequestDownloadStorePackageUpdatesAsync` — this does not require the resident daemon to stop.
+It lives in `Virtue.WindowsApp` (the WinUI project, `net8.0-windows10.0.19041.0`) rather than
+`Virtue.WindowsApp.Core` (plain `net8.0`, no Windows SDK projection, kept that way so it stays
+unit-testable and platform-neutral — the same reason `RestartWatchdog` avoids WinRT), since
+`StoreContext` is a WinRT API only usable from the packaged process.
+
+Once an update is staged, `App.xaml.cs` polls every 5 minutes for a safe point to install it —
+`UpdateRestartPolicy.ShouldRestartNow` (`Virtue.WindowsApp.Core/Interop/UpdateRestartPolicy.cs`,
+unit-tested) requires the settings/login window to be hidden and no login/logout in progress
+(`SessionViewModel.IsBusy`), but forces the restart through after a 6-hour deferral cap even if
+the window stays open. A tray "Restart to Update" menu item lets a user trigger it immediately
+instead of waiting. Either path stops the daemon the same way an OS session logoff/shutdown
+does (`RustInteropClient.StopMonitoringForOsSessionEnd`, **not** the tray-Exit path — this is
+not a user-initiated stop and must not log the device out), then calls
+`RequestDownloadAndInstallStorePackageUpdatesAsync` (fast, since the package was already staged)
+and exits. `RestartWatchdog` is deliberately left registered through this (unlike tray Exit) so
+its existing per-minute poll relaunches the updated build, and the released
+`AppLifecycleInstance` key means the relaunched process becomes the new primary instance with
+no extra code, exactly like a crash-recovery relaunch.
+
+There is no data-corruption risk from installing mid-tick: `DaemonState` is persisted after
+every tick and uploads use persisted backoff, so `stop_monitoring()` can only ever wait for an
+in-flight tick to finish (never truncate it) before returning — the same property that already
+makes `RestartWatchdog` safe for crash recovery. The one real cost is that this restart is
+**not** eligible for CORE-002's `note_user_stop` excuse (only an actual user-initiated stop may
+use it), so it's recorded as ordinary late-wakeup lateness — but that's exactly the gap shape
+crash-recovery relaunches already produce, which is what the 1-to-2-minute threshold bump
+described above already accounts for. No `client/core`/SPEC.md changes were needed for this
+feature.
+
 ## Runtime Data Locations
 
 The WinUI app and Rust resident monitoring host share state under `%PROGRAMDATA%\Virtue`:

--- a/client/windows/Virtue.WindowsApp.Core/Interop/UpdateRestartPolicy.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Interop/UpdateRestartPolicy.cs
@@ -1,0 +1,39 @@
+namespace Virtue.WindowsApp.Core.Interop;
+
+/// <summary>
+/// Pure decision logic for when a staged Store update is safe to install. Kept free of
+/// WinRT/OS dependencies so it's unit-testable, unlike <see cref="StoreUpdateManager"/> and
+/// <see cref="RestartWatchdog"/> which are thin OS glue.
+///
+/// The daemon itself has no data-corruption window to protect against here — see
+/// <see cref="StoreUpdateManager"/>'s doc comment for why. What this policy actually guards
+/// is UX: don't restart out from under an actively-interacting user or mid-login. A deferral
+/// cap forces the restart through even if the window happens to stay open indefinitely.
+/// </summary>
+public static class UpdateRestartPolicy
+{
+    public static readonly TimeSpan DeferralCap = TimeSpan.FromHours(6);
+
+    /// <param name="mainWindowVisible">Whether the settings/login window is currently shown to the user.</param>
+    /// <param name="sessionIsBusy">Whether <c>SessionViewModel.IsBusy</c> is set (e.g. a login/logout in progress).</param>
+    /// <param name="updateStagedAtUtc">When the update finished downloading/staging.</param>
+    /// <param name="nowUtc">Current time, passed in for testability.</param>
+    public static bool ShouldRestartNow(
+        bool mainWindowVisible,
+        bool sessionIsBusy,
+        DateTimeOffset updateStagedAtUtc,
+        DateTimeOffset nowUtc)
+    {
+        if (sessionIsBusy)
+        {
+            return false;
+        }
+
+        if (!mainWindowVisible)
+        {
+            return true;
+        }
+
+        return nowUtc - updateStagedAtUtc >= DeferralCap;
+    }
+}

--- a/client/windows/Virtue.WindowsApp.Core/Tray/ITrayIconHost.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/ITrayIconHost.cs
@@ -5,6 +5,7 @@ public interface ITrayIconHost : IDisposable
     event EventHandler? OpenRequested;
     event EventHandler? ExitRequested;
     event EventHandler? ReportBugRequested;
+    event EventHandler? RestartToUpdateRequested;
     event EventHandler? SessionLogoffObserved;
     event EventHandler? SystemShutdownObserved;
 

--- a/client/windows/Virtue.WindowsApp.Core/Tray/NullTrayIconHost.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/NullTrayIconHost.cs
@@ -5,6 +5,7 @@ public sealed class NullTrayIconHost : ITrayIconHost
     public event EventHandler? OpenRequested;
     public event EventHandler? ExitRequested;
     public event EventHandler? ReportBugRequested;
+    public event EventHandler? RestartToUpdateRequested;
     public event EventHandler? SessionLogoffObserved;
     public event EventHandler? SystemShutdownObserved;
 
@@ -21,6 +22,8 @@ public sealed class NullTrayIconHost : ITrayIconHost
     public void RequestExit() => ExitRequested?.Invoke(this, EventArgs.Empty);
 
     public void RequestReportBug() => ReportBugRequested?.Invoke(this, EventArgs.Empty);
+
+    public void RequestRestartToUpdate() => RestartToUpdateRequested?.Invoke(this, EventArgs.Empty);
 
     public void RequestSessionLogoff() => SessionLogoffObserved?.Invoke(this, EventArgs.Empty);
 

--- a/client/windows/Virtue.WindowsApp.Core/Tray/TrayMenuController.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/TrayMenuController.cs
@@ -10,6 +10,7 @@ public sealed class TrayMenuController : IDisposable
         _host.OpenRequested += (_, _) => OpenRequested?.Invoke(this, EventArgs.Empty);
         _host.ExitRequested += (_, _) => ExitRequested?.Invoke(this, EventArgs.Empty);
         _host.ReportBugRequested += (_, _) => ReportBugRequested?.Invoke(this, EventArgs.Empty);
+        _host.RestartToUpdateRequested += (_, _) => RestartToUpdateRequested?.Invoke(this, EventArgs.Empty);
         _host.SessionLogoffObserved += (_, _) => SessionLogoffObserved?.Invoke(this, EventArgs.Empty);
         _host.SystemShutdownObserved += (_, _) => SystemShutdownObserved?.Invoke(this, EventArgs.Empty);
     }
@@ -17,6 +18,7 @@ public sealed class TrayMenuController : IDisposable
     public event EventHandler? OpenRequested;
     public event EventHandler? ExitRequested;
     public event EventHandler? ReportBugRequested;
+    public event EventHandler? RestartToUpdateRequested;
     public event EventHandler? SessionLogoffObserved;
     public event EventHandler? SystemShutdownObserved;
 

--- a/client/windows/Virtue.WindowsApp.Core/Tray/WindowsTrayIconHost.cs
+++ b/client/windows/Virtue.WindowsApp.Core/Tray/WindowsTrayIconHost.cs
@@ -25,6 +25,7 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
     private const int IdTrayOpen = 2001;
     private const int IdTrayExit = 2002;
     private const int IdTrayReportBug = 2003;
+    private const int IdTrayRestartToUpdate = 2004;
     private const int WindowId = 1;
     private static readonly uint WmTrayIcon = WmApp + 1;
 
@@ -46,6 +47,7 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
     public event EventHandler? OpenRequested;
     public event EventHandler? ExitRequested;
     public event EventHandler? ReportBugRequested;
+    public event EventHandler? RestartToUpdateRequested;
     public event EventHandler? SessionLogoffObserved;
     public event EventHandler? SystemShutdownObserved;
 
@@ -80,6 +82,7 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
         _menuHandle = CreatePopupMenu();
         _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayOpen, "Open");
         _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayReportBug, "Report a Bug");
+        _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayRestartToUpdate, "Restart to Update");
         _ = AppendMenu(_menuHandle, MfString, (UIntPtr)IdTrayExit, "Exit");
 
         AddOrUpdateIcon(NimAdd);
@@ -234,6 +237,10 @@ public sealed class WindowsTrayIconHost : ITrayIconHost
                 else if (command == IdTrayReportBug)
                 {
                     ReportBugRequested?.Invoke(this, EventArgs.Empty);
+                }
+                else if (command == IdTrayRestartToUpdate)
+                {
+                    RestartToUpdateRequested?.Invoke(this, EventArgs.Empty);
                 }
                 else if (command == IdTrayExit)
                 {

--- a/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
+++ b/client/windows/Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs
@@ -27,6 +27,7 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     private bool _hasUserEditedEmailInput;
     private string? _transitionMessage;
     private string? _errorText;
+    private bool _updateReady;
 
     public SessionViewModel(IRustInteropClient interopClient, string? windowsPackageVersion = null)
     {
@@ -181,6 +182,9 @@ public sealed class SessionViewModel : INotifyPropertyChanged
     public string MonitorStateDisplay => MonitorState.Replace('_', ' ');
 
     public string TrayTooltip =>
+        BaseTrayTooltip + (_updateReady ? " (update ready)" : string.Empty);
+
+    private string BaseTrayTooltip =>
         MonitorState switch
         {
             "loading" => "Virtue: loading status",
@@ -192,6 +196,20 @@ public sealed class SessionViewModel : INotifyPropertyChanged
             "signed_out" => "Virtue: sign in required",
             _ => "Virtue: monitoring stopped",
         };
+
+    /// <summary>
+    /// Called once a Store update has finished downloading/staging, so the tray tooltip
+    /// reflects it. See <c>Virtue.WindowsApp.Update.StoreUpdateManager</c>.
+    /// </summary>
+    public void NotifyUpdateStaged()
+    {
+        if (SetProperty(ref _updateReady, true, nameof(UpdateReady)))
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TrayTooltip)));
+        }
+    }
+
+    public bool UpdateReady => _updateReady;
 
     public bool IsBusy
     {

--- a/client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs
+++ b/client/windows/Virtue.WindowsApp.Tests/SessionViewModelTests.cs
@@ -21,6 +21,18 @@ public sealed class SessionViewModelTests
     }
 
     [Fact]
+    public void NotifyUpdateStaged_AppendsUpdateReadySuffixToTrayTooltip()
+    {
+        var fakeClient = new FakeRustInteropClient();
+        var viewModel = new SessionViewModel(fakeClient, "0.0.5.1234");
+
+        viewModel.NotifyUpdateStaged();
+
+        Assert.True(viewModel.UpdateReady);
+        Assert.Equal("Virtue: loading status (update ready)", viewModel.TrayTooltip);
+    }
+
+    [Fact]
     public async Task LoginAsync_RefreshesStatusAfterSuccess()
     {
         var fakeClient = new FakeRustInteropClient
@@ -351,6 +363,20 @@ public sealed class SessionViewModelTests
         host.RequestReportBug();
 
         Assert.True(reportBugRaised);
+    }
+
+    [Fact]
+    public void TrayMenuController_RoutesRestartToUpdateEvent()
+    {
+        var host = new NullTrayIconHost();
+        var controller = new TrayMenuController(host);
+        var restartToUpdateRaised = false;
+
+        controller.RestartToUpdateRequested += (_, _) => restartToUpdateRaised = true;
+
+        host.RequestRestartToUpdate();
+
+        Assert.True(restartToUpdateRaised);
     }
 
     [Fact]

--- a/client/windows/Virtue.WindowsApp.Tests/UpdateRestartPolicyTests.cs
+++ b/client/windows/Virtue.WindowsApp.Tests/UpdateRestartPolicyTests.cs
@@ -1,0 +1,49 @@
+using Virtue.WindowsApp.Core.Interop;
+using Xunit;
+
+namespace Virtue.WindowsApp.Tests;
+
+public sealed class UpdateRestartPolicyTests
+{
+    private static readonly DateTimeOffset StagedAt = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Busy_NeverRestarts_RegardlessOfWindowOrTime()
+    {
+        Assert.False(UpdateRestartPolicy.ShouldRestartNow(
+            mainWindowVisible: false,
+            sessionIsBusy: true,
+            updateStagedAtUtc: StagedAt,
+            nowUtc: StagedAt + UpdateRestartPolicy.DeferralCap + TimeSpan.FromDays(1)));
+    }
+
+    [Fact]
+    public void WindowHidden_AndNotBusy_RestartsImmediately()
+    {
+        Assert.True(UpdateRestartPolicy.ShouldRestartNow(
+            mainWindowVisible: false,
+            sessionIsBusy: false,
+            updateStagedAtUtc: StagedAt,
+            nowUtc: StagedAt));
+    }
+
+    [Fact]
+    public void WindowVisible_UnderDeferralCap_DoesNotRestart()
+    {
+        Assert.False(UpdateRestartPolicy.ShouldRestartNow(
+            mainWindowVisible: true,
+            sessionIsBusy: false,
+            updateStagedAtUtc: StagedAt,
+            nowUtc: StagedAt + UpdateRestartPolicy.DeferralCap - TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public void WindowVisible_AtOrPastDeferralCap_AndNotBusy_ForcesRestart()
+    {
+        Assert.True(UpdateRestartPolicy.ShouldRestartNow(
+            mainWindowVisible: true,
+            sessionIsBusy: false,
+            updateStagedAtUtc: StagedAt,
+            nowUtc: StagedAt + UpdateRestartPolicy.DeferralCap));
+    }
+}

--- a/client/windows/Virtue.WindowsApp/App.xaml.cs
+++ b/client/windows/Virtue.WindowsApp/App.xaml.cs
@@ -7,6 +7,7 @@ using WinRT;
 using Virtue.WindowsApp.Core.Tray;
 using Virtue.WindowsApp.Core.Interop;
 using Virtue.WindowsApp.Core.ViewModels;
+using Virtue.WindowsApp.Update;
 using WinUiLaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
 using StartupTaskActivatedEventArgs = Windows.ApplicationModel.Activation.StartupTaskActivatedEventArgs;
 using AppLifecycleInstance = Microsoft.Windows.AppLifecycle.AppInstance;
@@ -22,6 +23,10 @@ public partial class App : Application
     private CancellationTokenSource? _refreshLoopCancellation;
     private AppLifecycleInstance? _mainInstance;
     private DispatcherQueue? _dispatcherQueue;
+    private StoreUpdateManager? _updateManager;
+    private CancellationTokenSource? _safePointPollCancellation;
+    private DateTimeOffset? _updateStagedAtUtc;
+    private static readonly TimeSpan SafePointPollInterval = TimeSpan.FromMinutes(5);
     private static readonly string StartupLogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
         "Virtue",
@@ -59,6 +64,7 @@ public partial class App : Application
             _trayController.OpenRequested += (_, _) => ShowMainWindow();
             _trayController.ExitRequested += async (_, _) => await RequestResidentShutdownAsync();
             _trayController.ReportBugRequested += async (_, _) => await ShowReportBugFromTrayAsync();
+            _trayController.RestartToUpdateRequested += (_, _) => _ = HandleManualRestartToUpdateAsync();
             _trayController.SessionLogoffObserved += (_, _) => HandleSessionLogoff();
             _trayController.SystemShutdownObserved += (_, _) => HandleSystemShutdown();
             _trayController.Initialize();
@@ -69,6 +75,11 @@ public partial class App : Application
             StartRefreshLoop();
 
             RegisterWatchdog();
+
+            _updateManager = new StoreUpdateManager();
+            _updateManager.UpdateStaged += (_, _) => OnUpdateStaged();
+            _updateManager.UpdateCheckFailed += (_, reason) => LogStartup($"Store update check/download failed: {reason}");
+            _updateManager.Start();
 
             var activation = AppLifecycleInstance.GetCurrent().GetActivatedEventArgs();
             if (!IsQuietActivation(activation))
@@ -292,6 +303,8 @@ public partial class App : Application
         {
             RestartWatchdog.Unregister();
             _refreshLoopCancellation?.Cancel();
+            _safePointPollCancellation?.Cancel();
+            _updateManager?.Dispose();
             if (_viewModel is not null)
             {
                 if (_viewModel.LoggedIn)
@@ -383,6 +396,88 @@ public partial class App : Application
         catch (Exception ex)
         {
             LogStartup($"System shutdown lifecycle handling failed: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Fired once <see cref="StoreUpdateManager"/> finishes downloading/staging an update.
+    /// Reflects the state in the tray tooltip and starts polling for a safe point to install
+    /// it — see <c>UpdateRestartPolicy.ShouldRestartNow</c> for what "safe" means here.
+    /// </summary>
+    private void OnUpdateStaged()
+    {
+        _updateStagedAtUtc = DateTimeOffset.UtcNow;
+        _ = _dispatcherQueue?.TryEnqueue(() => _viewModel?.NotifyUpdateStaged());
+        LogStartup("Store update staged; polling for a safe restart point.");
+
+        _safePointPollCancellation?.Cancel();
+        _safePointPollCancellation = new CancellationTokenSource();
+        var token = _safePointPollCancellation.Token;
+        _ = Task.Run(async () =>
+        {
+            using var timer = new PeriodicTimer(SafePointPollInterval);
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                var mainWindowVisible = _mainWindow?.IsVisibleToUser ?? false;
+                var sessionIsBusy = _viewModel?.IsBusy ?? false;
+                var stagedAtUtc = _updateStagedAtUtc ?? DateTimeOffset.UtcNow;
+
+                if (UpdateRestartPolicy.ShouldRestartNow(mainWindowVisible, sessionIsBusy, stagedAtUtc, DateTimeOffset.UtcNow))
+                {
+                    _ = InstallUpdateAndRestartAsync();
+                    return;
+                }
+            }
+        }, token);
+    }
+
+    /// <summary>
+    /// The tray "Restart to Update" menu item's handler — an explicit user request always
+    /// proceeds immediately, bypassing the safe-point poll (unlike the automatic path).
+    /// </summary>
+    private async Task HandleManualRestartToUpdateAsync()
+    {
+        if (_updateManager?.IsUpdateStaged != true)
+        {
+            return;
+        }
+
+        await InstallUpdateAndRestartAsync();
+    }
+
+    /// <summary>
+    /// Stops resident monitoring the same way an OS session logoff/shutdown does (NOT the
+    /// tray-exit path — this must not be treated as a user-initiated stop for CORE-002
+    /// purposes, and it must not log the device out), installs the staged Store update, and
+    /// exits. `RestartWatchdog` is deliberately left registered (unlike tray Exit) so its
+    /// existing per-minute poll relaunches the updated build.
+    /// </summary>
+    private async Task InstallUpdateAndRestartAsync()
+    {
+        _safePointPollCancellation?.Cancel();
+        // MainWindow is a WinRT object with UI-thread affinity; this method may run on a
+        // background poll thread (the automatic safe-point path) as well as the UI thread
+        // (the manual tray-menu path), so always marshal the hide through the dispatcher.
+        _ = _dispatcherQueue?.TryEnqueue(() => _mainWindow?.HideToTray());
+
+        try
+        {
+            _refreshLoopCancellation?.Cancel();
+            new RustInteropClient().StopMonitoringForOsSessionEnd();
+            LogStartup("Stopped resident monitoring for Store update install.");
+
+            var installed = await _updateManager!.TryInstallStagedUpdateAsync();
+            LogStartup($"Update install call returned (installed={installed}).");
+        }
+        catch (Exception ex)
+        {
+            LogStartup($"Update install failed: {ex}");
+        }
+        finally
+        {
+            // Application.Exit() also has UI-thread affinity — same reasoning as the
+            // HideToTray() marshal above.
+            _ = _dispatcherQueue?.TryEnqueue(() => Current.Exit());
         }
     }
 

--- a/client/windows/Virtue.WindowsApp/Update/StoreUpdateManager.cs
+++ b/client/windows/Virtue.WindowsApp/Update/StoreUpdateManager.cs
@@ -1,0 +1,145 @@
+using Windows.Services.Store;
+
+namespace Virtue.WindowsApp.Update;
+
+/// <summary>
+/// Detects, downloads, and installs Microsoft Store package updates for this MSIX app.
+///
+/// This lives in <c>Virtue.WindowsApp</c> (not <c>Virtue.WindowsApp.Core</c>, which targets
+/// plain <c>net8.0</c> with no Windows SDK/WinRT projection so it stays unit-testable and
+/// platform-neutral — see how <c>RestartWatchdog</c> avoids WinRT entirely for the same
+/// reason) because <see cref="StoreContext"/> is a WinRT API only usable from the packaged
+/// WinUI process.
+///
+/// Detect and download are deliberately kept separate from install:
+///  - <see cref="CheckOnceAsync"/> only calls <c>GetAppAndOptionalStorePackageUpdatesAsync</c>
+///    and <c>RequestDownloadStorePackageUpdatesAsync</c>, both of which run in the background
+///    without requiring the app to stop — see the task-level design notes captured in
+///    the implementation plan for this feature.
+///  - <see cref="TryInstallStagedUpdateAsync"/> (which calls
+///    <c>RequestDownloadAndInstallStorePackageUpdatesAsync</c> — a fast install-only pass
+///    since the update was already staged by the download step) is only ever invoked by
+///    <c>App.xaml.cs</c> once it has stopped the resident monitoring daemon at a safe point.
+///
+/// No changes were made to `client/core`'s tamper-detection budget (CORE-002) for this: an
+/// update-triggered exit is deliberately treated the same as a crash by the daemon (it is
+/// NOT excused via `note_user_stop`, since only an actual user-initiated stop may use that
+/// path), and relies on `RestartWatchdog`'s existing per-minute relaunch to bring the app
+/// back — the same worst-case gap crash recovery already produces, which is what the
+/// CORE-002 single-late threshold was already sized for. See `client/windows/README.md`.
+/// </summary>
+public sealed class StoreUpdateManager : IDisposable
+{
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromHours(4);
+
+    private readonly StoreContext _storeContext = StoreContext.GetDefault();
+    private CancellationTokenSource? _loopCancellation;
+
+    /// <summary>Raised once an update has finished downloading/staging and is ready to install.</summary>
+    public event EventHandler? UpdateStaged;
+
+    /// <summary>Raised (log-only) when a check or download attempt fails; the loop retries on its own schedule.</summary>
+    public event EventHandler<string>? UpdateCheckFailed;
+
+    public bool IsUpdateStaged { get; private set; }
+
+    /// <summary>
+    /// Starts the periodic background check. Safe to call once per process lifetime.
+    /// </summary>
+    public void Start()
+    {
+        if (_loopCancellation is not null)
+        {
+            return;
+        }
+
+        _loopCancellation = new CancellationTokenSource();
+        var token = _loopCancellation.Token;
+        _ = Task.Run(async () =>
+        {
+            await CheckOnceAsync().ConfigureAwait(false);
+
+            using var timer = new PeriodicTimer(CheckInterval);
+            while (await timer.WaitForNextTickAsync(token).ConfigureAwait(false))
+            {
+                if (!IsUpdateStaged)
+                {
+                    await CheckOnceAsync().ConfigureAwait(false);
+                }
+            }
+        }, token);
+    }
+
+    private async Task CheckOnceAsync()
+    {
+        try
+        {
+            var updates = await _storeContext.GetAppAndOptionalStorePackageUpdatesAsync();
+            if (updates.Count == 0)
+            {
+                return;
+            }
+
+            var downloadOperation = _storeContext.RequestDownloadStorePackageUpdatesAsync(updates);
+            var downloadResult = await downloadOperation;
+            if (downloadResult.OverallState == StorePackageUpdateState.Completed)
+            {
+                IsUpdateStaged = true;
+                UpdateStaged?.Invoke(this, EventArgs.Empty);
+            }
+            else
+            {
+                UpdateCheckFailed?.Invoke(this, $"update download ended in state {downloadResult.OverallState}");
+            }
+        }
+        catch (Exception ex)
+        {
+            UpdateCheckFailed?.Invoke(this, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Installs the update staged by a prior <see cref="CheckOnceAsync"/> call. Only ever
+    /// called once the caller has confirmed this is a safe point (daemon stopped). Never
+    /// throws — failures are reported via <see cref="UpdateCheckFailed"/> and the caller
+    /// should proceed with its planned exit/relaunch regardless of the result, since the
+    /// daemon has already been stopped by the time this runs.
+    /// </summary>
+    public async Task<bool> TryInstallStagedUpdateAsync()
+    {
+        if (!IsUpdateStaged)
+        {
+            return false;
+        }
+
+        try
+        {
+            // Re-fetch rather than trusting the cached flag, in case the Store retracted the
+            // update between staging and now.
+            var updates = await _storeContext.GetAppAndOptionalStorePackageUpdatesAsync();
+            if (updates.Count == 0)
+            {
+                IsUpdateStaged = false;
+                return false;
+            }
+
+            var installOperation = _storeContext.RequestDownloadAndInstallStorePackageUpdatesAsync(updates);
+            var installResult = await installOperation;
+            IsUpdateStaged = false;
+            return installResult.OverallState == StorePackageUpdateState.Completed;
+        }
+        catch (Exception ex)
+        {
+            UpdateCheckFailed?.Invoke(this, ex.Message);
+            IsUpdateStaged = false;
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        _loopCancellation?.Cancel();
+        _loopCancellation?.Dispose();
+        _loopCancellation = null;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `StoreUpdateManager`, which checks the Microsoft Store for package updates every 4 hours and downloads/stages them in the background without interrupting monitoring.
- Once an update is staged, `App.xaml.cs` polls every 5 minutes for a safe point to install it (`UpdateRestartPolicy.ShouldRestartNow`): the settings/login window must be hidden and no login/logout in progress, but the restart is forced through after a 6-hour deferral cap.
- Adds a tray "Restart to Update" menu item so a user can trigger the restart immediately instead of waiting.
- Either path stops the daemon the same way an OS session logoff/shutdown does (not the tray-Exit path), so it isn't treated as a user-initiated stop and doesn't log the device out.

## Changes

Type of change: Feature
Components: Windows

- `Virtue.WindowsApp/Update/StoreUpdateManager.cs` (new) — WinRT `StoreContext` polling/staging
- `Virtue.WindowsApp.Core/Interop/UpdateRestartPolicy.cs` (new) — pure, unit-tested safe-restart decision logic
- `Virtue.WindowsApp/App.xaml.cs` — wires update manager, safe-point poll loop, manual restart handler
- `Virtue.WindowsApp.Core/Tray/*` — new `RestartToUpdateRequested` tray event plumbed through `ITrayIconHost`/`NullTrayIconHost`/`WindowsTrayIconHost`/`TrayMenuController`
- `Virtue.WindowsApp.Core/ViewModels/SessionViewModel.cs` — `NotifyUpdateStaged()` appends "(update ready)" to the tray tooltip
- `client/windows/README.md` — new "Store Update Handling" section documenting the design and safety rationale

No `client/core`/SPEC.md changes needed — data-corruption safety relies on the same tick-boundary property (`DaemonState` persisted after every tick) that already makes crash recovery via `RestartWatchdog` safe.

## Testing

- `Virtue.WindowsApp.Core` builds clean (0 warnings/errors) on the `virtue-win11` remote build VM.
- `Virtue.WindowsApp.Tests`: 34/34 pass on real Windows/.NET 8, including new `UpdateRestartPolicyTests` (busy/hidden/deferral-cap cases), `SessionViewModel.NotifyUpdateStaged` tooltip test, and `TrayMenuController_RoutesRestartToUpdateEvent`.
- `Virtue.WindowsApp` (WinUI project, including `App.xaml.cs` and `StoreUpdateManager.cs`) builds successfully via `dotnet build -p:Platform=x64` on the remote Windows VM — full XAML compilation succeeded.
- Ran via `client/windows/scripts/remote-windows-build.sh --build-host virtue-win11 --mode smoke`, the repo's standard Linux-driven remote smoke check.